### PR TITLE
Fix #248 Lifeline Header

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/META-INF/MANIFEST.MF
@@ -26,4 +26,5 @@ Export-Package: org.eclipse.papyrus.uml.diagram.sequence.runtime.internal;x-frie
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.parsers;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.part;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
+ org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util;x-internal:=true,
  org.eclipse.papyrus.uml.diagram.sequence.runtime.util

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/Activator.java
@@ -12,7 +12,9 @@
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal;
 
 import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gmf.runtime.diagram.core.preferences.PreferencesHint;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.papyrus.infra.core.log.LogHelper;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
@@ -64,13 +66,33 @@ public class Activator extends AbstractUIPlugin {
 	}
 
 	/**
-	 * Obtains the layout helper for an editing domain.
+	 * Obtain the layout helper for an editing domain.
 	 * 
 	 * @param editingDomain
 	 *            an editing domain
 	 * @return its layout helper
 	 */
 	public LayoutHelper getLayoutHelper(EditingDomain editingDomain) {
+		return LogicalModelPlugin.INSTANCE.getLayoutHelper(editingDomain);
+	}
+
+	/**
+	 * Obtain the layout helper for an edit-part.
+	 * 
+	 * @param editPart
+	 *            an edit-part that can provide an editing domain
+	 * @return its layout helper
+	 * @throws IllegalArgumentException
+	 *             if the edit-part cannot provide an editing domain
+	 */
+	public LayoutHelper getLayoutHelper(EditPart editPart) {
+		EditingDomain editingDomain = null;
+		if (editPart instanceof IGraphicalEditPart) {
+			editingDomain = ((IGraphicalEditPart)editPart).getEditingDomain();
+		}
+		if (editingDomain == null) {
+			throw new IllegalArgumentException("editPart"); //$NON-NLS-1$
+		}
 		return LogicalModelPlugin.INSTANCE.getLayoutHelper(editingDomain);
 	}
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineHeaderEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineHeaderEditPart.java
@@ -21,12 +21,14 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.editpolicies.ResizableEditPolicy;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.AbstractBorderedShapeEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IBorderItemEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.figures.BorderItemLocator;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.LifelineHeaderFigure;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineHeaderResizeEditPolicy;
 import org.eclipse.papyrus.uml.tools.utils.UMLUtil;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Lifeline;
