### PR TITLE
TCI - restore metadata files as they were for the public repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,13 @@ install: true
 
 script:
  - mvn -f releng/org.eclipse.papyrus.uml.diagram.sequence.releng/pom.xml -Poxygen clean verify -Dtycho.localArtifacts=ignore -Declipse.p2.mirrors=false
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUBTOKEN
+  keep-history: false
+  local-dir: releng/org.eclipse.papyrus.uml.diagram.sequence.updatesite/target/repository
+  on:
+    branch: master
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Papyrus Sequence Diagrams [![Build Status](https://travis-ci.com/eclipsesource/papyrus-seqd-int.svg?token=KmiHsvqTVUDnxZ1sNeBc&branch=master)](https://travis-ci.com/eclipsesource/papyrus-seqd-int)
+# Papyrus Sequence Diagrams [![Build Status](https://travis-ci.org/eclipsesource/papyrus-seqd.svg?branch=master)](https://travis-ci.org/eclipsesource/papyrus-seqd)
+
+## Installation
+
+At this point, only a nightly built test version is provided. The nightly version can be installed from the following p2 repository: http://github.eclipsesource.com/papyrus-seqd/
 
 ## Developer information
 


### PR DESCRIPTION
trivial commit to restore the behavior for metadata files, that should not have been overridden by commit from private repository.