### PR TITLE
Issue #295: Logical Model View Link Selection

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model.edit/plugin.properties
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.edit/plugin.properties
@@ -38,6 +38,7 @@ _UI_MElement_element_feature = Element
 _UI_MElement_top_feature = Top
 _UI_MElement_bottom_feature = Bottom
 _UI_MElement_name_feature = Name
+_UI_MElement_diagramView_feature = Diagram View
 _UI_MInteraction_lifelines_feature = Lifelines
 _UI_MInteraction_messages_feature = Messages
 _UI_MLifeline_executionOccurrences_feature = Execution Occurrences

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.edit/src-gen/org/eclipse/papyrus/uml/interaction/model/provider/MElementItemProvider.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.edit/src-gen/org/eclipse/papyrus/uml/interaction/model/provider/MElementItemProvider.java
@@ -1,23 +1,27 @@
 /**
  * Copyright (c) 2018 Christian W. Damus and others.
- *  
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Christian W. Damus - Initial API and implementation
- * 
+ *
  */
 package org.eclipse.papyrus.uml.interaction.model.provider;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.ResourceLocator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.emf.edit.provider.IItemLabelProvider;
@@ -28,6 +32,7 @@ import org.eclipse.emf.edit.provider.ITreeItemContentProvider;
 import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ItemProviderAdapter;
 import org.eclipse.emf.edit.provider.ViewerNotification;
+import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 
@@ -35,7 +40,7 @@ import org.eclipse.papyrus.uml.interaction.model.MElement;
  * This is the item provider adapter for a
  * {@link org.eclipse.papyrus.uml.interaction.model.MElement} object. <!--
  * begin-user-doc --> <!-- end-user-doc -->
- * 
+ *
  * @generated
  */
 public class MElementItemProvider extends ItemProviderAdapter implements IEditingDomainItemProvider,
