### PR TITLE
Logical Element Deletion #33, #53, #54, #55, #56, #57, #63

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
@@ -37,7 +37,7 @@
     <eOperations name="nudge" lowerBound="1" eType="#//Command">
       <eParameters name="deltaY" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
     </eOperations>
-    <eOperations name="remove" lowerBound="1" eType="#//RemovalCommand"/>
+    <eOperations name="remove" lowerBound="1" eType="#//Command"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="interaction" lowerBound="1"
         eType="#//MInteraction" changeable="false" volatile="true" transient="true"
         derived="true" resolveProxies="false"/>
@@ -411,7 +411,5 @@
     </eTypeParameters>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EObject" instanceClassName="org.eclipse.emf.ecore.EObject"
-      serializable="false"/>
-  <eClassifiers xsi:type="ecore:EDataType" name="RemovalCommand" instanceClassName="org.eclipse.papyrus.uml.interaction.model.RemovalCommand"
       serializable="false"/>
 </ecore:EPackage>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
@@ -37,6 +37,7 @@
     <eOperations name="nudge" lowerBound="1" eType="#//Command">
       <eParameters name="deltaY" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
     </eOperations>
+    <eOperations name="remove" lowerBound="1" eType="#//RemovalCommand"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="interaction" lowerBound="1"
         eType="#//MInteraction" changeable="false" volatile="true" transient="true"
         derived="true" resolveProxies="false"/>
@@ -410,5 +411,7 @@
     </eTypeParameters>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EObject" instanceClassName="org.eclipse.emf.ecore.EObject"
+      serializable="false"/>
+  <eClassifiers xsi:type="ecore:EDataType" name="RemovalCommand" instanceClassName="org.eclipse.papyrus.uml.interaction.model.RemovalCommand"
       serializable="false"/>
 </ecore:EPackage>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
@@ -24,7 +24,6 @@
       <genTypeParameters ecoreTypeParameter="seqd.ecore#//CreationCommand/T"/>
     </genDataTypes>
     <genDataTypes ecoreDataType="seqd.ecore#//EObject"/>
-    <genDataTypes ecoreDataType="seqd.ecore#//RemovalCommand"/>
     <genClasses image="false" ecoreClass="seqd.ecore#//MElement">
       <genTypeParameters ecoreTypeParameter="seqd.ecore#//MElement/T"/>
       <genFeatures property="Readonly" notify="false" createChild="false" ecoreFeature="ecore:EReference seqd.ecore#//MElement/interaction"/>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
@@ -24,6 +24,7 @@
       <genTypeParameters ecoreTypeParameter="seqd.ecore#//CreationCommand/T"/>
     </genDataTypes>
     <genDataTypes ecoreDataType="seqd.ecore#//EObject"/>
+    <genDataTypes ecoreDataType="seqd.ecore#//RemovalCommand"/>
     <genClasses image="false" ecoreClass="seqd.ecore#//MElement">
       <genTypeParameters ecoreTypeParameter="seqd.ecore#//MElement/T"/>
       <genFeatures property="Readonly" notify="false" createChild="false" ecoreFeature="ecore:EReference seqd.ecore#//MElement/interaction"/>
@@ -40,6 +41,7 @@
       <genOperations ecoreOperation="seqd.ecore#//MElement/nudge">
         <genParameters ecoreParameter="seqd.ecore#//MElement/nudge/deltaY"/>
       </genOperations>
+      <genOperations ecoreOperation="seqd.ecore#//MElement/remove"/>
     </genClasses>
     <genClasses ecoreClass="seqd.ecore#//MInteraction">
       <genFeatures property="None" children="true" createChild="false" ecoreFeature="ecore:EReference seqd.ecore#//MInteraction/lifelines"/>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
@@ -170,13 +170,21 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MELEMENT___NUDGE__INT = 4;
 
 	/**
+	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MELEMENT___REMOVE = 5;
+
+	/**
 	 * The number of operations of the '<em>MElement</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
 	 * @generated
 	 * @ordered
 	 */
-	int MELEMENT_OPERATION_COUNT = 5;
+	int MELEMENT_OPERATION_COUNT = 6;
 
 	/**
 	 * The meta object id for the
@@ -291,6 +299,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MINTERACTION___NUDGE__INT = MELEMENT___NUDGE__INT;
+
+	/**
+	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MINTERACTION___REMOVE = MELEMENT___REMOVE;
 
 	/**
 	 * The operation id for the '<em>Get Diagram View</em>' operation. <!-- begin-user-doc --> <!--
@@ -476,6 +492,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MLIFELINE___NUDGE__INT = MELEMENT___NUDGE__INT;
+
+	/**
+	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MLIFELINE___REMOVE = MELEMENT___REMOVE;
 
 	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -680,6 +704,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MEXECUTION___NUDGE__INT = MELEMENT___NUDGE__INT;
 
 	/**
+	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION___REMOVE = MELEMENT___REMOVE;
+
+	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -838,6 +870,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MOCCURRENCE___NUDGE__INT = MELEMENT___NUDGE__INT;
 
 	/**
+	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MOCCURRENCE___REMOVE = MELEMENT___REMOVE;
+
+	/**
 	 * The number of operations of the '<em>MOccurrence</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
@@ -960,6 +1000,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MEXECUTION_OCCURRENCE___NUDGE__INT = MOCCURRENCE___NUDGE__INT;
+
+	/**
+	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION_OCCURRENCE___REMOVE = MOCCURRENCE___REMOVE;
 
 	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1129,6 +1177,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MMESSAGE_END___NUDGE__INT = MOCCURRENCE___NUDGE__INT;
 
 	/**
+	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MMESSAGE_END___REMOVE = MOCCURRENCE___REMOVE;
+
+	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -1295,6 +1351,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MMESSAGE___NUDGE__INT = MELEMENT___NUDGE__INT;
 
 	/**
+	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MMESSAGE___REMOVE = MELEMENT___REMOVE;
+
+	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -1374,6 +1438,16 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 */
 	int EOBJECT = 12;
+
+	/**
+	 * The meta object id for the '<em>Removal Command</em>' data type. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @see org.eclipse.papyrus.uml.interaction.model.RemovalCommand
+	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getRemovalCommand()
+	 * @generated
+	 */
+	int REMOVAL_COMMAND = 13;
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.papyrus.uml.interaction.model.MElement
@@ -1496,6 +1570,16 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 */
 	EOperation getMElement__Nudge__int();