@@ -59,6 +61,14 @@ public class LifelineHeaderEditPart extends AbstractBorderedShapeEditPart {
 	@Override
 	public IFigure getContentPane() {
 		return super.getContentPane();
+	}
+
+	@Override
+	protected void createDefaultEditPolicies() {
+		super.createDefaultEditPolicies();
+
+		ResizableEditPolicy resizePolicy = new LifelineHeaderResizeEditPolicy();
+		installEditPolicy(EditPolicy.PRIMARY_DRAG_ROLE, resizePolicy);
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineHeaderResizeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineHeaderResizeEditPolicy.java
@@ -1,0 +1,69 @@
+/*****************************************************************************
+ * Copyright (c) 2018 EclipseSource and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   EclipseSource - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil.asBounds;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil.asRectangle;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil.getMoveDelta;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil.getSizeDelta;
+
+import java.util.List;
+
+import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.requests.ChangeBoundsRequest;
+import org.eclipse.gmf.runtime.diagram.ui.editpolicies.ResizableShapeEditPolicy;
+import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.Activator;
+
+/**
+ * <p>
+ * An edit policy for moving and resizing of the header of a Lifeline. This policy shows the East and West
+ * handles to indicate selection, and allows resizing only from those.
+ * </p>
+ * <p>
+ * This policy also constrains the Drag/Move behavior to the horizontal dimension.
+ * </p>
+ */
+public class LifelineHeaderResizeEditPolicy extends ResizableShapeEditPolicy {
+
+	public LifelineHeaderResizeEditPolicy() {
+		setResizeDirections(PositionConstants.EAST_WEST);
+	}
+
+	@Override
+	protected void createResizeHandle(@SuppressWarnings({"rawtypes", "hiding" }) List handles,
+			int direction) {
+		if ((getResizeDirections() & direction) != 0) {
+			// Display & enable the South handle
+			super.createResizeHandle(handles, direction);
+		}
+	}
+
+	@Override
+	protected void showChangeBoundsFeedback(ChangeBoundsRequest request) {
+		Rectangle current = getHostFigure().getBounds();
+		Rectangle rectangle = request.getTransformedRectangle(current);
+		Bounds bounds = asBounds(rectangle);
+		bounds = Activator.getDefault().getLayoutHelper(getHost()).getAdjustedBounds(
+				getHost().getAdapter(EObject.class), getHost().getAdapter(Node.class), bounds);
+		rectangle = asRectangle(bounds);
+
+		// Create the minimal new request that the super implementation needs
+		ChangeBoundsRequest newRequest = new ChangeBoundsRequest(request.getType());
+		newRequest.setMoveDelta(getMoveDelta(current, rectangle));
+		newRequest.setSizeDelta(getSizeDelta(current, rectangle));
+		super.showChangeBoundsFeedback(newRequest);
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/util/GeometryUtil.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/util/GeometryUtil.java
@@ -1,0 +1,87 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util;
+
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.NotationFactory;
+
+/**
+ * Utilities for working with GEF/GMF geometry.
+ *
+ * @author Christian W. Damus
+ */
+public class GeometryUtil {
+
+	/**
+	 * Not instantiable by clients.
+	 */
+	private GeometryUtil() {
+		super();
+	}
+
+	/**
+	 * Convert a GEF {@code rectangle} to a GMF bounds.
+	 * 
+	 * @param rectangle
+	 *            a GEF rectangle
+	 * @return an equivalent GMF bounds
+	 */
+	public static Bounds asBounds(Rectangle rectangle) {
+		Bounds result = NotationFactory.eINSTANCE.createBounds();
+		result.setX(rectangle.x());
+		result.setY(rectangle.y());
+		result.setWidth(rectangle.width());
+		result.setHeight(rectangle.height());
+		return result;
+	}
+
+	/**
+	 * Convert a GMF {@code bounds} to a GEF rectangle.
+	 * 
+	 * @param bounds
+	 *            a GMF bounds
+	 * @return an equivalent GEF rectangle
+	 */
+	public static Rectangle asRectangle(Bounds bounds) {
+		return new Rectangle(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+	}
+
+	/**
+	 * Compute the move delta between two rectangles.
+	 * 
+	 * @param from
+	 *            the source rectangle
+	 * @param to
+	 *            the destination rectangle
+	 * @return the difference between their {@linkplain Rectangle#getLocation() locations}
+	 */
+	public static Point getMoveDelta(Rectangle from, Rectangle to) {
+		return new Point(to.x() - from.x(), to.y() - from.y());
+	}
+
+	/**
+	 * Compute the size delta between two rectangles.
+	 * 
+	 * @param from
+	 *            the source rectangle
+	 * @param to
+	 *            the destination rectangle
+	 * @return the difference between their {@linkplain Rectangle#getSize() sizes}
+	 */
+	public static Dimension getSizeDelta(Rectangle from, Rectangle to) {
+		return new Dimension(to.width() - from.width(), to.height() - from.height());
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
@@ -16,6 +16,7 @@ import java.util.OptionalInt;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.notation.Anchor;
 import org.eclipse.gmf.runtime.notation.Bounds;
 import org.eclipse.gmf.runtime.notation.Node;
@@ -141,7 +142,8 @@ public interface LayoutHelper {
 	/**
 	 * Returns the bounds for a new representation, given the proposed bounds.
 	 * 
-	 * @Param eClass the metaclass of the semantic object to be presented
+	 * @param eClass
+	 *            the metaclass of the semantic object to be presented
 	 * @param proposedBounds
 	 *            the bounds initially proposed for creation of the element
 	 * @param container
@@ -149,5 +151,18 @@ public interface LayoutHelper {
 	 * @return the bounds for a new representation
 	 */
 	Bounds getNewBounds(EClass eClass, Bounds proposedBounds, Node container);
+
+	/**
+	 * Computes the bounds for an existing representation, given the proposed bounds.
+	 * 
+	 * @param semanticObject
+	 *            the semantic object to be presented
+	 * @param view
+	 *            the visual representation of the semantic object
+	 * @param proposedBounds
+	 *            the bounds initially proposed for the representation (being moved/resized/etc.)
+	 * @return the adjusted bounds for the representation
+	 */
+	Bounds getAdjustedBounds(EObject semanticObject, Node view, Bounds proposedBounds);
 
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/META-INF/MANIFEST.MF
@@ -10,5 +10,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.papyrus.uml.diagram.sequence.runtime;bundle-version="1.0.0",
  org.eclipse.uml2.uml.resources;bundle-version="[5.3.0,6.0.0)",
  org.eclipse.papyrus.uml.interaction.graph;bundle-version="[1.0.0,2.0.0)",
- org.eclipse.papyrus.uml.interaction.graph.tests;bundle-version="[1.0.0,2.0.0)"
+ org.eclipse.papyrus.uml.interaction.graph.tests;bundle-version="[1.0.0,2.0.0)",
+ org.eclipse.draw2d;bundle-version="[3.10.100,4.0.0)"
 Bundle-Description: Tests of the core run-time APIs of the sequence diagram.
+Export-Package: org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers;version="1.0.0"

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/util/tests/GeometryUtilTest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/util/tests/GeometryUtilTest.java
@@ -1,0 +1,82 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isRect;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isSize;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NotationMatchers.isBounds;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.NotationFactory;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link GeometryUtil} class.
+ *
+ * @author Christian W. Damus
+ */
+@SuppressWarnings("restriction")
+public class GeometryUtilTest {
+
+	@Test
+	public void asBounds() {
+		Bounds bounds = GeometryUtil.asBounds(new Rectangle(1, 2, 3, 4));
+		assertThat(bounds, isBounds(1, 2, 3, 4));
+	}
+
+	@Test
+	public void asRectangle() {
+		Rectangle rect = GeometryUtil.asRectangle(bounds(1, 2, 3, 4));
+		assertThat(rect, isRect(1, 2, 3, 4));
+	}
+
+	@Test
+	public void getMoveDelta() {
+		Rectangle from = new Rectangle(1, 2, 3, 4);
+		Rectangle to = new Rectangle(11, 22, 33, 44);
+		Point delta = GeometryUtil.getMoveDelta(from, to);
+		assertThat(delta, isPoint(10, 20));
+	}
+
+	@Test
+	public void getSizeDelta() {
+		Rectangle from = new Rectangle(1, 2, 3, 4);
+		Rectangle to = new Rectangle(11, 22, 33, 44);
+		Dimension delta = GeometryUtil.getSizeDelta(from, to);
+		assertThat(delta, isSize(30, 40));
+	}
+
+	//
+	// Test framework
+	//
+
+	static Rectangle rect(int x, int y, int width, int height) {
+		return new Rectangle(x, y, width, height);
+	}
+
+	static Bounds bounds(int x, int y, int width, int height) {
+		Bounds result = NotationFactory.eINSTANCE.createBounds();
+		result.setX(x);
+		result.setY(y);
+		result.setWidth(width);
+		result.setHeight(height);
+		return result;
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/matchers/GEFMatchers.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/matchers/GEFMatchers.java
@@ -1,0 +1,261 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.SelfDescribing;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+/**
+ * Matchers for assertions on GEF.
+ *
+ * @author Christian W. Damus
+ */
+public class GEFMatchers {
+
+	/**
+	 * Not instantiable by clients.
+	 */
+	private GEFMatchers() {
+		super();
+	}
+
+	/**
+	 * Matcher for a rectangle.
+	 *
+	 * @param x
+	 *            the expected x location
+	 * @param y
+	 *            the expected y location
+	 * @param width
+	 *            the expected width
+	 * @param height
+	 *            the expected height
+	 *
+	 * @return the rectangle matcher
+	 */
+	public static Matcher<Rectangle> isRect(int x, int y, int width, int height) {
+		return isRect(is(x), is(y), is(width), is(height));
+	}
+
+	/**
+	 * Matcher for a rectangle.
+	 *
+	 * @param x
+	 *            matcher for the x location, or {@code null} if none
+	 * @param y
+	 *            matcher for the y location, or {@code null} if none
+	 * @param width
+	 *            matcher for the width, or {@code null} if none
+	 * @param height
+	 *            matcher for the height or {@code null} if none
+	 *
+	 * @return the rectangle matcher
+	 */
+	public static Matcher<Rectangle> isRect(Matcher<? super Integer> x, Matcher<? super Integer> y,
+			Matcher<? super Integer> width, Matcher<? super Integer> height) {
+
+		return new TypeSafeDiagnosingMatcher<Rectangle>() {
+			@Override
+			public void describeTo(Description description) {
+				boolean appended = false;
+				description.appendText("rectangle that ");
+
+				SelfDescribing[] parts = { x, y, width, height };
+				String[] names = { "x", "y", "width", "height" };
+				for (int i = 0; i < parts.length; i++) {
+					if (parts[i] == null) {
+						continue;
+					}
+
+					if (appended) {
+						description.appendText(" and ");
+					}
+					description.appendText(names[i]).appendText(" that ");
+					description.appendDescriptionOf(parts[i]);
+					appended = true;
+				}
+
+				if (!appended) {
+					description.appendText("exists");
+				}
+			}
+
+			@Override
+			protected boolean matchesSafely(Rectangle item, Description mismatchDescription) {
+				if ((x != null) && !x.matches(item.x())) {
+					x.describeMismatch(item.x(), mismatchDescription);
+					return false;
+				}
+				if ((y != null) && !y.matches(item.y())) {
+					y.describeMismatch(item.y(), mismatchDescription);
+					return false;
+				}
+				if ((width != null) && !width.matches(item.width())) {
+					width.describeMismatch(item.width(), mismatchDescription);
+					return false;
+				}
+				if ((height != null) && !height.matches(item.height())) {
+					height.describeMismatch(item.height(), mismatchDescription);
+					return false;
+				}
+
+				return true;
+			}
+		};
+	}
+
+	/**
+	 * Matcher for a point.
+	 *
+	 * @param x
+	 *            the expected x location
+	 * @param y
+	 *            the expected y location
+	 *
+	 * @return the point matcher
+	 */
+	public static Matcher<Point> isPoint(int x, int y) {
+		return isPoint(is(x), is(y));
+	}
+
+	/**
+	 * Matcher for a point.
+	 *
+	 * @param x
+	 *            matcher for the x location, or {@code null} if none
+	 * @param y
+	 *            matcher for the y location, or {@code null} if none
+	 *
+	 * @return the point matcher
+	 */
+	public static Matcher<Point> isPoint(Matcher<? super Integer> x, Matcher<? super Integer> y) {
+
+		return new TypeSafeDiagnosingMatcher<Point>() {
+			@Override
+			public void describeTo(Description description) {
+				boolean appended = false;
+				description.appendText("point that ");
+
+				SelfDescribing[] parts = { x, y };
+				String[] names = { "x", "y" };
+				for (int i = 0; i < parts.length; i++) {
+					if (parts[i] == null) {
+						continue;
+					}
+
+					if (appended) {
+						description.appendText(" and ");
+					}
+					description.appendText(names[i]).appendText(" that ");
+					description.appendDescriptionOf(parts[i]);
+					appended = true;
+				}
+
+				if (!appended) {
+					description.appendText("exists");
+				}
+			}
+
+			@Override
+			protected boolean matchesSafely(Point item, Description mismatchDescription) {
+				if ((x != null) && !x.matches(item.x())) {
+					x.describeMismatch(item.x(), mismatchDescription);
+					return false;
+				}
+				if ((y != null) && !y.matches(item.y())) {
+					y.describeMismatch(item.y(), mismatchDescription);
+					return false;
+				}
+
+				return true;
+			}
+		};
+	}
+
+	/**
+	 * Matcher for a dimension.
+	 *
+	 * @param width
+	 *            the expected width
+	 * @param height
+	 *            the expected height
+	 *
+	 * @return the dimension matcher
+	 */
+	public static Matcher<Dimension> isSize(int width, int height) {
+		return isSize(is(width), is(height));
+	}
+
+	/**
+	 * Matcher for a dimension.
+	 *
+	 * @param width
+	 *            matcher for the width, or {@code null} if none
+	 * @param height
+	 *            matcher for the height or {@code null} if none
+	 *
+	 * @return the dimension matcher
+	 */
+	public static Matcher<Dimension> isSize(Matcher<? super Integer> width,
+			Matcher<? super Integer> height) {
+
+		return new TypeSafeDiagnosingMatcher<Dimension>() {
+			@Override
+			public void describeTo(Description description) {
+				boolean appended = false;
+				description.appendText("dimension that ");
+
+				SelfDescribing[] parts = { width, height };
+				String[] names = { "width", "height" };
+				for (int i = 0; i < parts.length; i++) {
+					if (parts[i] == null) {
+						continue;
+					}
+
+					if (appended) {
+						description.appendText(" and ");
+					}
+					description.appendText(names[i]).appendText(" that ");
+					description.appendDescriptionOf(parts[i]);
+					appended = true;
+				}
+
+				if (!appended) {
+					description.appendText("exists");
+				}
+			}
+
+			@Override
+			protected boolean matchesSafely(Dimension item, Description mismatchDescription) {
+				if ((width != null) && !width.matches(item.width())) {
+					width.describeMismatch(item.width(), mismatchDescription);
+					return false;
+				}
+				if ((height != null) && !height.matches(item.height())) {
+					height.describeMismatch(item.height(), mismatchDescription);
+					return false;
+				}
+
+				return true;
+			}
+		};
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.graph.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.papyrus.uml.interaction.graph.tests/META-INF/MANIFEST.MF
@@ -7,8 +7,12 @@ Bundle-Vendor: Eclipse Modeling Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.junit;bundle-version="[4.12.0,5.0.0)",
+ org.eclipse.uml2.uml;bundle-version="[5.3.0,6.0.0)";visibility:=reexport,
  org.eclipse.uml2.uml.resources;bundle-version="[5.3.0,6.0.0)",
- org.eclipse.papyrus.uml.interaction.graph;bundle-version="1.0.0"
+ org.eclipse.papyrus.uml.interaction.graph;bundle-version="1.0.0";visibility:=reexport,
+ org.eclipse.uml2.uml.edit;bundle-version="[5.3.0,6.0.0)",
+ org.eclipse.gmf.runtime.notation.edit;bundle-version="[1.7.0,2.0.0)"
 Bundle-Description: Tests of the core run-time APIs of the sequence diagram.
 Export-Package: org.eclipse.papyrus.uml.interaction.graph.tests,
- org.eclipse.papyrus.uml.interaction.tests.rules
+ org.eclipse.papyrus.uml.interaction.tests.matchers;version="1.0.0",
+ org.eclipse.papyrus.uml.interaction.tests.rules;version="1.0.0"

--- a/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/matchers/NotationMatchers.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/matchers/NotationMatchers.java
@@ -1,0 +1,122 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.tests.matchers;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import org.eclipse.gmf.runtime.notation.Bounds;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.SelfDescribing;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+/**
+ * Matchers for assertions on notation.
+ *
+ * @author Christian W. Damus
+ */
+public class NotationMatchers {
+
+	/**
+	 * Not instantiable by clients.
+	 */
+	private NotationMatchers() {
+		super();
+	}
+
+	/**
+	 * Matcher for a bounds.
+	 *
+	 * @param x
+	 *            the expected x location
+	 * @param y
+	 *            the expected y location
+	 * @param width
+	 *            the expected width
+	 * @param height
+	 *            the expected height
+	 *
+	 * @return the bounds matcher
+	 */
+	public static Matcher<Bounds> isBounds(int x, int y, int width, int height) {
+		return isBounds(is(x), is(y), is(width), is(height));
+	}
+
+	/**
+	 * Matcher for a bounds.
+	 *
+	 * @param x
+	 *            matcher for the x location, or {@code null} if none
+	 * @param y
+	 *            matcher for the y location, or {@code null} if none
+	 * @param width
+	 *            matcher for the width, or {@code null} if none
+	 * @param height
+	 *            matcher for the height or {@code null} if none
+	 *
+	 * @return the bounds matcher
+	 */
+	public static Matcher<Bounds> isBounds(Matcher<? super Integer> x, Matcher<? super Integer> y,
+			Matcher<? super Integer> width, Matcher<? super Integer> height) {
+
+		return new TypeSafeDiagnosingMatcher<Bounds>() {
+			@Override
+			public void describeTo(Description description) {
+				boolean appended = false;
+				description.appendText("bounds that ");
+
+				SelfDescribing[] parts = { x, y, width, height };
+				String[] names = { "x", "y", "width", "height" };
+				for (int i = 0; i < parts.length; i++) {
+					if (parts[i] == null) {
+						continue;
+					}
+
+					if (appended) {
+						description.appendText(" and ");
+					}
+					description.appendText(names[i]).appendText(" that ");
+					description.appendDescriptionOf(parts[i]);
+					appended = true;
+				}
+
+				if (!appended) {
+					description.appendText("exists");
+				}
+			}
+
+			@Override
+			protected boolean matchesSafely(Bounds item, Description mismatchDescription) {
+				if ((x != null) && !x.matches(item.getX())) {
+					x.describeMismatch(item.getX(), mismatchDescription);
+					return false;
+				}
+				if ((y != null) && !y.matches(item.getY())) {
+					y.describeMismatch(item.getY(), mismatchDescription);
+					return false;
+				}
+				if ((width != null) && !width.matches(item.getWidth())) {
+					width.describeMismatch(item.getWidth(), mismatchDescription);
+					return false;
+				}
+				if ((height != null) && !height.matches(item.getHeight())) {
+					height.describeMismatch(item.getHeight(), mismatchDescription);
+					return false;
+				}
+
+				return true;
+			}
+		};
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/.classpath
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.papyrus.uml.interaction.model.tests
+Export-Package: org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests,
+ org.eclipse.papyrus.uml.interaction.model.tests
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.papyrus.uml.interaction.model;visibility:=reexport,
  org.eclipse.emf.ecore;visibility:=reexport,
@@ -17,5 +18,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore.xmi;visibility:=reexport,
  org.junit;visibility:=reexport,
  org.eclipse.emf.edit;bundle-version="[2.12.0,3.0.0)",
- org.eclipse.uml2.uml.edit;bundle-version="[5.3.0,6.0.0)"
+ org.eclipse.uml2.uml.edit;bundle-version="[5.3.0,6.0.0)",
+ org.eclipse.papyrus.uml.interaction.graph;bundle-version="[1.0.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
+Import-Package: org.eclipse.papyrus.uml.interaction.tests.matchers;version="[1.0.0,2.0.0)",
+ org.eclipse.papyrus.uml.interaction.tests.rules;version="[1.0.0,2.0.0)"

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/build.properties
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/build.properties
@@ -13,5 +13,6 @@ bin.includes = .,\
                META-INF/,\
                plugin.properties
 jars.compile.order = .
-source.. = src-gen/
+source.. = src-gen/,\
+           src/
 output.. = bin/

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/SeqdAllTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/SeqdAllTests.java
@@ -1,17 +1,18 @@
 /**
  * Copyright (c) 2018 Christian W. Damus and others.
- *  
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Christian W. Damus - Initial API and implementation
- * 
+ *
  */
 package org.eclipse.papyrus.uml.interaction.model.tests;
 
+import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
@@ -19,14 +20,14 @@ import junit.textui.TestRunner;
 /**
  * <!-- begin-user-doc --> A test suite for the '<em><b>Seqd</b></em>' model.
  * <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class SeqdAllTests extends TestSuite {
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated
 	 */
 	public static void main(String[] args) {
@@ -35,18 +36,19 @@ public class SeqdAllTests extends TestSuite {
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated
 	 */
 	public static Test suite() {
 		TestSuite suite = new SeqdAllTests("Seqd Tests"); //$NON-NLS-1$
 		suite.addTest(SequenceDiagramTests.suite());
+		suite.addTest(new JUnit4TestAdapter(SeqDCustomTests.class));
 		return suite;
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated
 	 */
 	public SeqdAllTests(String name) {

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/DefaultLayoutHelperTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/DefaultLayoutHelperTest.java
@@ -1,0 +1,95 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests;
+
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NotationMatchers.isBounds;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.gmf.runtime.notation.NotationFactory;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutHelper;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.Lifeline;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test cases for the {@link DefaultLayoutHelper} class.
+ *
+ * @author Christian W. Damus
+ */
+@SuppressWarnings("restriction")
+@ModelResource({ "lifelines_layout.uml", "lifelines_layout.notation" })
+public class DefaultLayoutHelperTest {
+
+	@Rule
+	public final ModelFixture.Edit model = new ModelFixture.Edit();
+
+	private DefaultLayoutHelper helper;
+
+	/**
+	 * Initializes me.
+	 */
+	public DefaultLayoutHelperTest() {
+		super();
+	}
+
+	@Test
+	public void getAdjustedBounds_lifeline() {
+		Lifeline centre = model.getElement("AnchorsModel::LifelineHeaderAnchor::CenterLine",
+				Lifeline.class);
+		Node view = require(model.vertex(centre).getDiagramView(), Node.class);
+
+		Bounds current = bounds(view);
+		Bounds bounds = helper.getAdjustedBounds(centre, view, bounds(1000, 1000, 150, 150));
+		assertThat(bounds, isBounds(1000, current.getY(), 150, current.getHeight()));
+	}
+
+	//
+	// Test framework
+	//
+
+	@Before
+	public void createSUT() {
+		helper = new DefaultLayoutHelper(model.getEditingDomain());
+	}
+
+	@After
+	public void destroySUT() {
+		helper = null;
+	}
+
+	static <T> T require(Object object, Class<T> type) {
+		assertThat("object is not a " + type.getSimpleName(), object, instanceOf(type));
+		return type.cast(object);
+	}
+
+	static Bounds bounds(View view) {
+		return require(require(view, Node.class).getLayoutConstraint(), Bounds.class);
+	}
+
+	static Bounds bounds(int x, int y, int width, int height) {
+		Bounds result = NotationFactory.eINSTANCE.createBounds();
+		result.setX(x);
+		result.setY(y);
+		result.setWidth(width);
+		result.setHeight(height);
+		return result;
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/lifelines_layout.di
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/lifelines_layout.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/lifelines_layout.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/lifelines_layout.notation
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+  <notation:Diagram xmi:id="_ZqujACIHEei5e5kSMChtjA" type="LightweightSequenceDiagram" name="LifelineHeaderAnchorsDiagram" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_ZqujASIHEei5e5kSMChtjA" type="Shape_Interaction">
+      <children xmi:type="notation:Compartment" xmi:id="_ZqujAiIHEei5e5kSMChtjA" type="Interaction_Contents">
+        <children xmi:type="notation:Shape" xmi:id="_ZqvKECIHEei5e5kSMChtjA" type="Shape_Lifeline_Header">
+          <children xmi:type="notation:Shape" xmi:id="_K-C0JEFsEei1zqUjbAwdJw" type="Compartment_Lifeline_Header">
+            <children xmi:type="notation:Shape" xmi:id="_K-C0JUFsEei1zqUjbAwdJw" type="Label_Lifeline_Name"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_8e1YkkFrEei1zqUjbAwdJw" type="Shape_Lifeline_Body">
+            <layoutConstraint xmi:type="notation:Size" height="300"  xmi:id="_vOnYUkFuEeioV-9wZ7qOXA"/>
+          </children>
+          <element xmi:type="uml:Lifeline" href="lifelines_layout.uml#_Zqq4oSIHEei5e5kSMChtjA"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZqvKESIHEei5e5kSMChtjA" x="45" y="86" width="116" height="25"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_qMryECIKEei5e5kSMChtjA" type="Shape_Lifeline_Header">
+          <children xmi:type="notation:Shape" xmi:id="_K-C0JkFsEei1zqUjbAwdJw" type="Compartment_Lifeline_Header">
+            <children xmi:type="notation:Shape" xmi:id="_K-C0J0FsEei1zqUjbAwdJw" type="Label_Lifeline_Name"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_8e1Yk0FrEei1zqUjbAwdJw" type="Shape_Lifeline_Body">
+            <layoutConstraint xmi:type="notation:Size" height="300"  xmi:id="_vOnYU0FuEeioV-9wZ7qOXA"/>
+          </children>
+          <element xmi:type="uml:Lifeline" href="lifelines_layout.uml#_jmWXQCIKEei5e5kSMChtjA"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qMryESIKEei5e5kSMChtjA" x="196" y="28" width="116" height="25"/>
+        </children>
+        <children xmi:type="notation:Shape" xmi:id="_ZqvKEiIHEei5e5kSMChtjA" type="Shape_Lifeline_Header">
+          <children xmi:type="notation:Shape" xmi:id="_K-C0KEFsEei1zqUjbAwdJw" type="Compartment_Lifeline_Header">
+            <children xmi:type="notation:Shape" xmi:id="_K-C0KUFsEei1zqUjbAwdJw" type="Label_Lifeline_Name"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_8e1YlEFrEei1zqUjbAwdJw" type="Shape_Lifeline_Body">
+            <layoutConstraint xmi:type="notation:Size" height="300"  xmi:id="_vOnYVEFuEeioV-9wZ7qOXA"/>
+          </children>
+          <element xmi:type="uml:Lifeline" href="lifelines_layout.uml#_Zqq4oiIHEei5e5kSMChtjA"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZqvKEyIHEei5e5kSMChtjA" x="385" y="66" width="116" height="25"/>
+        </children>
+        <element xmi:type="uml:Interaction" href="lifelines_layout.uml#_Zqq4oCIHEei5e5kSMChtjA"/>
+      </children>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZqvKFCIHEei5e5kSMChtjA" x="37" y="12" width="600" height="450"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_ZqvKFSIHEei5e5kSMChtjA" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_ZqvKFiIHEei5e5kSMChtjA"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_ZqvKFyIHEei5e5kSMChtjA" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+      <owner xmi:type="uml:Interaction" href="lifelines_layout.uml#_Zqq4oCIHEei5e5kSMChtjA"/>
+    </styles>
+    <element xmi:type="uml:Interaction" href="lifelines_layout.uml#_Zqq4oCIHEei5e5kSMChtjA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_ZqvKGCIHEei5e5kSMChtjA" type="Edge_Message" source="_8e1Yk0FrEei1zqUjbAwdJw" target="_ZqvKEiIHEei5e5kSMChtjA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="__jPDcCILEei_t7TTDunvqw" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="__jPqgCILEei_t7TTDunvqw" key="routing" value="true"/>
+      </eAnnotations>
+      <element xmi:type="uml:Message" href="lifelines_layout.uml#_1oUqtSe3Eei33oLfoI_NYA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZqvKGSIHEei5e5kSMChtjA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4VHP4CILEei_t7TTDunvqw" id="20"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4VHP4SILEei_t7TTDunvqw" id="left;10"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_ZqvKHCIHEei5e5kSMChtjA" type="Edge_Message" source="_8e1Yk0FrEei1zqUjbAwdJw" target="_ZqvKECIHEei5e5kSMChtjA">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_ZqvKHSIHEei5e5kSMChtjA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_ZqvKHiIHEei5e5kSMChtjA" key="routing" value="true"/>
+      </eAnnotations>
+      <element xmi:type="uml:Message" href="lifelines_layout.uml#_1oUqtCe3Eei33oLfoI_NYA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ZqvKHyIHEei5e5kSMChtjA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4VHP4iILEei_t7TTDunvqw" id="40"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4VHP4yILEei_t7TTDunvqw" id="right;10"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/lifelines_layout.uml
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/lifelines_layout.uml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_3XpTICHsEeiIiO6KSag_9g" name="AnchorsModel">
+  <packageImport xmi:id="_3euykCHsEeiIiO6KSag_9g">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_Zqq4oCIHEei5e5kSMChtjA" name="LifelineHeaderAnchor">
+    <lifeline xmi:id="_Zqq4oSIHEei5e5kSMChtjA" name="LeftLine" coveredBy="_1oUqsSe3Eei33oLfoI_NYA"/>
+    <lifeline xmi:id="_Zqq4oiIHEei5e5kSMChtjA" name="RightLine" coveredBy="_1oUqsye3Eei33oLfoI_NYA"/>
+    <lifeline xmi:id="_jmWXQCIKEei5e5kSMChtjA" name="CenterLine" coveredBy="_1oUqsCe3Eei33oLfoI_NYA _1oUqsie3Eei33oLfoI_NYA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_1oUqsie3Eei33oLfoI_NYA" name="ctr-send1" covered="_jmWXQCIKEei5e5kSMChtjA" message="_1oUqtSe3Eei33oLfoI_NYA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_1oUqsye3Eei33oLfoI_NYA" name="right-recv" covered="_Zqq4oiIHEei5e5kSMChtjA" message="_1oUqtSe3Eei33oLfoI_NYA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_1oUqsCe3Eei33oLfoI_NYA" name="ctr-send2" covered="_jmWXQCIKEei5e5kSMChtjA" message="_1oUqtCe3Eei33oLfoI_NYA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_1oUqsSe3Eei33oLfoI_NYA" name="left-recv" covered="_Zqq4oSIHEei5e5kSMChtjA" message="_1oUqtCe3Eei33oLfoI_NYA"/>
+    <message xmi:id="_1oUqtSe3Eei33oLfoI_NYA" name="leftToRight" messageSort="createMessage" receiveEvent="_1oUqsye3Eei33oLfoI_NYA" sendEvent="_1oUqsie3Eei33oLfoI_NYA"/>
+    <message xmi:id="_1oUqtCe3Eei33oLfoI_NYA" name="rightToLeft" messageSort="createMessage" receiveEvent="_1oUqsSe3Eei33oLfoI_NYA" sendEvent="_1oUqsCe3Eei33oLfoI_NYA"/>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Class" xmi:id="_YKEb8D27EeiY7p28vqpoYg" name="Foo" classifierBehavior="_bJLRYD27EeiY7p28vqpoYg">
+    <ownedBehavior xmi:type="uml:Activity" xmi:id="_bJLRYD27EeiY7p28vqpoYg" name="Lifecycle" node="_iKpwED27EeiY7p28vqpoYg">
+      <node xmi:type="uml:OpaqueAction" xmi:id="_iKpwED27EeiY7p28vqpoYg" name="doIt"/>
+    </ownedBehavior>
+    <ownedOperation xmi:id="_5rhUMD3NEeiY7p28vqpoYg" name="doIt"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -1,0 +1,39 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model.tests;
+
+import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.DefaultLayoutHelperTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * Test suite encompassing all of the custom JUnit4 tests for the <em>Logical
+ * Model</em>.
+ *
+ * @author Christian W. Damus
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ //
+		DefaultLayoutHelperTest.class, //
+})
+public class SeqDCustomTests {
+
+	/**
+	 * Initializes me.
+	 */
+	public SeqDCustomTests() {
+		super();
+	}
+
+}


### PR DESCRIPTION
## Description

Add an API to the `LayoutHelper` to adjust proposed bounds for an existing shape in the diagram.  Use this new API to constrain the moving of lifeline headers to the horizontal dimension (including visual feed-back). Editing the size of a lifeline header likewise is constrained to the horizontal dimension (otherwise the lifeline body would be moved vertically).

## Testing

The new `LayoutHelper` API and a few supporting utilities are covered with some simple JUnit tests.  Importantly, all of the `org.eclipse.papyrus.uml.interaction.{graph, model}` tests currently support stand-alone execution (without a running Eclipse platform), and I think we should maintain that.

However, there isn't yet any coverage of the edit policies, because we don't yet have an established pattern (there are currently no tests in this area).  @rschnekenbu and @planger I'll be happy to add JUnit or RCPTT tests to cover the behavioural changes in this PR if you'd like to suggest which way we should go.