@@ -43,7 +48,7 @@ public class MElementItemProvider extends ItemProviderAdapter implements IEditin
 	/**
 	 * This constructs an instance from a factory and a notifier. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated
 	 */
 	public MElementItemProvider(AdapterFactory adapterFactory) {
@@ -53,7 +58,7 @@ public class MElementItemProvider extends ItemProviderAdapter implements IEditin
 	/**
 	 * This returns the property descriptors for the adapted class. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated
 	 */
 	@Override
@@ -73,7 +78,7 @@ public class MElementItemProvider extends ItemProviderAdapter implements IEditin
 	/**
 	 * This adds a property descriptor for the Interaction feature. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated
 	 */
 	protected void addInteractionPropertyDescriptor(Object object) {
@@ -150,6 +155,38 @@ public class MElementItemProvider extends ItemProviderAdapter implements IEditin
 	}
 
 	/**
+	 * This specifies how to implement {@link #getChildren} and is used to deduce an
+	 * appropriate feature for an {@link org.eclipse.emf.edit.command.AddCommand},
+	 * {@link org.eclipse.emf.edit.command.RemoveCommand} or
+	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
+		if (childrenFeatures == null) {
+			super.getChildrenFeatures(object);
+			childrenFeatures.add(SequenceDiagramPackage.Literals.MELEMENT__ELEMENT);
+		}
+		return childrenFeatures;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	protected EStructuralFeature getChildFeature(Object object, Object child) {
+		// Check the type of the specified child object and return the proper feature to
+		// use for
+		// adding (see {@link AddCommand}) it as a child.
+
+		return super.getChildFeature(object, child);
+	}
+
+	/**
 	 * This returns the label text for the adapted class. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * 
@@ -196,10 +233,24 @@ public class MElementItemProvider extends ItemProviderAdapter implements IEditin
 		super.collectNewChildDescriptors(newChildDescriptors, object);
 	}
 
+	@Override
+	public Collection<?> getChildren(Object object) {
+		@SuppressWarnings("unchecked")
+		Collection<Object> result = (Collection<Object>) super.getChildren(object);
+
+		// Don't show the diagram, which will repeat the views of everything else
+		MElement<?> element = (MElement<?>) object;
+		Predicate<EObject> isDiagram = Diagram.class::isInstance;
+		Optional<? extends EObject> view = element.getDiagramView().filter(isDiagram.negate());
+		view.ifPresent(result::add);
+
+		return result;
+	}
+
 	/**
 	 * Return the resource locator for this item provider's resources. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
-	 * 
+	 *
 	 * @generated
 	 */
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/LogicalModelPage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/LogicalModelPage.java
@@ -13,11 +13,17 @@
 package org.eclipse.papyrus.uml.interaction.model.internal.view;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.ui.viewer.IViewerProvider;
 import org.eclipse.emf.common.util.EList;
@@ -32,37 +38,36 @@ import org.eclipse.emf.edit.ui.celleditor.AdapterFactoryTreeEditor;
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryContentProvider;
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
 import org.eclipse.emf.edit.ui.view.ExtendedPropertySheetPage;
-import org.eclipse.emf.transaction.ResourceSetChangeEvent;
-import org.eclipse.emf.transaction.ResourceSetListener;
-import org.eclipse.emf.transaction.ResourceSetListenerImpl;
-import org.eclipse.emf.transaction.RunnableWithResult;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
-import org.eclipse.emf.transaction.util.TransactionUtil;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.parts.IDiagramGraphicalViewer;
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.papyrus.infra.core.utils.JobBasedFuture;
 import org.eclipse.papyrus.infra.core.utils.TransactionHelper;
+import org.eclipse.papyrus.infra.gmfdiag.common.utils.DiagramEditPartsUtil;
 import org.eclipse.papyrus.uml.diagram.common.part.UmlGmfDiagramEditor;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.util.LogicalModelAdapter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.ui.part.IPageBookViewPage;
 import org.eclipse.ui.part.Page;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
 import org.eclipse.ui.views.properties.PropertySheetPage;
-
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
+import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.Interaction;
 
 /**
  * A page in the {@link LogicalModelView}, which presents the logical model of a
@@ -76,11 +81,18 @@ public class LogicalModelPage extends Page implements IPageBookViewPage, IEditin
 	private final TransactionalEditingDomain editingDomain;
 	private final AdapterFactory adapterFactory;
 	private final Diagram sequenceDiagram;
-	private final ResourceSetListener modelListener;
+	private final IDiagramGraphicalViewer diagramViewer;
+
+	private final LogicalModelAdapter<MInteraction> logicalModelAdapter;
+	private final ISelectionChangedListener diagramSelectionListener = this::diagramSelectionChanged;
+	private final ISelectionChangedListener modelSelectionListener = this::modelSelectionChanged;
 
 	private PropertySheetPage propertySheetPage;
 
 	private TreeViewer selectionViewer;
+
+	private boolean selectionLock; // lock out selection updates to prevent feedback
+	private final AtomicReference<Job> interactionComputation = new AtomicReference<>();
 
 	/**
 	 * Initializes me.
@@ -92,8 +104,10 @@ public class LogicalModelPage extends Page implements IPageBookViewPage, IEditin
 		editingDomain = editor.getEditingDomain();
 		adapterFactory = ((AdapterFactoryEditingDomain) editingDomain).getAdapterFactory();
 		sequenceDiagram = editor.getDiagram();
-		modelListener = new ModelListener();
-		editingDomain.addResourceSetListener(modelListener);
+		diagramViewer = editor.getDiagramGraphicalViewer();
+		diagramViewer.addSelectionChangedListener(diagramSelectionListener);
+		logicalModelAdapter = new LogicalModelAdapter<>((Interaction) sequenceDiagram.getElement(),
+				MInteraction.class);
 	}
 
 	@Override
@@ -114,18 +128,23 @@ public class LogicalModelPage extends Page implements IPageBookViewPage, IEditin
 				return contents;
 			}
 		};
+		logicalModelAdapter.onLogicalModelCreated(model -> setInput(resource, model));
+		logicalModelAdapter.onLogicalModelDisposed(__ -> setInput());
+
 		selectionViewer.setInput(resource);
 		setInput();
 
 		new AdapterFactoryTreeEditor(selectionViewer.getTree(), adapterFactory);
 
 		getSite().setSelectionProvider(selectionViewer);
+		selectionViewer.addSelectionChangedListener(modelSelectionListener);
 	}
 
 	@Override
 	public void dispose() {
 		try {
-			editingDomain.removeResourceSetListener(modelListener);
+			selectionViewer.removeSelectionChangedListener(modelSelectionListener);
+			diagramViewer.removeSelectionChangedListener(diagramSelectionListener);
 
 			if (propertySheetPage != null) {
 				propertySheetPage.dispose();
@@ -135,69 +154,51 @@ public class LogicalModelPage extends Page implements IPageBookViewPage, IEditin
 		}
 	}
 
-	private ListenableFuture<MInteraction> computeInteraction() {
-		if (TransactionHelper.isDisposed(editingDomain)) {
-			return Futures.immediateCancelledFuture();
-		}
+	private void setInput() {
+		Job computation = new Job("Computing logical model") {
+			{
+				setSystem(true);
+			}
 
-		JobBasedFuture<MInteraction> result = new JobBasedFuture<MInteraction>("Computing logical model") {
 			@Override
-			protected MInteraction compute(IProgressMonitor monitor) throws Exception {
-				if (TransactionHelper.isDisposed(editingDomain)) {
-					cancel(true);
-					return null;
+			protected IStatus run(IProgressMonitor monitor) {
+				if (!TransactionHelper.isDisposed(editingDomain)
+						&& interactionComputation.compareAndSet(this, null)) {
+					// I'm the last one standing. Compute the logical model. The adapter
+					// will be notified if it's actually computed anew, to update the UI
+					try {
+						editingDomain.runExclusive(() -> MInteraction.getInstance(sequenceDiagram));
+					} catch (InterruptedException e) {
+						return Status.CANCEL_STATUS;
+					}
+					return Status.OK_STATUS;
+				} else {
+					return Status.CANCEL_STATUS;
 				}
-
-				return TransactionUtil.runExclusive(editingDomain,
-						new RunnableWithResult.Impl<MInteraction>() {
-							@Override
-							public void run() {
-								setResult(MInteraction.getInstance(sequenceDiagram));
-							}
-						});
 			}
 		};
-		result.schedule();
-		return result;
+		interactionComputation.set(computation);
+		computation.schedule();
 	}
 
-	private void setInput() {
-		ListenableFuture<MInteraction> interaction = computeInteraction();
-		Futures.addCallback(interaction, new FutureCallback<MInteraction>() {
-			@Override
-			public void onSuccess(MInteraction result) {
-				Resource resource = (Resource) selectionViewer.getInput();
-				resource.getContents().clear();
-
-				if (result == null) {
-					// Cancelled, but not calling onFailure(...). Okay
-					return;
-				}
-
-				resource.getContents().add((EObject) result);
-
-				if (!selectionViewer.getControl().isDisposed()) {
-					// Preserve selection
-					MElement<?> selected = getSelectedElement();
-					if (selected != null) {
-						// Get the one in the new interaction
-						selected = result.getElement(selected.getElement()).orElse(null);
-					}
-					if (selected == null) {
-						selected = result;
-					}
+	private void setInput(Resource input, MInteraction model) {
+		Control control = selectionViewer.getControl();
+		if (!control.isDisposed()) {
+			control.getDisplay().asyncExec(() -> {
+				if (!control.isDisposed()) {
+					Resource resource = (Resource) selectionViewer.getInput();
+					resource.getContents().clear();
+					resource.getContents().add((EObject) model);
 
 					selectionViewer.refresh();
-					selectionViewer.setSelection(new StructuredSelection(selected), true);
 					selectionViewer.expandToLevel(2);
-				}
-			}
 
-			@Override
-			public void onFailure(Throwable t) {
-				// TODO
-			}
-		}, getSite().getShell().getDisplay()::asyncExec);
+					// Push selection from diagram
+					diagramSelectionChanged(
+							new SelectionChangedEvent(diagramViewer, diagramViewer.getSelection()));
+				}
+			});
+		}
 	}
 
 	MElement<?> getSelectedElement() {
@@ -266,9 +267,13 @@ public class LogicalModelPage extends Page implements IPageBookViewPage, IEditin
 	}
 
 	protected void setSelectionToViewer(Collection<?> collection) {
-		if ((collection != null) && !collection.isEmpty()) {
-			getSite().getShell().getDisplay()
-					.asyncExec(() -> setSelection(new StructuredSelection(collection.toArray())));
+		if (collection != null) {
+			Display display = getSite().getShell().getDisplay();
+			if (display != Display.getCurrent()) {
+				display.asyncExec(() -> setSelection(new StructuredSelection(collection.toArray())));
+			} else {
+				setSelection(new StructuredSelection(collection.toArray()));
+			}
 		}
 	}
 
@@ -288,20 +293,54 @@ public class LogicalModelPage extends Page implements IPageBookViewPage, IEditin
 		return propertySheetPage;
 	}
 
-	//
-	// Nested types
-	//
+	private void diagramSelectionChanged(SelectionChangedEvent event) {
+		withSelectionLock(() -> {
+			// Get the selected edit part
+			Optional<IGraphicalEditPart> editPart = Optional
+					.ofNullable(event.getStructuredSelection().getFirstElement())
+					.filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast);
 
-	private class ModelListener extends ResourceSetListenerImpl {
+			// And the current logical model
+			Optional<MInteraction> model = ((Resource) selectionViewer.getInput()).getContents().stream()
+					.filter(MInteraction.class::isInstance).map(MInteraction.class::cast).findAny();
 
-		@Override
-		public boolean isPostcommitOnly() {
-			return true;
+			// Find the logical model element
+			Optional<Element> semantic = editPart.map(IGraphicalEditPart::resolveSemanticElement)
+					.filter(Element.class::isInstance).map(Element.class::cast);
+			Optional<MElement<?>> element = model
+					.<MElement<?>>flatMap(m -> semantic.flatMap(m::getElement));
+
+			setSelectionToViewer(element.map(Collections::singleton).orElse(Collections.emptySet()));
+		});
+	}
+
+	private void modelSelectionChanged(SelectionChangedEvent event) {
+		withSelectionLock(() -> {
+			// Get the selected model element
+			Optional<MElement<?>> element = Optional
+					.ofNullable((MElement<?>) event.getStructuredSelection().getFirstElement());
+			Optional<Element> uml = element.map(MElement::getElement);
+
+			// Find the edit part
+			ISelection selection = uml.map(StructuredSelection::new).orElse(StructuredSelection.EMPTY);
+			Optional<EditPart> editPart = DiagramEditPartsUtil
+					.getEditPartsFromSelection(selection, diagramViewer).stream().findFirst();
+
+			editPart.ifPresent(diagramViewer::select);
+		});
+	}
+
+	private void withSelectionLock(Runnable action) {
+		if (selectionLock) {
+			return;
 		}
 
-		@Override
-		public void resourceSetChanged(ResourceSetChangeEvent event) {
-			setInput();
+		selectionLock = true;
+		try {
+			action.run();
+		} finally {
+			selectionLock = false;
 		}
 	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/META-INF/MANIFEST.MF
@@ -19,10 +19,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Description: This plugin is in charge of the specific values that should be used for the sequence notation elements defined in the sequence diagram notation plugin.
 Bundle-ActivationPolicy: lazy
-Export-Package: org.eclipse.papyrus.uml.interaction.internal.model;x-internal:=true,
+Export-Package: org.eclipse.papyrus.uml.interaction.internal.model;x-friends:="org.eclipse.papyrus.uml.interaction.model.edit",
  org.eclipse.papyrus.uml.interaction.internal.model.commands;x-internal:=true,
- org.eclipse.papyrus.uml.interaction.internal.model.impl;
-  x-friends:="org.eclipse.papyrus.uml.diagram.sequence.runtime",
+ org.eclipse.papyrus.uml.interaction.internal.model.impl;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.runtime",
  org.eclipse.papyrus.uml.interaction.internal.model.spi.impl;x-internal:=true,
  org.eclipse.papyrus.uml.interaction.model,
  org.eclipse.papyrus.uml.interaction.model.spi,

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
@@ -27,7 +27,8 @@
     <genClasses image="false" ecoreClass="seqd.ecore#//MElement">
       <genTypeParameters ecoreTypeParameter="seqd.ecore#//MElement/T"/>
       <genFeatures property="Readonly" notify="false" createChild="false" ecoreFeature="ecore:EReference seqd.ecore#//MElement/interaction"/>
-      <genFeatures property="Readonly" notify="false" createChild="false" ecoreFeature="ecore:EReference seqd.ecore#//MElement/element"/>
+      <genFeatures property="Readonly" notify="false" children="true" createChild="false"
+          ecoreFeature="ecore:EReference seqd.ecore#//MElement/element"/>
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute seqd.ecore#//MElement/top"/>
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute seqd.ecore#//MElement/bottom"/>
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute seqd.ecore#//MElement/name"/>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/impl/InteractionModelBuilder.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/impl/InteractionModelBuilder.java
@@ -76,18 +76,17 @@ public class InteractionModelBuilder {
 	public MInteraction build() {
 		// The initial vertex is the interaction
 		Interaction interaction = (Interaction)graph.initial().getInteractionElement();
-		Diagram diagram = (Diagram)graph.initial().getDiagramView();
 
-		MInteractionImpl result = new MInteractionImpl(interaction).withGraph(graph);
-		result.dispose();
+		MInteractionImpl result = new MInteractionImpl().withGraph(graph);
+		build(result, interaction);
 
-		build(result);
+		// Now make the association for LogicalModelAdapters to discover it
+		result.setElement(interaction);
+
 		return result;
 	}
 
-	void build(MInteractionImpl interaction) {
-		Interaction uml = interaction.getElement();
-
+	void build(MInteractionImpl interaction, Interaction uml) {
 		uml.getLifelines().forEach(lifelineBuilder(interaction));
 		uml.getMessages().forEach(messageBuilder(interaction));
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/LogicalModelAdapter.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/LogicalModelAdapter.java
@@ -1,0 +1,168 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model.util;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.emf.common.notify.Notifier;
+import org.eclipse.emf.common.notify.impl.BasicNotifierImpl.EObservableAdapterList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MObject;
+import org.eclipse.uml2.uml.Element;
+
+/**
+ * An adapter on the UML model that notifies of changes to the <em>Logical Model</em> representation of it.
+ *
+ * @param <T>
+ *            the <em>Logical Model</em> type to be notified of
+ * @author Christian W. Damus
+ */
+public class LogicalModelAdapter<T extends MElement<?>> {
+
+	private Element target;
+
+	private EObservableAdapterList.Listener listener;
+
+	private AtomicReference<Consumer<T>> oldModelHandler = new AtomicReference<>(this::pass);
+
+	private AtomicReference<Consumer<T>> newModelHandler = new AtomicReference<>(this::pass);
+
+	private final Class<? extends T> modelType;
+
+	/**
+	 * Initializes me.
+	 * 
+	 * @param element
+	 *            the interaction element on which I listen for <em>Logical Model</em> changes
+	 * @param modelType
+	 *            the <em>Logical Model</em> type to be notified of
+	 */
+	public LogicalModelAdapter(Element element, Class<? extends T> modelType) {
+		super();
+
+		target = element;
+		this.modelType = modelType;
+		listener = new AdapterHandler();
+		EObservableAdapterList adapters = (EObservableAdapterList)target.eAdapters();
+		adapters.addListener(listener);
+	}
+
+	/**
+	 * Stop listening and clean up. A disposed adapter will not notify any listeners.
+	 */
+	public void dispose() {
+		if (target != null) {
+			EObservableAdapterList adapters = (EObservableAdapterList)target.eAdapters();
+			adapters.removeListener(listener);
+
+			target = null;
+			listener = null;
+
+			oldModelHandler.set(this::pass);
+			newModelHandler.set(this::pass);
+		}
+	}
+
+	/**
+	 * Queries whether I am {@linkplain #dispose() disposed}.
+	 * 
+	 * @return whether I am disposed
+	 * @see #dispose()
+	 */
+	public boolean isDisposed() {
+		return target == null;
+	}
+
+	/**
+	 * Obtains the UML interaction element that I adapt.
+	 * 
+	 * @return the UML interaction element, or {@code null} if I am {@linkplain #dispose() disposed}
+	 * @see #dispose()
+	 */
+	public Element getInteraction() {
+		return target;
+	}
+
+	/**
+	 * Add a handler to be called whenever the logical model is discarded.
+	 * 
+	 * @param oldLogicalModelHandler
+	 *            an action to apply to the logical model that was disposed
+	 */
+	public void onLogicalModelDisposed(Consumer<? super T> oldLogicalModelHandler) {
+		if (!isDisposed()) {
+			this.oldModelHandler.accumulateAndGet(safeHandler(oldLogicalModelHandler), Consumer::andThen);
+		}
+	}
+
+	/**
+	 * Add a handler to be called whenever the logical model is created. If at the time of this call a logical
+	 * model exists for my UML interaction, then the handler is invoked immediately.
+	 * 
+	 * @param newLogicalModelHandler
+	 *            an action to apply to the logical model that was created for my UML interaction
+	 */
+	public void onLogicalModelCreated(Consumer<? super T> newLogicalModelHandler) {
+		if (!isDisposed()) {
+			Consumer<T> newHandler = safeHandler(newLogicalModelHandler);
+			this.newModelHandler.accumulateAndGet(newHandler, Consumer::andThen);
+
+			getExistingLogicalModel().ifPresent(newHandler::accept);
+		}
+	}
+
+	private void pass(@SuppressWarnings("unused") T __) {
+		// Pass
+	}
+
+	private Consumer<T> safeHandler(Consumer<? super T> handler) {
+		return logicalModel -> {
+			try {
+				handler.accept(logicalModel);
+			} catch (Exception e) {
+				LogicalModelPlugin.INSTANCE.log(e);
+			}
+		};
+	}
+
+	private Optional<T> getExistingLogicalModel() {
+		return Optional.ofNullable(target)
+				.map(notifier -> EcoreUtil.getExistingAdapter(notifier, MObject.class))
+				.filter(modelType::isInstance).map(modelType::cast);
+	}
+
+	//
+	// Nested types
+	//
+
+	private final class AdapterHandler implements EObservableAdapterList.Listener {
+		@Override
+		public void added(Notifier notifier, Adapter adapter) {
+			if (notifier == target && modelType.isInstance(adapter)) {
+				newModelHandler.get().accept(modelType.cast(adapter));
+			}
+		}
+
+		@Override
+		public void removed(Notifier notifier, Adapter adapter) {
+			if (notifier == target && modelType.isInstance(adapter)) {
+				oldModelHandler.get().accept(modelType.cast(adapter));
+			}
+		}
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/SeqdAllTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/SeqdAllTests.java
@@ -12,12 +12,14 @@
  */
 package org.eclipse.papyrus.uml.interaction.model.tests;
 
+import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import junit.textui.TestRunner;
 
 /**
- * <!-- begin-user-doc --> A test suite for the '<em><b>Seqd</b></em>' model. <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A test suite for the '<em><b>Seqd</b></em>' model.
+ * <!-- end-user-doc -->
  * 
  * @generated
  */
@@ -37,9 +39,15 @@ public class SeqdAllTests extends TestSuite {
 	 * 
 	 * @generated
 	 */
-	public static Test suite() {
+	public static Test suiteGen() {
 		TestSuite suite = new SeqdAllTests("Seqd Tests"); //$NON-NLS-1$
 		suite.addTest(SequenceDiagramTests.suite());
+		return suite;
+	}
+
+	public static Test suite() {
+		TestSuite suite = (TestSuite) suiteGen();
+		suite.addTest(new JUnit4TestAdapter(SeqDCustomTests.class));
 		return suite;
 	}
 

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/LogicalModelAdapterTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/LogicalModelAdapterTest.java
@@ -1,0 +1,111 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.util.LogicalModelAdapter;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link LogicalModelAdapter} class.
+ *
+ * @author Christian W. Damus
+ */
+@ModelResource("lifelines_layout.uml")
+public class LogicalModelAdapterTest {
+
+	@Rule
+	public final ModelFixture.Edit model = new ModelFixture.Edit();
+
+	private LogicalModelAdapter<MInteraction> adapter;
+
+	/**
+	 * Initializes me.
+	 *
+	 */
+	public LogicalModelAdapterTest() {
+		super();
+	}
+
+	/**
+	 * Test that the adapter notifies creation of an already existing logical model
+	 * when the handler is added.
+	 */
+	@Test
+	public void onLogicalModelCreated_immediate() {
+		MInteraction interaction = MInteraction.getInstance(model.getInteraction());
+		AtomicReference<MInteraction> ref = new AtomicReference<>();
+
+		adapter.onLogicalModelCreated(ref::set);
+
+		assertThat("Handler not notified", ref.get(), is(interaction));
+	}
+
+	/**
+	 * Test that the adapter notifies creation of a new logical model when it is
+	 * created when the handler is added.
+	 */
+	@Test
+	public void onLogicalModelCreated_new() {
+		AtomicReference<MInteraction> ref = new AtomicReference<>();
+
+		adapter.onLogicalModelCreated(ref::set);
+		assumeThat("Logical model already existed", ref.get(), nullValue());
+
+		MInteraction interaction = MInteraction.getInstance(model.getInteraction());
+		assertThat("Handler not notified", ref.get(), is(interaction));
+	}
+
+	/**
+	 * Test that the adapter notifies disposal of a logical model.
+	 */
+	@Test
+	public void onLogicalModelDisposed() {
+		MInteraction interaction = MInteraction.getInstance(model.getInteraction());
+		AtomicReference<MInteraction> ref = new AtomicReference<>();
+
+		adapter.onLogicalModelDisposed(ref::set);
+
+		// This triggers disposal of the logical model
+		interaction.getElement().setName("NewName");
+
+		assertThat("Handler not notified", ref.get(), is(interaction));
+	}
+
+	//
+	// Test framework
+	//
+
+	@Before
+	public void createSUT() {
+		adapter = new LogicalModelAdapter<>(model.getInteraction(), MInteraction.class);
+	}
+
+	@After
+	public void destroySUT() {
+		adapter = null;
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.papyrus.uml.interaction.model.tests;
 
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.DefaultLayoutHelperTest;
+import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.LogicalModelAdapterTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -26,6 +27,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ //
 		DefaultLayoutHelperTest.class, //
+		LogicalModelAdapterTest.class, //
 })
 public class SeqDCustomTests {
 


### PR DESCRIPTION
Implement linkage of the selection in the **Logical Model View** with the edit-part selection in the diagram editor.  This incidentally fixes a few problems:

- unnecessary preëmptive disposal of a new logical model
- attaching a new logical model to the UML `Interaction` before it has been initialized