+
+	/**
+	 * Returns the meta object for the '{@link org.eclipse.papyrus.uml.interaction.model.MElement#remove()
+	 * <em>Remove</em>}' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the '<em>Remove</em>' operation.
+	 * @see org.eclipse.papyrus.uml.interaction.model.MElement#remove()
+	 * @generated
+	 */
+	EOperation getMElement__Remove();
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.papyrus.uml.interaction.model.MInteraction
@@ -2141,6 +2225,17 @@ public interface SequenceDiagramPackage extends EPackage {
 	EDataType getEObject();
 
 	/**
+	 * Returns the meta object for data type '{@link org.eclipse.papyrus.uml.interaction.model.RemovalCommand
+	 * <em>Removal Command</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for data type '<em>Removal Command</em>'.
+	 * @see org.eclipse.papyrus.uml.interaction.model.RemovalCommand
+	 * @model instanceClass="org.eclipse.papyrus.uml.interaction.model.RemovalCommand" serializeable="false"
+	 * @generated
+	 */
+	EDataType getRemovalCommand();
+
+	/**
 	 * Returns the factory that creates the instances of the model. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
@@ -2254,6 +2349,14 @@ public interface SequenceDiagramPackage extends EPackage {
 		 * @generated
 		 */
 		EOperation MELEMENT___NUDGE__INT = eINSTANCE.getMElement__Nudge__int();
+
+		/**
+		 * The meta object literal for the '<em><b>Remove</b></em>' operation. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
+		 * @generated
+		 */
+		EOperation MELEMENT___REMOVE = eINSTANCE.getMElement__Remove();
 
 		/**
 		 * The meta object literal for the
@@ -2747,6 +2850,16 @@ public interface SequenceDiagramPackage extends EPackage {
 		 * @generated
 		 */
 		EDataType EOBJECT = eINSTANCE.getEObject();
+
+		/**
+		 * The meta object literal for the '<em>Removal Command</em>' data type. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
+		 * @see org.eclipse.papyrus.uml.interaction.model.RemovalCommand
+		 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getRemovalCommand()
+		 * @generated
+		 */
+		EDataType REMOVAL_COMMAND = eINSTANCE.getRemovalCommand();
 
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
@@ -1440,16 +1440,6 @@ public interface SequenceDiagramPackage extends EPackage {
 	int EOBJECT = 12;
 
 	/**
-	 * The meta object id for the '<em>Removal Command</em>' data type. <!-- begin-user-doc --> <!--
-	 * end-user-doc -->
-	 * 
-	 * @see org.eclipse.papyrus.uml.interaction.model.RemovalCommand
-	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getRemovalCommand()
-	 * @generated
-	 */
-	int REMOVAL_COMMAND = 13;
-
-	/**
 	 * Returns the meta object for class '{@link org.eclipse.papyrus.uml.interaction.model.MElement
 	 * <em>MElement</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
@@ -2225,17 +2215,6 @@ public interface SequenceDiagramPackage extends EPackage {
 	EDataType getEObject();
 
 	/**
-	 * Returns the meta object for data type '{@link org.eclipse.papyrus.uml.interaction.model.RemovalCommand
-	 * <em>Removal Command</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
-	 * @return the meta object for data type '<em>Removal Command</em>'.
-	 * @see org.eclipse.papyrus.uml.interaction.model.RemovalCommand
-	 * @model instanceClass="org.eclipse.papyrus.uml.interaction.model.RemovalCommand" serializeable="false"
-	 * @generated
-	 */
-	EDataType getRemovalCommand();
-
-	/**
 	 * Returns the factory that creates the instances of the model. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
@@ -2850,16 +2829,6 @@ public interface SequenceDiagramPackage extends EPackage {
 		 * @generated
 		 */
 		EDataType EOBJECT = eINSTANCE.getEObject();
-
-		/**
-		 * The meta object literal for the '<em>Removal Command</em>' data type. <!-- begin-user-doc --> <!--
-		 * end-user-doc -->
-		 * 
-		 * @see org.eclipse.papyrus.uml.interaction.model.RemovalCommand
-		 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getRemovalCommand()
-		 * @generated
-		 */
-		EDataType REMOVAL_COMMAND = eINSTANCE.getRemovalCommand();
 
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MElementImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MElementImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.NudgeCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.NamedElement;
 
@@ -214,6 +215,16 @@ public abstract class MElementImpl<T extends Element> extends MObjectImpl<T> imp
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
+	 * @generated NOT
+	 */
+	@Override
+	public RemovalCommand remove() {
+		return RemovalCommand.UnexecutableRemovalCommand.INSTANCE;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -273,6 +284,8 @@ public abstract class MElementImpl<T extends Element> extends MObjectImpl<T> imp
 				return following();
 			case SequenceDiagramPackage.MELEMENT___NUDGE__INT:
 				return nudge((Integer)arguments.get(0));
+			case SequenceDiagramPackage.MELEMENT___REMOVE:
+				return remove();
 		}
 		return super.eInvoke(operationID, arguments);
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MElementImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MElementImpl.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
@@ -25,7 +26,6 @@ import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.NudgeCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.NamedElement;
 
@@ -218,8 +218,8 @@ public abstract class MElementImpl<T extends Element> extends MObjectImpl<T> imp
 	 * @generated NOT
 	 */
 	@Override
-	public RemovalCommand remove() {
-		return RemovalCommand.UnexecutableRemovalCommand.INSTANCE;
+	public Command remove() {
+		return UnexecutableCommand.INSTANCE;
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionImpl.java
@@ -19,9 +19,11 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.RemoveExecutionCommand;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 
 /**
@@ -151,6 +153,14 @@ public class MExecutionImpl extends MElementImpl<ExecutionSpecification> impleme
 				return getDiagramView();
 		}
 		return super.eInvoke(operationID, arguments);
+	}
+
+	/**
+	 * @generated NOT
+	 */
+	@Override
+	public RemovalCommand remove() {
+		return new RemoveExecutionCommand(this, true);
 	}
 
 } // MExecutionImpl

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.papyrus.uml.interaction.internal.model.impl;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.gmf.runtime.notation.Shape;
@@ -23,7 +24,6 @@ import org.eclipse.papyrus.uml.interaction.internal.model.commands.RemoveExecuti
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 
 /**
@@ -159,7 +159,7 @@ public class MExecutionImpl extends MElementImpl<ExecutionSpecification> impleme
 	 * @generated NOT
 	 */
 	@Override
-	public RemovalCommand remove() {
+	public Command remove() {
 		return new RemoveExecutionCommand(this, true);
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
@@ -41,7 +41,6 @@ import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.ExecutionOccurrenceSpecification;
 import org.eclipse.uml2.uml.ExecutionSpecification;
@@ -290,7 +289,7 @@ public class MLifelineImpl extends MElementImpl<Lifeline> implements MLifeline {
 	 * @generated NOT
 	 */
 	@Override
-	public RemovalCommand remove() {
+	public Command remove() {
 		return new RemoveLifelineCommand(this, true);
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
@@ -34,12 +34,14 @@ import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.InsertExecutionCommand;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.InsertMessageCommand;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.NudgeHorizontallyCommand;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.RemoveLifelineCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.ExecutionOccurrenceSpecification;
 import org.eclipse.uml2.uml.ExecutionSpecification;
@@ -280,6 +282,16 @@ public class MLifelineImpl extends MElementImpl<Lifeline> implements MLifeline {
 	@Override
 	public Command nudgeHorizontally(int deltaX) {
 		return new NudgeHorizontallyCommand(this, deltaX);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated NOT
+	 */
+	@Override
+	public RemovalCommand remove() {
+		return new RemoveLifelineCommand(this, true);
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MMessageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MMessageImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.papyrus.uml.interaction.internal.model.impl;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.EList;
@@ -29,7 +30,6 @@ import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageEnd;
 
@@ -410,7 +410,7 @@ public class MMessageImpl extends MElementImpl<Message> implements MMessage {
 	 * @generated NOT
 	 */
 	@Override
-	public RemovalCommand remove() {
+	public Command remove() {
 		return new RemoveMessageCommand(this, true);
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MMessageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MMessageImpl.java
@@ -23,11 +23,13 @@ import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.RemoveMessageCommand;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageEnd;
 
@@ -400,6 +402,16 @@ public class MMessageImpl extends MElementImpl<Message> implements MMessage {
 	@Override
 	public Optional<MMessageEnd> getEnd(MessageEnd end) {
 		return getElement(end, getSend(), getReceive());
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated NOT
+	 */
+	@Override
+	public RemovalCommand remove() {
+		return new RemoveMessageCommand(this, true);
 	}
 
 } // MMessageImpl

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
@@ -39,6 +39,7 @@ import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.types.TypesPackage;
 import org.eclipse.uml2.uml.UMLPackage;
 
@@ -138,6 +139,13 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	private EDataType eObjectEDataType = null;
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	private EDataType removalCommandEDataType = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -317,6 +325,16 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	@Override
 	public EOperation getMElement__Nudge__int() {
 		return mElementEClass.getEOperations().get(4);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	public EOperation getMElement__Remove() {
+		return mElementEClass.getEOperations().get(5);
 	}
 
 	/**
@@ -895,6 +913,16 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
+	public EDataType getRemovalCommand() {
+		return removalCommandEDataType;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
 	public SequenceDiagramFactory getSequenceDiagramFactory() {
 		return (SequenceDiagramFactory)getEFactoryInstance();
 	}
@@ -930,6 +958,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		createEOperation(mElementEClass, MELEMENT___VERTICAL_DISTANCE__MELEMENT);
 		createEOperation(mElementEClass, MELEMENT___FOLLOWING);
 		createEOperation(mElementEClass, MELEMENT___NUDGE__INT);
+		createEOperation(mElementEClass, MELEMENT___REMOVE);
 
 		mInteractionEClass = createEClass(MINTERACTION);
 		createEReference(mInteractionEClass, MINTERACTION__LIFELINES);
@@ -998,6 +1027,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		commandEDataType = createEDataType(COMMAND);
 		creationCommandEDataType = createEDataType(CREATION_COMMAND);
 		eObjectEDataType = createEDataType(EOBJECT);
+		removalCommandEDataType = createEDataType(REMOVAL_COMMAND);
 	}
 
 	/**
@@ -1131,6 +1161,9 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		op = initEOperation(getMElement__Nudge__int(), this.getCommand(), "nudge", 1, 1, IS_UNIQUE, //$NON-NLS-1$
 				IS_ORDERED);
 		addEParameter(op, ecorePackage.getEInt(), "deltaY", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		initEOperation(getMElement__Remove(), this.getRemovalCommand(), "remove", 1, 1, IS_UNIQUE, //$NON-NLS-1$
+				IS_ORDERED);
 
 		initEClass(mInteractionEClass, MInteraction.class, "MInteraction", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
 				IS_GENERATED_INSTANCE_CLASS);
@@ -1457,6 +1490,8 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		initEDataType(creationCommandEDataType, CreationCommand.class, "CreationCommand", !IS_SERIALIZABLE, //$NON-NLS-1$
 				!IS_GENERATED_INSTANCE_CLASS);
 		initEDataType(eObjectEDataType, EObject.class, "EObject", !IS_SERIALIZABLE, //$NON-NLS-1$
+				!IS_GENERATED_INSTANCE_CLASS);
+		initEDataType(removalCommandEDataType, RemovalCommand.class, "RemovalCommand", !IS_SERIALIZABLE, //$NON-NLS-1$
 				!IS_GENERATED_INSTANCE_CLASS);
 
 		// Create resource

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
@@ -39,7 +39,6 @@ import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.types.TypesPackage;
 import org.eclipse.uml2.uml.UMLPackage;
 
@@ -139,13 +138,6 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	private EDataType eObjectEDataType = null;
-
-	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
-	 * @generated
-	 */
-	private EDataType removalCommandEDataType = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -913,16 +905,6 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
-	public EDataType getRemovalCommand() {
-		return removalCommandEDataType;
-	}
-
-	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * 
-	 * @generated
-	 */
-	@Override
 	public SequenceDiagramFactory getSequenceDiagramFactory() {
 		return (SequenceDiagramFactory)getEFactoryInstance();
 	}
@@ -1027,7 +1009,6 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		commandEDataType = createEDataType(COMMAND);
 		creationCommandEDataType = createEDataType(CREATION_COMMAND);
 		eObjectEDataType = createEDataType(EOBJECT);
-		removalCommandEDataType = createEDataType(REMOVAL_COMMAND);
 	}
 
 	/**
@@ -1162,8 +1143,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 				IS_ORDERED);
 		addEParameter(op, ecorePackage.getEInt(), "deltaY", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
-		initEOperation(getMElement__Remove(), this.getRemovalCommand(), "remove", 1, 1, IS_UNIQUE, //$NON-NLS-1$
-				IS_ORDERED);
+		initEOperation(getMElement__Remove(), this.getCommand(), "remove", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(mInteractionEClass, MInteraction.class, "MInteraction", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
 				IS_GENERATED_INSTANCE_CLASS);
@@ -1490,8 +1470,6 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		initEDataType(creationCommandEDataType, CreationCommand.class, "CreationCommand", !IS_SERIALIZABLE, //$NON-NLS-1$
 				!IS_GENERATED_INSTANCE_CLASS);
 		initEDataType(eObjectEDataType, EObject.class, "EObject", !IS_SERIALIZABLE, //$NON-NLS-1$
-				!IS_GENERATED_INSTANCE_CLASS);
-		initEDataType(removalCommandEDataType, RemovalCommand.class, "RemovalCommand", !IS_SERIALIZABLE, //$NON-NLS-1$
 				!IS_GENERATED_INSTANCE_CLASS);
 
 		// Create resource

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
@@ -170,9 +170,9 @@ public interface MElement<T extends Element> extends MObject {
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
-	 * @model dataType="org.eclipse.papyrus.uml.interaction.model.RemovalCommand" required="true"
+	 * @model dataType="org.eclipse.papyrus.uml.interaction.model.Command" required="true"
 	 * @generated
 	 */
-	RemovalCommand remove();
+	Command remove();
 
 } // MElement

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
@@ -167,4 +167,12 @@ public interface MElement<T extends Element> extends MObject {
 	 */
 	Command nudge(int deltaY);
 
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @model dataType="org.eclipse.papyrus.uml.interaction.model.RemovalCommand" required="true"
+	 * @generated
+	 */
+	RemovalCommand remove();
+
 } // MElement

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MMessage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MMessage.java
@@ -13,7 +13,6 @@
 package org.eclipse.papyrus.uml.interaction.model;
 
 import java.util.Optional;
-
 import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageEnd;

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/CompoundModelCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/CompoundModelCommand.java
@@ -13,6 +13,7 @@
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.common.command.Command;
@@ -92,6 +93,31 @@ public class CompoundModelCommand extends StrictCompoundCommand {
 		}
 
 		return new CompoundModelCommand(first, second);
+	}
+
+	/**
+	 * Compose multiple commands.
+	 *
+	 * @param editingDomain
+	 *            the editing domain context inwhich the composed command will be executed, which may inform
+	 *            the kind of composite that is created
+	 * @param commands
+	 *            the commands to compose
+	 * @param the
+	 *            resulting composite, which may be optimized in such a way that it isn't literally a
+	 *            {@link CompoundCommand} of any kind
+	 */
+	public static Command compose(EditingDomain editingDomain, List<Command> commands) {
+		if (commands.size() == 1) {
+			return commands.get(0);
+		} else if (commands.size() > 1) {
+			Command result = CompoundModelCommand.compose(editingDomain, commands.get(0), commands.get(1));
+			for (int i = 2; i < commands.size(); i++) {
+				result = result.chain(commands.get(i));
+			}
+			return result;
+		}
+		return UnexecutableCommand.INSTANCE;
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionCommand.java
@@ -12,10 +12,10 @@
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.ecore.EObject;
@@ -23,8 +23,8 @@ import org.eclipse.papyrus.uml.interaction.internal.model.impl.MExecutionImpl;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MMessageImpl;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommandImpl;
 import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
 
@@ -85,7 +85,7 @@ public class RemoveExecutionCommand extends ModelCommand<MExecutionImpl> impleme
 	}
 
 	@Override
-	public Set<EObject> getElementsToRemove() {
+	public Collection<EObject> getElementsToRemove() {
 		if (delegate == null) {
 			return Collections.emptySet();
 		}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionCommand.java
@@ -1,0 +1,95 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Johannes Faltermeier and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Johannes Faltermeier - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MExecutionImpl;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MMessageImpl;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
+import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommandImpl;
+import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
+
+/**
+ * An execution removal operation.
+ *
+ * @author Johannes Faltermeier
+ */
+public class RemoveExecutionCommand extends ModelCommand<MExecutionImpl> implements RemovalCommand {
+
+	private RemovalCommand delegate;
+
+	private boolean nudge;
+
+	/**
+	 * @param executionToRemove
+	 *            the {@link MExecutionImpl} which should be deleted
+	 * @param nudge
+	 *            whether this command will nudge remaining diagram elements
+	 */
+	public RemoveExecutionCommand(MExecutionImpl executionToRemove, boolean nudge) {
+		super(executionToRemove);
+		this.nudge = nudge;
+		command = createCommand();
+	}
+
+	@Override
+	protected Command createCommand() {
+		MExecutionImpl execution = getTarget();
+
+		/* remove messages */
+		List<RemovalCommand> allCommands = new ArrayList<>(3);
+		removeMessageIfPresent(execution.getStart()).ifPresent(c -> allCommands.add(c));
+		removeMessageIfPresent(execution.getFinish()).ifPresent(c -> allCommands.add(c));
+
+		/* semantics */
+		SemanticHelper semantics = semanticHelper();
+		allCommands.add(semantics.deleteExecutionSpecification(execution.getElement()));
+
+		delegate = new RemovalCommandImpl(getEditingDomain(), allCommands);
+
+		/* diagram */
+		DiagramHelper diagrams = diagramHelper();
+		Command diagramsResultCommand = diagrams.deleteView(execution.getDiagramView().get());
+
+		/* chain */
+		return CompoundModelCommand.compose(getEditingDomain(), delegate, diagramsResultCommand);
+	}
+
+	private Optional<RemovalCommand> removeMessageIfPresent(Optional<MOccurrence<?>> occurrence) {
+		if (occurrence.isPresent()) {
+			MElement<?> owner = occurrence.get().getOwner();
+			if (MMessageImpl.class.isInstance(owner)) {
+				return Optional.of(new RemoveMessageCommand((MMessageImpl)owner, getTarget(), false));
+			}
+		}
+		return Optional.empty();
+	}
+
+	@Override
+	public Set<EObject> getElementsToRemove() {
+		if (delegate == null) {
+			return Collections.emptySet();
+		}
+		return delegate.getElementsToRemove();
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveLifelineCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveLifelineCommand.java
@@ -12,6 +12,7 @@
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -23,8 +24,8 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MExecutionImpl;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MLifelineImpl;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MMessageImpl;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommandImpl;
 import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
 import org.eclipse.uml2.uml.MessageOccurrenceSpecification;
@@ -96,7 +97,7 @@ public class RemoveLifelineCommand extends ModelCommand<MLifelineImpl> implement
 	}
 
 	@Override
-	public Set<EObject> getElementsToRemove() {
+	public Collection<EObject> getElementsToRemove() {
 		if (delegate == null) {
 			return Collections.emptySet();
 		}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveLifelineCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveLifelineCommand.java
@@ -1,0 +1,106 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Johannes Faltermeier and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Johannes Faltermeier - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MExecutionImpl;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MLifelineImpl;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MMessageImpl;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
+import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommandImpl;
+import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
+import org.eclipse.uml2.uml.MessageOccurrenceSpecification;
+
+/**
+ * An lifeline removal operation.
+ *
+ * @author Johannes Faltermeier
+ */
+public class RemoveLifelineCommand extends ModelCommand<MLifelineImpl> implements RemovalCommand {
+
+	private RemovalCommand delegate;
+
+	private boolean nudge;
+
+	/**
+	 * @param target
+	 *            the {@link MLifelineImpl} to delete
+	 * @param nudge
+	 *            whether this command will nudge remaining diagram elements
+	 */
+	public RemoveLifelineCommand(MLifelineImpl target, boolean nudge) {
+		super(target);
+		this.nudge = nudge;
+		command = createCommand();
+	}
+
+	@Override
+	protected Command createCommand() {
+		MLifelineImpl lifeline = getTarget();
+
+		List<RemovalCommand> allCommands = new ArrayList<>(lifeline.getExecutions().size() + 1);
+
+		/* collect non execution related messages */
+		Set<MessageOccurrenceSpecification> messageEndsToDelete = new LinkedHashSet<MessageOccurrenceSpecification>(
+				lifeline.getElement().getCoveredBys().stream()//
+						.filter(MessageOccurrenceSpecification.class::isInstance)//
+						.map(MessageOccurrenceSpecification.class::cast)//
+						.collect(Collectors.toSet()));
+
+		/* remove executions */
+		lifeline.getExecutions().forEach(e -> {
+			e.getStart().ifPresent(o -> messageEndsToDelete.remove(o.getElement()));
+			e.getFinish().ifPresent(o -> messageEndsToDelete.remove(o.getElement()));
+			allCommands.add(new RemoveExecutionCommand((MExecutionImpl)e, false));
+		});
+
+		/* remove non execution messages */
+		messageEndsToDelete.stream()//
+				.map(mos -> mos.getMessage())//
+				.map(m -> lifeline.getInteraction().getMessage(m))//
+				.filter(m -> m.isPresent())//
+				.map(m -> m.get())//
+				.collect(Collectors.toSet())//
+				.forEach(m -> allCommands.add(new RemoveMessageCommand((MMessageImpl)m, false)));
+
+		/* semantics */
+		SemanticHelper semantics = semanticHelper();
+		allCommands.add(semantics.deleteLifeline(lifeline.getElement()));
+
+		delegate = new RemovalCommandImpl(getEditingDomain(), allCommands);
+
+		/* diagram */
+		DiagramHelper diagrams = diagramHelper();
+		Command diagramsResultCommand = diagrams.deleteView(lifeline.getDiagramView().get());
+
+		/* chain */
+		return CompoundModelCommand.compose(getEditingDomain(), delegate, diagramsResultCommand);
+	}
+
+	@Override
+	public Set<EObject> getElementsToRemove() {
+		if (delegate == null) {
+			return Collections.emptySet();
+		}
+		return delegate.getElementsToRemove();
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveMessageCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveMessageCommand.java
@@ -1,0 +1,105 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Johannes Faltermeier and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Johannes Faltermeier - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MMessageImpl;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
+import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
+
+/**
+ * A message removal operation.
+ *
+ * @author Johannes Faltermeier
+ */
+public class RemoveMessageCommand extends ModelCommand<MMessageImpl> implements RemovalCommand {
+
+	private RemovalCommand delegate;
+
+	private MElement<?> trigger;
+
+	private boolean nudge;
+
+	/**
+	 * Constructs a new {@link RemoveMessageCommand}.
+	 * 
+	 * @param messageToRemove
+	 *            message to remove
+	 * @param nudge
+	 *            whether this command will nudge remaining diagram elements
+	 */
+	public RemoveMessageCommand(MMessageImpl messageToRemove, boolean nudge) {
+		this(messageToRemove, null, nudge);
+	}
+
+	/**
+	 * Constructs a new {@link RemoveMessageCommand}.
+	 * 
+	 * @param messageToRemove
+	 *            message to remove
+	 * @param trigger
+	 *            the (also deleted) parent element that triggers this deletion
+	 */
+	public RemoveMessageCommand(MMessageImpl messageToRemove, MElement<?> trigger, boolean nudge) {
+		super(messageToRemove);
+		this.nudge = nudge;
+		this.trigger = trigger;
+		command = createCommand();
+	}
+
+	@Override
+	protected Command createCommand() {
+		/*
+		 * deletion of a message that triggers an execution specification should delete the execution
+		 * specification. vice versa the deletion of an execution specification should delete all related
+		 * fragments. so in this case we will delegate the deletion to the execution specification remove
+		 * command. Do not attempt to delete an element which triggered our own deletion.
+		 */
+		Optional<MMessageEnd> receive = getTarget().getReceive();
+		if (receive.isPresent()) {
+			Optional<MExecution> startedExecution = receive.get().getStartedExecution();
+			if (startedExecution.isPresent() && startedExecution.get() != trigger) {
+				delegate = startedExecution.get().remove();
+				return delegate;
+			}
+		}
+
+		/* semantics */
+		SemanticHelper semantics = semanticHelper();
+		delegate = semantics.deleteMessage(getTarget().getElement());
+
+		/* diagram */
+		DiagramHelper diagrams = diagramHelper();
+		Command diagramsResultCommand = diagrams.deleteView(getTarget().getDiagramView().get());
+
+		/* chain */
+		return delegate.chain(diagramsResultCommand);
+	}
+
+	@Override
+	public Set<EObject> getElementsToRemove() {
+		if (delegate == null) {
+			return Collections.emptySet();
+		}
+		return delegate.getElementsToRemove();
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveMessageCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveMessageCommand.java
@@ -11,18 +11,19 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MExecutionImpl;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MMessageImpl;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
 
 /**
@@ -77,7 +78,7 @@ public class RemoveMessageCommand extends ModelCommand<MMessageImpl> implements 
 		if (receive.isPresent()) {
 			Optional<MExecution> startedExecution = receive.get().getStartedExecution();
 			if (startedExecution.isPresent() && startedExecution.get() != trigger) {
-				delegate = startedExecution.get().remove();
+				delegate = new RemoveExecutionCommand((MExecutionImpl)startedExecution.get(), nudge);
 				return delegate;
 			}
 		}
@@ -95,7 +96,7 @@ public class RemoveMessageCommand extends ModelCommand<MMessageImpl> implements 
 	}
 
 	@Override
-	public Set<EObject> getElementsToRemove() {
+	public Collection<EObject> getElementsToRemove() {
 		if (delegate == null) {
 			return Collections.emptySet();
 		}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
@@ -18,6 +18,8 @@ import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.edit.command.DeleteCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.gmf.runtime.diagram.core.util.ViewUtil;
 import org.eclipse.gmf.runtime.notation.Bounds;
@@ -213,6 +215,11 @@ public class DefaultDiagramHelper implements DiagramHelper {
 		return createMessage.chain(setSource).chain(setTarget);
 	}
 
+	@Override
+	public Command deleteView(EObject diagramView) {
+		return DeleteCommand.create(editingDomain, diagramView);
+	}
+
 	protected final SemanticHelper semanticHelper() {
 		return semanticHelper.get();
 	}
@@ -220,4 +227,5 @@ public class DefaultDiagramHelper implements DiagramHelper {
 	protected final LayoutHelper layoutHelper() {
 		return layoutHelper.get();
 	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultSemanticHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultSemanticHelper.java
@@ -14,9 +14,12 @@ package org.eclipse.papyrus.uml.interaction.internal.model.spi.impl;
 
 import static java.util.Collections.singleton;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.UnexecutableCommand;
@@ -26,12 +29,18 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.command.AddCommand;
+import org.eclipse.emf.edit.command.DeleteCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
+import org.eclipse.papyrus.uml.interaction.model.spi.DeferredAddCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredCreateCommand;
+import org.eclipse.papyrus.uml.interaction.model.spi.DeferredDeleteCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredSetCommand;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommandImpl;
 import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
 import org.eclipse.uml2.uml.Action;
 import org.eclipse.uml2.uml.ActionExecutionSpecification;
@@ -40,10 +49,12 @@ import org.eclipse.uml2.uml.BehaviorExecutionSpecification;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.ExecutionOccurrenceSpecification;
 import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Gate;
 import org.eclipse.uml2.uml.Interaction;
 import org.eclipse.uml2.uml.Lifeline;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageEnd;
+import org.eclipse.uml2.uml.MessageOccurrenceSpecification;
 import org.eclipse.uml2.uml.MessageSort;
 import org.eclipse.uml2.uml.NamedElement;
 import org.eclipse.uml2.uml.OccurrenceSpecification;
@@ -101,6 +112,20 @@ public class DefaultSemanticHelper implements SemanticHelper {
 	@Override
 	public Command set(EObject owner, EStructuralFeature feature, Object value) {
 		return SetCommand.create(editingDomain, owner, feature, value);
+	}
+
+	@Override
+	public Command delete(EObject toDelete) {
+		return DeleteCommand.create(editingDomain, toDelete);
+	}
+
+	private RemovalCommand removalCommand(EObject toDelete) {
+		return new RemovalCommandImpl(editingDomain, delete(toDelete), toDelete);
+	}
+
+	private RemovalCommand deferredRemovalCommand(Supplier<? extends EObject> toDelete) {
+		return new RemovalCommandImpl(editingDomain, new DeferredDeleteCommand(editingDomain, toDelete),
+				toDelete.get());
 	}
 
 	@Override
@@ -384,6 +409,78 @@ public class DefaultSemanticHelper implements SemanticHelper {
 				UMLPackage.Literals.MESSAGE_END__MESSAGE, result);
 
 		return result.andThen(editingDomain, sendSetMessage).andThen(editingDomain, recvSetMessage);
+	}
+
+	@Override
+	public RemovalCommand deleteMessage(Message message) {
+		List<RemovalCommand> commands = new ArrayList<>(3);
+		commands.add(removalCommand(message));
+		deleteMessageEnd(message.getReceiveEvent()).ifPresent(c -> commands.add(c));
+		deleteMessageEnd(message.getSendEvent()).ifPresent(c -> commands.add(c));
+		return new RemovalCommandImpl(editingDomain, commands);
+	}
+
+	private Optional<RemovalCommand> deleteMessageEnd(MessageEnd messageEnd) {
+		if (messageEnd == null) {
+			return Optional.empty();
+		}
+
+		if (Gate.class.isInstance(messageEnd)) {
+			// TODO JF according to req docs message ends should be deleted. it does not state an exception
+			// for gates
+			return Optional.empty();
+		}
+
+		if (MessageOccurrenceSpecification.class.isInstance(messageEnd) && messageEnd.getMessage() != null) {
+			/* find ExecutionSpecifications where this end is start or finish */
+			Interaction interaction = messageEnd.getMessage().getInteraction();
+			List<ExecutionSpecification> executionSpecifications = interaction.getFragments().stream()
+					.filter(f -> ExecutionSpecification.class.isInstance(f))
+					.map(f -> ExecutionSpecification.class.cast(f))
+					.filter(es -> es.getStart() == messageEnd || es.getFinish() == messageEnd)
+					.collect(Collectors.toList());
+
+			/* if this end is neither start nor finish -> simply delete it */
+			if (executionSpecifications.isEmpty()) {
+				return Optional.of(removalCommand(messageEnd));
+			}
+
+			/*
+			 * if this end is a start or finish is has to be replaced by an ExecutionOccurrenceSpecification
+			 */
+			List<Command> commandList = new ArrayList<Command>(executionSpecifications.size() + 1);
+			commandList.add(delete(messageEnd));
+			executionSpecifications.forEach(es -> {
+				boolean isStart = es.getStart() == messageEnd;
+				CreationParameters parameters = isStart ? CreationParameters.before(es)
+						: CreationParameters.after(es);
+				CreationCommand<OccurrenceSpecification> creationAndSet = isStart
+						? createStart(() -> es, parameters)
+						: createFinish(() -> es, parameters);
+				commandList.add(creationAndSet);
+				/* also add to lifeline */
+				es.getCovereds().stream().findFirst().ifPresent(l -> commandList.add(
+						new DeferredAddCommand(l, UMLPackage.Literals.LIFELINE__COVERED_BY, creationAndSet)));
+			});
+			return Optional.of(new RemovalCommandImpl(editingDomain,
+					CompoundModelCommand.compose(editingDomain, commandList)));
+		}
+
+		return Optional.of(removalCommand(messageEnd));
+	}
+
+	@Override
+	public RemovalCommand deleteExecutionSpecification(ExecutionSpecification execution) {
+		List<RemovalCommand> commands = new ArrayList<>(3);
+		commands.add(deferredRemovalCommand(() -> execution.getStart()));
+		commands.add(deferredRemovalCommand(() -> execution.getFinish()));
+		commands.add(removalCommand(execution));
+		return new RemovalCommandImpl(editingDomain, commands);
+	}
+
+	@Override
+	public RemovalCommand deleteLifeline(Lifeline lifeline) {
+		return removalCommand(lifeline);
 	}
 
 	//

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultSemanticHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultSemanticHelper.java
@@ -35,11 +35,11 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredAddCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredCreateCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredDeleteCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredSetCommand;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommandImpl;
 import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
 import org.eclipse.uml2.uml.Action;
@@ -472,8 +472,8 @@ public class DefaultSemanticHelper implements SemanticHelper {
 	@Override
 	public RemovalCommand deleteExecutionSpecification(ExecutionSpecification execution) {
 		List<RemovalCommand> commands = new ArrayList<>(3);
-		commands.add(deferredRemovalCommand(() -> execution.getStart()));
-		commands.add(deferredRemovalCommand(() -> execution.getFinish()));
+		commands.add(deferredRemovalCommand(execution::getStart));
+		commands.add(deferredRemovalCommand(execution::getFinish));
 		commands.add(removalCommand(execution));
 		return new RemovalCommandImpl(editingDomain, commands);
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/RemovalCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/RemovalCommand.java
@@ -1,0 +1,61 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Johannes Faltermeier and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Johannes Faltermeier - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CommandWrapper;
+import org.eclipse.emf.common.command.UnexecutableCommand;
+import org.eclipse.emf.ecore.EObject;
+
+/**
+ * Command which is supposed to delete model element. It offers methods to access the elements marked for
+ * deletion.
+ */
+public interface RemovalCommand extends Command, Supplier<Set<EObject>> {
+
+	/**
+	 * @return the elements which are marked for removal when this command was created.
+	 */
+	Set<EObject> getElementsToRemove();
+
+	@Override
+	default Set<EObject> get() {
+		return getElementsToRemove();
+	}
+
+	/**
+	 * Unexecutable command which implements {@link RemovalCommand}.
+	 */
+	static class UnexecutableRemovalCommand extends CommandWrapper implements RemovalCommand {
+
+		/**
+		 * The singleton instance.
+		 */
+		public static final RemovalCommand INSTANCE = new UnexecutableRemovalCommand();
+
+		private UnexecutableRemovalCommand() {
+			super(UnexecutableCommand.INSTANCE);
+		}
+
+		@Override
+		public Set<EObject> getElementsToRemove() {
+			return Collections.emptySet();
+		}
+
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DeferredDeleteCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DeferredDeleteCommand.java
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Johannes Faltermeier and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Johannes Faltermeier - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.spi;
+
+import java.util.function.Supplier;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CommandWrapper;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
+
+/**
+ * This is the {@code DeferredDeleteCommand} type. Enjoy.
+ *
+ * @author Johannes Faltermeier
+ */
+public class DeferredDeleteCommand extends CommandWrapper {
+
+	private EditingDomain domain;
+
+	private Supplier<? extends EObject> toDelete;
+
+	/**
+	 * Initializes me.
+	 */
+	public DeferredDeleteCommand(EditingDomain domain, Supplier<? extends EObject> toDelete) {
+		super();
+
+		this.domain = domain;
+		this.toDelete = toDelete;
+	}
+
+	@Override
+	protected Command createCommand() {
+		return getSemanticHelper().delete(toDelete.get());
+	}
+
+	SemanticHelper getSemanticHelper() {
+		return LogicalModelPlugin.getInstance().getSemanticHelper(domain);
+	}
+
+	@Override
+	public Command chain(Command next) {
+		return CompoundModelCommand.compose(domain, this, next);
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DiagramHelper.java
@@ -16,6 +16,7 @@ import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.gmf.runtime.notation.View;
@@ -95,5 +96,14 @@ public interface DiagramHelper {
 	Command createMessageConnector(Supplier<Message> message, //
 			Supplier<? extends View> source, IntSupplier sourceY, //
 			Supplier<? extends View> target, IntSupplier targetY);
+
+	/**
+	 * Obtain a command to delete a given {@code connector}.
+	 * 
+	 * @param diagramView
+	 *            the connector to delete
+	 * @return the deletion command
+	 */
+	Command deleteView(EObject diagramView);
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/RemovalCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/RemovalCommand.java
@@ -10,52 +10,28 @@
  *   Johannes Faltermeier - Initial API and implementation
  *****************************************************************************/
 
-package org.eclipse.papyrus.uml.interaction.model;
+package org.eclipse.papyrus.uml.interaction.model.spi;
 
-import java.util.Collections;
-import java.util.Set;
+import java.util.Collection;
 import java.util.function.Supplier;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.CommandWrapper;
-import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.ecore.EObject;
 
 /**
  * Command which is supposed to delete model element. It offers methods to access the elements marked for
  * deletion.
  */
-public interface RemovalCommand extends Command, Supplier<Set<EObject>> {
+public interface RemovalCommand extends Command, Supplier<Collection<EObject>> {
 
 	/**
 	 * @return the elements which are marked for removal when this command was created.
 	 */
-	Set<EObject> getElementsToRemove();
+	Collection<EObject> getElementsToRemove();
 
 	@Override
-	default Set<EObject> get() {
+	default Collection<EObject> get() {
 		return getElementsToRemove();
-	}
-
-	/**
-	 * Unexecutable command which implements {@link RemovalCommand}.
-	 */
-	static class UnexecutableRemovalCommand extends CommandWrapper implements RemovalCommand {
-
-		/**
-		 * The singleton instance.
-		 */
-		public static final RemovalCommand INSTANCE = new UnexecutableRemovalCommand();
-
-		private UnexecutableRemovalCommand() {
-			super(UnexecutableCommand.INSTANCE);
-		}
-
-		@Override
-		public Set<EObject> getElementsToRemove() {
-			return Collections.emptySet();
-		}
-
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/RemovalCommandImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/RemovalCommandImpl.java
@@ -12,6 +12,7 @@
 package org.eclipse.papyrus.uml.interaction.model.spi;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -23,7 +24,6 @@ import org.eclipse.emf.common.command.CommandWrapper;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 
 /**
  * Basic implementation of a {@link RemovalCommand}.
@@ -64,7 +64,7 @@ public class RemovalCommandImpl extends CommandWrapper implements RemovalCommand
 	}
 
 	@Override
-	public Set<EObject> getElementsToRemove() {
+	public Collection<EObject> getElementsToRemove() {
 		return Collections.unmodifiableSet(toRemove);
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/RemovalCommandImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/RemovalCommandImpl.java
@@ -1,0 +1,76 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Johannes Faltermeier and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Johannes Faltermeier - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.spi;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CommandWrapper;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
+
+/**
+ * Basic implementation of a {@link RemovalCommand}.
+ */
+public class RemovalCommandImpl extends CommandWrapper implements RemovalCommand {
+
+	private Set<EObject> toRemove = new LinkedHashSet<EObject>();
+
+	private EditingDomain domain;
+
+	/**
+	 * Creates an empty removal command, which wraps the given command.
+	 */
+	public RemovalCommandImpl(EditingDomain domain, Command command) {
+		super(command);
+		this.domain = domain;
+	}
+
+	/**
+	 * Creates a new removal command. It is expected that the given command will lead to the deletion of the
+	 * given object once executed.
+	 */
+	public RemovalCommandImpl(EditingDomain domain, Command command, EObject object) {
+		super(command);
+		this.domain = domain;
+		toRemove.add(object);
+	}
+
+	/**
+	 * Creates a removal command which combines the result of the given removal commands.
+	 */
+	public RemovalCommandImpl(EditingDomain domain, List<RemovalCommand> commands) {
+		super(CompoundModelCommand.compose(domain, new ArrayList<Command>(commands)));
+		this.domain = domain;
+		toRemove.addAll(commands.stream()//
+				.flatMap(rm -> rm.getElementsToRemove().stream())//
+				.collect(Collectors.toSet()));
+	}
+
+	@Override
+	public Set<EObject> getElementsToRemove() {
+		return Collections.unmodifiableSet(toRemove);
+	}
+
+	@Override
+	public Command chain(Command next) {
+		return CompoundModelCommand.compose(domain, this, next);
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/SemanticHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/SemanticHelper.java
@@ -20,7 +20,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.Action;
 import org.eclipse.uml2.uml.Behavior;
 import org.eclipse.uml2.uml.Element;

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/SemanticHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/SemanticHelper.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
 import org.eclipse.uml2.uml.Action;
 import org.eclipse.uml2.uml.Behavior;
 import org.eclipse.uml2.uml.Element;
@@ -82,6 +83,15 @@ public interface SemanticHelper {
 	 * @return the command
 	 */
 	Command set(EObject owner, EStructuralFeature feature, Object value);
+
+	/**
+	 * Obtain a command that will remove an EObject from its container and any resource.
+	 * 
+	 * @param toDelete
+	 *            the object to delete
+	 * @return the command
+	 */
+	Command delete(EObject toDelete);
 
 	/**
 	 * Obtain a command that inserts {@code values} after some other in a {@code feature} of an {@code owner}
@@ -280,5 +290,32 @@ public interface SemanticHelper {
 	CreationCommand<Message> createMessage(Supplier<? extends MessageEnd> sendEvent,
 			Supplier<? extends MessageEnd> recvEvent, MessageSort sort, NamedElement signature,
 			CreationParameters messageParams);
+
+	/**
+	 * Deletes an existing message.
+	 * 
+	 * @param message
+	 *            the message to delete
+	 * @return the delete command
+	 */
+	RemovalCommand deleteMessage(Message message);
+
+	/**
+	 * Delete an existing execution specification.
+	 * 
+	 * @param execution
+	 *            the execution to delete
+	 * @return the delete command
+	 */
+	RemovalCommand deleteExecutionSpecification(ExecutionSpecification execution);
+
+	/**
+	 * Delete an existing lifeline.
+	 * 
+	 * @param lifeline
+	 *            the lifeline to delete
+	 * @return the delete command
+	 */
+	RemovalCommand deleteLifeline(Lifeline lifeline);
 
 }

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MElementTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MElementTest.java
@@ -27,6 +27,7 @@ import java.util.OptionalInt;
 import org.eclipse.emf.common.EMFPlugin;
 import org.eclipse.emf.common.command.BasicCommandStack;
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -183,6 +184,36 @@ public abstract class MElementTest extends TestCase {
 		assertThat(String.format("No element %s of type %s", qualifiedName, type.getSimpleName()), result,
 				isPresent());
 		return result.get();
+	}
+	
+	protected Optional<View> findTypeInChildren(View shape, String type) {
+		TreeIterator<EObject> contents = shape.eAllContents();
+		while(contents.hasNext()) {
+			EObject next = contents.next();
+			if(View.class.isInstance(next)) {
+				View view = View.class.cast(next);
+				if(type.equals(view.getType())) {
+					return Optional.of(view);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+	
+
+	protected int countTypesInChildren(View shape, String type) {
+		int found = 0;
+		TreeIterator<EObject> contents = shape.eAllContents();
+		while(contents.hasNext()) {
+			EObject next = contents.next();
+			if(View.class.isInstance(next)) {
+				View view = View.class.cast(next);
+				if(type.equals(view.getType())) {
+					found++;
+				}
+			}
+		}
+		return found;
 	}
 
 	@Override

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionTest.java
@@ -15,7 +15,13 @@ package org.eclipse.papyrus.uml.interaction.model.tests;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.uml2.uml.InteractionFragment;
 
 import junit.textui.TestRunner;
 
@@ -84,7 +90,13 @@ public class MExecutionTest extends MElementTest {
 
 	@Override
 	protected void initializeFixture() {
-		setFixture(interaction.getLifelines().get(1).getExecutions().get(0));
+		/* remove test may remove execution -> avoid NPE */
+		List<MExecution> executions = interaction.getLifelines().get(1).getExecutions();
+		if(executions.isEmpty()) {
+			setFixture(null);
+		}else {
+			setFixture(executions.get(0));
+		}
 	}
 
 	/**
@@ -175,6 +187,33 @@ public class MExecutionTest extends MElementTest {
 	public void testGetDiagramView() {
 		super.testGetDiagramView();
 		assertThat(getFixture().getDiagramView().get().getType(), is("Shape_Execution_Specification"));
+	}
+	
+	public void testRemove() {
+		MExecution execution = getFixture();
+		
+		/* act */
+		Command command = execution.remove();
+		assertThat(command, executable());
+		execute(command);
+		
+		/* assert execution with messages removed */
+		/* assert logical representation */
+		assertEquals(2, interaction.getLifelines().size());
+		assertTrue(interaction.getLifelines().get(1).getExecutions().isEmpty());
+		assertTrue(interaction.getMessages().isEmpty());
+		
+		/* assert semantics */
+		assertEquals(2, umlInteraction.getLifelines().size());
+		assertTrue(umlInteraction.getLifelines().get(1).getCoveredBys().isEmpty());
+		assertTrue(umlInteraction.getFragments().isEmpty());
+		assertTrue(umlInteraction.getMessages().isEmpty());
+		
+		/* assert diagram */
+		assertTrue(sequenceDiagram.getEdges().isEmpty());
+		Optional<Shape> lifeLineView = interaction.getLifelines().get(1).getDiagramView();
+		assertTrue(lifeLineView.isPresent());
+		assertFalse(findTypeInChildren(lifeLineView.get(),"Shape_Execution_Specification").isPresent());
 	}
 
 } // MExecutionTest

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MLifelineTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MLifelineTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 import java.util.Optional;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.Edge;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
@@ -134,7 +135,11 @@ public class MLifelineTest extends MElementTest {
 				break;
 		}
 
-		setFixture(interaction.getLifelines().get(which));
+		if (which < interaction.getLifelines().size()) {
+			setFixture(interaction.getLifelines().get(which));
+		} else {
+			setFixture(null);
+		}
 	}
 
 	/**
@@ -382,6 +387,31 @@ public class MLifelineTest extends MElementTest {
 		assertThat(edge.getTarget(), notNullValue());
 		assertThat(edge.getTarget().getType(), containsString("Body"));
 		assertThat(edge.getTarget().getElement(), is(receiver.getElement()));
+	}
+
+	public void testRemove() {
+		MLifeline lifeline = getFixture();
+
+		/* act */
+		Command command = lifeline.remove();
+		assertThat(command, executable());
+		execute(command);
+
+		/* assert lifeline with executions and messages removed */
+		/* assert logical representation */
+		assertEquals(1, interaction.getLifelines().size());
+		assertTrue(interaction.getMessages().isEmpty());
+
+		/* assert semantics */
+		assertEquals(1, umlInteraction.getLifelines().size());
+		assertTrue(umlInteraction.getFragments().isEmpty());
+		assertTrue(umlInteraction.getMessages().isEmpty());
+
+		/* assert diagram */
+		assertTrue(sequenceDiagram.getEdges().isEmpty());
+		Optional<Diagram> diagramView = interaction.getDiagramView();
+		assertTrue(diagramView.isPresent());
+		assertEquals(1, countTypesInChildren(diagramView.get(), "Shape_Lifeline_Header"));
 	}
 
 	/**

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageTest.java
@@ -15,6 +15,7 @@ package org.eclipse.papyrus.uml.interaction.model.tests;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.uml2.uml.MessageEnd;
 
@@ -87,7 +88,11 @@ public class MMessageTest extends MElementTest {
 
 	@Override
 	protected void initializeFixture() {
-		setFixture(interaction.getMessages().get(0));
+		if (interaction.getMessages().isEmpty()) {
+			setFixture(null);
+		} else {
+			setFixture(interaction.getMessages().get(0));
+		}
 	}
 
 	/**
@@ -215,6 +220,41 @@ public class MMessageTest extends MElementTest {
 
 		MessageEnd recv = (MessageEnd)umlInteraction.getFragment("request-recv");
 		assertThat(getFixture().getEnd(recv), isPresent(wraps(recv)));
+	}
+
+	public void testRemove() {
+		MMessage requestMessage = getFixture();
+
+		/* assert semantic preconditions */
+		assertEquals(2, umlInteraction.getMessages().size());
+		assertNotNull(umlInteraction.getMessage("request"));
+		assertEquals(5, umlInteraction.getFragments().size());
+		assertNotNull(umlInteraction.getFragment("request-send"));
+		assertNotNull(umlInteraction.getFragment("request-recv"));
+		assertEquals(2, umlInteraction.getLifelines().size());
+		assertEquals(2, umlInteraction.getLifelines().get(0).getCoveredBys().size());
+		assertEquals(3, umlInteraction.getLifelines().get(1).getCoveredBys().size());
+
+		/* assert diagram preconditions */
+		assertEquals(2, sequenceDiagram.getEdges().size());
+
+		/* act */
+		Command command = requestMessage.remove();
+		assertThat(command, executable());
+		execute(command);
+
+		/* assert logical representation */
+		assertEquals(0, interaction.getMessages().size());
+
+		/* assert semantic representation */
+		assertEquals(0, umlInteraction.getMessages().size());
+		assertEquals(0, umlInteraction.getFragments().size());
+		assertEquals(2, umlInteraction.getLifelines().size());
+		assertEquals(0, umlInteraction.getLifelines().get(0).getCoveredBys().size());
+		assertEquals(0, umlInteraction.getLifelines().get(1).getCoveredBys().size());
+
+		/* assert diagram representation */
+		assertEquals(0, sequenceDiagram.getEdges().size());
 	}
 
 } // MMessageTest

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.papyrus.uml.interaction.model.tests;
 
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.DefaultLayoutHelperTest;
+import org.eclipse.papyrus.uml.interaction.model.tests.deletion.BasicDeletionTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -26,6 +27,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ //
 		DefaultLayoutHelperTest.class, //
+		BasicDeletionTest.class, //
 })
 public class SeqDCustomTests {
 

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/BasicDeletionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/BasicDeletionTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -14,7 +15,7 @@ import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
-import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommand;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.junit.Rule;
@@ -42,7 +43,7 @@ public class BasicDeletionTest {
 		/* make sure no duplicates */
 		Set<MElement<?>> exepcted = new LinkedHashSet<MElement<?>>(
 				Arrays.asList(expectedElementsToBeRemoved));
-		Set<EObject> elementsToRemove = remove.getElementsToRemove();
+		Collection<EObject> elementsToRemove = remove.getElementsToRemove();
 		assertEquals(exepcted.size(), elementsToRemove.size());
 		for (MElement<?> mElement : exepcted) {
 			assertTrue(elementsToRemove.contains(mElement.getElement()));
@@ -58,7 +59,7 @@ public class BasicDeletionTest {
 	public void message_notTriggeringExecution() {
 		/* act */
 		MMessage message = interaction().getMessages().get(1);
-		executeAndAssertRemoval(message.remove(), //
+		executeAndAssertRemoval((RemovalCommand)message.remove(), //
 				message, message.getSend().get(), message.getReceive().get());
 
 		/* assert: only message should be deleted with its ends */
@@ -79,7 +80,7 @@ public class BasicDeletionTest {
 		/* act */
 		MMessage message1 = interaction().getMessages().get(0);
 		MExecution execution2 = interaction().getLifelines().get(1).getExecutions().get(0);
-		executeAndAssertRemoval(message1.remove(), //
+		executeAndAssertRemoval((RemovalCommand)message1.remove(), //
 				message1, //
 				execution2, execution2.getStart().get(), execution2.getFinish().get());
 
@@ -105,7 +106,7 @@ public class BasicDeletionTest {
 		MExecution execution1 = interaction().getLifelines().get(0).getExecutions().get(0);
 		MMessage message1 = interaction().getMessages().get(0);
 		MExecution execution2 = interaction().getLifelines().get(1).getExecutions().get(0);
-		executeAndAssertRemoval(execution1.remove(), //
+		executeAndAssertRemoval((RemovalCommand)execution1.remove(), //
 				execution1, execution1.getStart().get(), execution1.getFinish().get(), //
 				message1, //
 				execution2, execution2.getStart().get(), execution2.getFinish().get());
@@ -131,7 +132,7 @@ public class BasicDeletionTest {
 		/* act */
 		MExecution execution2 = interaction().getLifelines().get(1).getExecutions().get(0);
 		MMessage message1 = interaction().getMessages().get(0);
-		executeAndAssertRemoval(execution2.remove(), //
+		executeAndAssertRemoval((RemovalCommand)execution2.remove(), //
 				execution2, execution2.getStart().get(), execution2.getFinish().get(), //
 				message1);
 
@@ -154,7 +155,7 @@ public class BasicDeletionTest {
 	public void execution_isolated() {
 		/* act */
 		MExecution execution3 = interaction().getLifelines().get(2).getExecutions().get(0);
-		executeAndAssertRemoval(execution3.remove(), //
+		executeAndAssertRemoval((RemovalCommand)execution3.remove(), //
 				execution3, execution3.getStart().get(), execution3.getFinish().get());
 
 		/*
@@ -181,7 +182,7 @@ public class BasicDeletionTest {
 		MMessage message1 = interaction().getMessages().get(0);
 		MMessage message2 = interaction().getMessages().get(1);
 
-		executeAndAssertRemoval(lifeline1.remove(), //
+		executeAndAssertRemoval((RemovalCommand)lifeline1.remove(), //
 				lifeline1, //
 				execution1, execution1.getStart().get(), execution1.getFinish().get(), //
 				execution2, execution2.getStart().get(), execution2.getFinish().get(), //
@@ -215,7 +216,7 @@ public class BasicDeletionTest {
 		MMessage message1 = interaction().getMessages().get(0);
 		MMessage message2 = interaction().getMessages().get(1);
 
-		executeAndAssertRemoval(lifeline2.remove(), //
+		executeAndAssertRemoval((RemovalCommand)lifeline2.remove(), //
 				lifeline2, //
 				execution2, execution2.getStart().get(), execution2.getFinish().get(), //
 				execution4, execution4.getStart().get(), execution4.getFinish().get(), //

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/BasicDeletionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/BasicDeletionTest.java
@@ -1,0 +1,237 @@
+package org.eclipse.papyrus.uml.interaction.model.tests.deletion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MMessage;
+import org.eclipse.papyrus.uml.interaction.model.RemovalCommand;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ModelResource({"DeletionTesting.uml", "DeletionTesting.notation" })
+public class BasicDeletionTest {
+
+	@Rule
+	public final ModelFixture.Edit model = new ModelFixture.Edit();
+
+	private MInteraction interaction;
+
+	private MInteraction interaction() {
+		if (interaction == null) {
+			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+		}
+		return interaction;
+	}
+
+	private void executeAndAssertRemoval(RemovalCommand remove, MElement<?>... expectedElementsToBeRemoved) {
+		if (!remove.canExecute()) {
+			fail("Command not executable"); //$NON-NLS-1$
+		}
+		/* make sure no duplicates */
+		Set<MElement<?>> exepcted = new LinkedHashSet<MElement<?>>(
+				Arrays.asList(expectedElementsToBeRemoved));
+		Set<EObject> elementsToRemove = remove.getElementsToRemove();
+		assertEquals(exepcted.size(), elementsToRemove.size());
+		for (MElement<?> mElement : exepcted) {
+			assertTrue(elementsToRemove.contains(mElement.getElement()));
+		}
+		remove.execute();
+
+		/* force reinit after change */
+		interaction = null;
+
+	}
+
+	@Test
+	public void message_notTriggeringExecution() {
+		/* act */
+		MMessage message = interaction().getMessages().get(1);
+		executeAndAssertRemoval(message.remove(), //
+				message, message.getSend().get(), message.getReceive().get());
+
+		/* assert: only message should be deleted with its ends */
+		assertEquals(1, interaction().getMessages().size());
+		assertEquals(3, interaction().getLifelines().size());
+		assertEquals(1, interaction().getLifelines().get(0).getExecutions().size());
+		assertEquals(2, interaction().getLifelines().get(1).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(2).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(0).getExecutionOccurrences().size());
+		assertEquals(3, interaction().getLifelines().get(1).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(2).getExecutionOccurrences().size());
+
+		// TODO executions 3 and 4 need to move up
+	}
+
+	@Test
+	public void message_triggeringExecution() {
+		/* act */
+		MMessage message1 = interaction().getMessages().get(0);
+		MExecution execution2 = interaction().getLifelines().get(1).getExecutions().get(0);
+		executeAndAssertRemoval(message1.remove(), //
+				message1, //
+				execution2, execution2.getStart().get(), execution2.getFinish().get());
+
+		/*
+		 * assert: message and execution on lifeline 2 should be deleted. the start of the execution on
+		 * lifeline 1 is no message end any more
+		 */
+		assertEquals(1, interaction().getMessages().size());
+		assertEquals(3, interaction().getLifelines().size());
+		assertEquals(1, interaction().getLifelines().get(0).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(1).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(2).getExecutions().size());
+		assertEquals(2, interaction().getLifelines().get(0).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(1).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(2).getExecutionOccurrences().size());
+
+		// TODO nothing should move, as execution 1 is as big as execution 2
+	}
+
+	@Test
+	public void execution_withMessageTriggeringOtherExecution() {
+		/* act */
+		MExecution execution1 = interaction().getLifelines().get(0).getExecutions().get(0);
+		MMessage message1 = interaction().getMessages().get(0);
+		MExecution execution2 = interaction().getLifelines().get(1).getExecutions().get(0);
+		executeAndAssertRemoval(execution1.remove(), //
+				execution1, execution1.getStart().get(), execution1.getFinish().get(), //
+				message1, //
+				execution2, execution2.getStart().get(), execution2.getFinish().get());
+
+		/*
+		 * assert: besides execution, a message, and the execution triggered by this message should get
+		 * deleted
+		 */
+		assertEquals(1, interaction().getMessages().size());
+		assertEquals(3, interaction().getLifelines().size());
+		assertEquals(0, interaction().getLifelines().get(0).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(1).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(2).getExecutions().size());
+		assertEquals(0, interaction().getLifelines().get(0).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(1).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(2).getExecutionOccurrences().size());
+
+		/* TODO remaining stuff should be moved up */
+	}
+
+	@Test
+	public void execution_triggeredByMessage() {
+		/* act */
+		MExecution execution2 = interaction().getLifelines().get(1).getExecutions().get(0);
+		MMessage message1 = interaction().getMessages().get(0);
+		executeAndAssertRemoval(execution2.remove(), //
+				execution2, execution2.getStart().get(), execution2.getFinish().get(), //
+				message1);
+
+		/*
+		 * assert
+		 */
+		assertEquals(1, interaction().getMessages().size());
+		assertEquals(3, interaction().getLifelines().size());
+		assertEquals(1, interaction().getLifelines().get(0).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(1).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(2).getExecutions().size());
+		assertEquals(2, interaction().getLifelines().get(0).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(1).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(2).getExecutionOccurrences().size());
+
+		/* TODO noting should be moved */
+	}
+
+	@Test
+	public void execution_isolated() {
+		/* act */
+		MExecution execution3 = interaction().getLifelines().get(2).getExecutions().get(0);
+		executeAndAssertRemoval(execution3.remove(), //
+				execution3, execution3.getStart().get(), execution3.getFinish().get());
+
+		/*
+		 * assert
+		 */
+		assertEquals(2, interaction().getMessages().size());
+		assertEquals(3, interaction().getLifelines().size());
+		assertEquals(1, interaction().getLifelines().get(0).getExecutions().size());
+		assertEquals(2, interaction().getLifelines().get(1).getExecutions().size());
+		assertEquals(0, interaction().getLifelines().get(2).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(0).getExecutionOccurrences().size());
+		assertEquals(3, interaction().getLifelines().get(1).getExecutionOccurrences().size());
+		assertEquals(0, interaction().getLifelines().get(2).getExecutionOccurrences().size());
+
+		/* TODO last execution should be moved up */
+	}
+
+	@Test
+	public void lifeline_executionTwoMessagesTriggeringOtherExecution() {
+		/* act */
+		MLifeline lifeline1 = interaction().getLifelines().get(0);
+		MExecution execution1 = interaction().getLifelines().get(0).getExecutions().get(0);
+		MExecution execution2 = interaction().getLifelines().get(1).getExecutions().get(0);
+		MMessage message1 = interaction().getMessages().get(0);
+		MMessage message2 = interaction().getMessages().get(1);
+
+		executeAndAssertRemoval(lifeline1.remove(), //
+				lifeline1, //
+				execution1, execution1.getStart().get(), execution1.getFinish().get(), //
+				execution2, execution2.getStart().get(), execution2.getFinish().get(), //
+				message1, //
+				message2, message2.getSend().get(), message2.getReceive().get()); // message2 is not linked to
+																					// an
+																					// execution, thats why
+																					// ends have to
+																					// be mentioned
+
+		/*
+		 * assert
+		 */
+		assertEquals(0, interaction().getMessages().size());
+		assertEquals(2, interaction().getLifelines().size());
+		assertEquals(1, interaction().getLifelines().get(0).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(1).getExecutions().size());
+		assertEquals(2, interaction().getLifelines().get(0).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(1).getExecutionOccurrences().size());
+
+		/* TODO move lifelines to left and move execution occurences up */
+	}
+
+	@Test
+	public void lifeline_twoMessagesTwoExecution() {
+		/* act */
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+
+		MExecution execution2 = interaction().getLifelines().get(1).getExecutions().get(0);
+		MExecution execution4 = interaction().getLifelines().get(1).getExecutions().get(1);
+		MMessage message1 = interaction().getMessages().get(0);
+		MMessage message2 = interaction().getMessages().get(1);
+
+		executeAndAssertRemoval(lifeline2.remove(), //
+				lifeline2, //
+				execution2, execution2.getStart().get(), execution2.getFinish().get(), //
+				execution4, execution4.getStart().get(), execution4.getFinish().get(), //
+				message1, //
+				message2, message2.getSend().get(), message2.getReceive().get());
+
+		/*
+		 * assert
+		 */
+		assertEquals(0, interaction().getMessages().size());
+		assertEquals(2, interaction().getLifelines().size());
+		assertEquals(1, interaction().getLifelines().get(0).getExecutions().size());
+		assertEquals(1, interaction().getLifelines().get(1).getExecutions().size());
+		assertEquals(2, interaction().getLifelines().get(0).getExecutionOccurrences().size());
+		assertEquals(2, interaction().getLifelines().get(1).getExecutionOccurrences().size());
+
+		/* TODO move lifelines to left and move execution occurences up */
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeletionTesting.di
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeletionTesting.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeletionTesting.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeletionTesting.notation
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_oNU9AGKCEeiIbNyTKulhvg" type="LightweightSequenceDiagram" name="Lightweight Sequence Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_oNU9AWKCEeiIbNyTKulhvg" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_oNU9AmKCEeiIbNyTKulhvg" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_oNU9A2KCEeiIbNyTKulhvg" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_9sGg0GKEEeiIbNyTKulhvg" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_9sGg0WKEEeiIbNyTKulhvg" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_9sGg0mKEEeiIbNyTKulhvg" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_9sGg02KEEeiIbNyTKulhvg" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_FMjagGKFEeiIbNyTKulhvg" type="Shape_Execution_Specification">
+            <element xmi:type="uml:BehaviorExecutionSpecification" href="DeletionTesting.uml#_FMhlUGKFEeiIbNyTKulhvg"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FMjagWKFEeiIbNyTKulhvg" x="-4" y="10" width="10" height="100"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_9sGg1GKEEeiIbNyTKulhvg" width="2" height="300"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="DeletionTesting.uml#_9sFSsGKEEeiIbNyTKulhvg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9sGg1WKEEeiIbNyTKulhvg" x="47" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_csgd0GKFEeiIbNyTKulhvg" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_csgd0WKFEeiIbNyTKulhvg" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_csgd0mKFEeiIbNyTKulhvg" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_csgd02KFEeiIbNyTKulhvg" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_F3xsUGKGEeiIbNyTKulhvg" type="Shape_Execution_Specification">
+            <element xmi:type="uml:BehaviorExecutionSpecification" href="DeletionTesting.uml#_F3vQEGKGEeiIbNyTKulhvg"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F3xsUWKGEeiIbNyTKulhvg" x="-4" y="10" width="10" height="100"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_X8yHcGMWEei-baqYVSEfiQ" type="Shape_Execution_Specification">
+            <element xmi:type="uml:BehaviorExecutionSpecification" href="DeletionTesting.uml#_X8w5UGMWEei-baqYVSEfiQ"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X8yHcWMWEei-baqYVSEfiQ" x="-4" y="225" width="10" height="40"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_csgd1GKFEeiIbNyTKulhvg" width="2" height="300"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="DeletionTesting.uml#_csfPsGKFEeiIbNyTKulhvg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_csgd1WKFEeiIbNyTKulhvg" x="317" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_OLNfsGMWEei-baqYVSEfiQ" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_OLNfsWMWEei-baqYVSEfiQ" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_OLNfsmMWEei-baqYVSEfiQ" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_OLNfs2MWEei-baqYVSEfiQ" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_WlinsGMWEei-baqYVSEfiQ" type="Shape_Execution_Specification">
+            <element xmi:type="uml:BehaviorExecutionSpecification" href="DeletionTesting.uml#_WleWQGMWEei-baqYVSEfiQ"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WlinsWMWEei-baqYVSEfiQ" x="-4" y="175" width="10" height="40"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_OLNftGMWEei-baqYVSEfiQ" width="2" height="300"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="DeletionTesting.uml#_OLMRkGMWEei-baqYVSEfiQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OLNftWMWEei-baqYVSEfiQ" x="530" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oNU9BGKCEeiIbNyTKulhvg" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_oNU9BWKCEeiIbNyTKulhvg" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_oNU9BmKCEeiIbNyTKulhvg"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_oNU9B2KCEeiIbNyTKulhvg" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="DeletionTesting.uml#_oM9woGKCEeiIbNyTKulhvg"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="DeletionTesting.uml#_oM9woGKCEeiIbNyTKulhvg"/>
+  <edges xmi:type="notation:Connector" xmi:id="_JUg94GMTEei-baqYVSEfiQ" type="Edge_Message" source="_9sGg02KEEeiIbNyTKulhvg" target="_csgd02KFEeiIbNyTKulhvg">
+    <element xmi:type="uml:Message" href="DeletionTesting.uml#_JUgW0mMTEei-baqYVSEfiQ"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JUg94WMTEei-baqYVSEfiQ"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUg94mMTEei-baqYVSEfiQ" id="10"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUg942MTEei-baqYVSEfiQ" id="10"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_M2nxsGMeEei-baqYVSEfiQ" type="Edge_Message" source="_9sGg02KEEeiIbNyTKulhvg" target="_csgd02KFEeiIbNyTKulhvg">
+    <element xmi:type="uml:Message" href="DeletionTesting.uml#_M2nKomMeEei-baqYVSEfiQ"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_M2nxsWMeEei-baqYVSEfiQ"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M2nxsmMeEei-baqYVSEfiQ" id="140"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_M2nxs2MeEei-baqYVSEfiQ" id="140"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeletionTesting.uml
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeletionTesting.uml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_oL-5MGKCEeiIbNyTKulhvg" name="DeletionTesting">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_oTJRIGKCEeiIbNyTKulhvg">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_oM9woGKCEeiIbNyTKulhvg" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_9sFSsGKEEeiIbNyTKulhvg" name="Lifeline1" coveredBy="_JUgW0GMTEei-baqYVSEfiQ _FMhlUGKFEeiIbNyTKulhvg _FMizcGKFEeiIbNyTKulhvg _M2nKoGMeEei-baqYVSEfiQ"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_csfPsGKFEeiIbNyTKulhvg" name="Lifeline2" coveredBy="_JUgW0WMTEei-baqYVSEfiQ _F3vQEGKGEeiIbNyTKulhvg _F3weMWKGEeiIbNyTKulhvg _X8w5UWMWEei-baqYVSEfiQ _X8w5UGMWEei-baqYVSEfiQ _X8xgYGMWEei-baqYVSEfiQ _M2nKoWMeEei-baqYVSEfiQ"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_OLMRkGMWEei-baqYVSEfiQ" name="Lifeline3" coveredBy="_WlgLcGMWEei-baqYVSEfiQ _WleWQGMWEei-baqYVSEfiQ _WlgygGMWEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_JUgW0GMTEei-baqYVSEfiQ" covered="_9sFSsGKEEeiIbNyTKulhvg" message="_JUgW0mMTEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_FMhlUGKFEeiIbNyTKulhvg" name="Execution1" covered="_9sFSsGKEEeiIbNyTKulhvg" finish="_FMizcGKFEeiIbNyTKulhvg" start="_JUgW0GMTEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_FMizcGKFEeiIbNyTKulhvg" covered="_9sFSsGKEEeiIbNyTKulhvg" execution="_FMhlUGKFEeiIbNyTKulhvg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_JUgW0WMTEei-baqYVSEfiQ" covered="_csfPsGKFEeiIbNyTKulhvg" message="_JUgW0mMTEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_F3vQEGKGEeiIbNyTKulhvg" name="Execution2" covered="_csfPsGKFEeiIbNyTKulhvg" finish="_F3weMWKGEeiIbNyTKulhvg" start="_JUgW0WMTEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_F3weMWKGEeiIbNyTKulhvg" covered="_csfPsGKFEeiIbNyTKulhvg" execution="_F3vQEGKGEeiIbNyTKulhvg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_M2nKoGMeEei-baqYVSEfiQ" covered="_9sFSsGKEEeiIbNyTKulhvg" message="_M2nKomMeEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_M2nKoWMeEei-baqYVSEfiQ" covered="_csfPsGKFEeiIbNyTKulhvg" message="_M2nKomMeEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_X8w5UWMWEei-baqYVSEfiQ" covered="_csfPsGKFEeiIbNyTKulhvg" execution="_X8w5UGMWEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_X8w5UGMWEei-baqYVSEfiQ" name="Execution4" covered="_csfPsGKFEeiIbNyTKulhvg" finish="_X8xgYGMWEei-baqYVSEfiQ" start="_X8w5UWMWEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_X8xgYGMWEei-baqYVSEfiQ" covered="_csfPsGKFEeiIbNyTKulhvg" execution="_X8w5UGMWEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_WlgLcGMWEei-baqYVSEfiQ" covered="_OLMRkGMWEei-baqYVSEfiQ" execution="_WleWQGMWEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_WleWQGMWEei-baqYVSEfiQ" name="Execution3" covered="_OLMRkGMWEei-baqYVSEfiQ" finish="_WlgygGMWEei-baqYVSEfiQ" start="_WlgLcGMWEei-baqYVSEfiQ"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_WlgygGMWEei-baqYVSEfiQ" covered="_OLMRkGMWEei-baqYVSEfiQ" execution="_WleWQGMWEei-baqYVSEfiQ"/>
+    <message xmi:type="uml:Message" xmi:id="_JUgW0mMTEei-baqYVSEfiQ" messageSort="asynchCall" receiveEvent="_JUgW0WMTEei-baqYVSEfiQ" sendEvent="_JUgW0GMTEei-baqYVSEfiQ"/>
+    <message xmi:type="uml:Message" xmi:id="_M2nKomMeEei-baqYVSEfiQ" messageSort="asynchCall" receiveEvent="_M2nKoWMeEei-baqYVSEfiQ" sendEvent="_M2nKoGMeEei-baqYVSEfiQ"/>
+  </packagedElement>
+</uml:Model>


### PR DESCRIPTION
Implement Logical Element deletion for Message, ExecutionSpecification, and Lifeline #33, #53, #54, #55, #56, #57, #63

* Add remove method to MElement
* Implement RemoveMessageCommand
* Implement RemoveExecutionCommand which uses existing RemoveMessageCommands before deleting the execution
* Implement RemoveLifelineCommand which uses existing RemoveExecutionCommands before deleting the execution
* Handle implicit Execution Specification Deletion of Message Deletion via delegation
* Allow to create CompoundModelCommand with list of Commands
* Introducde DeferredDeleteCommand
* Add basic tests