### PR TITLE
Build on Mac platform

### DIFF
--- a/releng/org.eclipse.papyrus.uml.diagram.sequence.releng/pom.xml
+++ b/releng/org.eclipse.papyrus.uml.diagram.sequence.releng/pom.xml
@@ -15,7 +15,7 @@
 		<jacoco-version>0.7.9</jacoco-version>
 		<findbugs.version>3.0.1</findbugs.version>
 		<!-- Platform-specific command-line arguments for tests. -->
-		<baseTestArgLine></baseTestArgLine>
+		<os-jvm-flags></os-jvm-flags>
 	</properties>
 
 	<pluginRepositories>
@@ -116,73 +116,34 @@
 					<log>xml</log>
 				</configuration>
 			</plugin>
-
-			<!-- We need the 'argLine' property always to be defined, otherwise Tycho 
-				test execution fails with a literal '${argLine}' on the command-line. But, 
-				we cannot define it statically in the Maven <properties> section because 
-				then the second pass for replacement of dynamic properties doesn't happen, 
-				so Jacoco's alteration of the argLine property would be for naught. Therefore, 
-				we define the property initially in a dynamic way based on the statically 
-				defined base value. -->
-			<plugin>
-				<groupId>org.codehaus.gmaven</groupId>
-				<artifactId>groovy-maven-plugin</artifactId>
-				<version>2.0</version>
-				<executions>
-					<execution>
-						<id>add-dynamic-properties</id>
-						<phase>initialize</phase>
-						<goals>
-							<goal>execute</goal>
-						</goals>
-						<configuration>
-							<source>
-								project.properties.argLine = '${baseTestArgLine}'
-							</source>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
-					only. It has no influence on the Maven build itself. -->
 				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tycho-version}</version>
 					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.codehaus.gmaven
-										</groupId>
-										<artifactId>
-											groovy-maven-plugin
-										</artifactId>
-										<versionRange>
-											[2.0,)
-										</versionRange>
-										<goals>
-											<goal>execute</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
+						<argLine>-Xms40m -Xmx1G ${os-jvm-flags}</argLine>
 					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
 	<profiles>
+		<profile>
+			<id>test-on-mac</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<!-- Platform-specific command-line arguments for tests. -->
+				<os-jvm-flags>-XstartOnFirstThread</os-jvm-flags>
+			</properties>
+		</profile>
 		<profile>
 			<id>findBugs</id> <!-- Analysis profile. Takes +1h -->
 			<build>


### PR DESCRIPTION
Fix the parent POM to run tests correctly on Mac.  Otherwise
they fail with SWT trying to initialize itself on the wrong
thread, Cocoa requiring the main thread.

Signed-off-by: Christian W. Damus <give.a.damus@gmail.com>