### PR TITLE
Fix #302 Elements not created at Mouse Pointer

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ISequenceEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ISequenceEditPolicy.java
@@ -12,11 +12,15 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
 
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.eclipse.emf.workspace.EMFCommandOperation;
+import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.UnexecutableCommand;
 import org.eclipse.gmf.runtime.notation.View;
@@ -52,5 +56,30 @@ public interface ISequenceEditPolicy extends EditPolicy {
 	static TransactionalEditingDomain __getEditingDomain(ISequenceEditPolicy __this) {
 		EObject view = __this.getHost().getAdapter(View.class);
 		return (view == null) ? null : TransactionUtil.getEditingDomain(view);
+	}
+
+	// This should be a private 'getHostFigure' method in Java 9
+	static IFigure __getHostFigure(ISequenceEditPolicy __this) {
+		EditPart host = __this.getHost();
+		return (host instanceof GraphicalEditPart) ? ((GraphicalEditPart)host).getFigure() : null;
+	}
+
+	/**
+	 * Compute a {@code location} relative in my host figure's coördinate space.
+	 * 
+	 * @param location
+	 *            an absolute location in the diagram viewer coördinates
+	 * @return the {@code location} in my host figure's coördinate space
+	 */
+	default Point getRelativeLocation(Point location) {
+		Point result = location.getCopy();
+
+		IFigure figure = __getHostFigure(this);
+		if (figure != null) {
+			figure.translateToRelative(result);
+			result.translate(figure.getBounds().getLocation().getNegated());
+		}
+
+		return result;
 	}
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineBodyGraphicalNodeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineBodyGraphicalNodeEditPolicy.java
@@ -62,18 +62,18 @@ public class LifelineBodyGraphicalNodeEditPolicy extends GraphicalNodeEditPolicy
 
 				IElementType messageType = request.getConnectionViewDescriptor().getElementAdapter()
 						.getAdapter(IElementType.class);
-				Point location = request.getLocation();
-				Optional<MElement<?>> before = mLifeline.elementAt(location.y());
 
+				Point location = getRelativeLocation(request.getLocation());
 				int offset = location.y();
+
+				Optional<MElement<?>> before = mLifeline.elementAt(offset);
 
 				if (before.isPresent()) {
 					// We know the top exists because that's how we found the 'before' element
-					offset = offset - before.get().getTop().getAsInt();
-				} else {
-					// It will be relative to the lifeline head
-					offset = offset - getLayoutHelper().getBottom(mLifeline.getDiagramView().get());
-				}
+					int relativeTopOfBefore = before.get().getTop().getAsInt()
+							- getLayoutHelper().getBottom(mLifeline.getDiagramView().get());
+					offset = offset - relativeTopOfBefore;
+				} // else it will be relative to the top of the lifeline body line
 
 				Command result = new StartMessageCommand(mLifeline, before, offset, getSort(messageType));
 				request.setStartCommand(result);

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineCreationEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineCreationEditPolicy.java
@@ -14,6 +14,7 @@
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
@@ -22,6 +23,7 @@ import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
 import org.eclipse.gmf.runtime.emf.type.core.IHintedType;
+import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.util.SequenceTypeSwitch;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
@@ -58,8 +60,16 @@ public class LifelineCreationEditPolicy extends LogicalModelCreationEditPolicy {
 						int offset = location.y();
 
 						if (before.isPresent()) {
-							// We know the top exists because that's how we found the 'before' element
-							offset = offset - before.get().getTop().getAsInt();
+							// Get the bottom of the before element
+							OptionalInt bottom = before.get().getBottom();
+							if (bottom.isPresent()) {
+								int relativeBottom = bottom.getAsInt()
+										- getLayoutHelper().getTop((Shape)parentView);
+								offset = offset - relativeBottom;
+							} else {
+								// If it doesn't have a bottom, then ignore it
+								before = Optional.empty();
+							}
 						}
 
 						return lifeline.insertExecutionAfter(before.orElse(lifeline), offset,

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineCreationEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineCreationEditPolicy.java
@@ -20,7 +20,6 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
 import org.eclipse.gmf.runtime.emf.type.core.IHintedType;
 import org.eclipse.gmf.runtime.notation.View;
@@ -88,14 +87,4 @@ public class LifelineCreationEditPolicy extends LogicalModelCreationEditPolicy {
 		return mLifeline.map(new CommandSwitch()::doSwitch);
 	}
 
-	@Override
-	protected Point getRelativeLocation(Point location) {
-		Point result = super.getRelativeLocation(location);
-
-		// And adjust for the lifeline header
-		GraphicalEditPart header = (GraphicalEditPart)getHost().getParent();
-		result.translate(0, -header.getFigure().getBounds().height());
-
-		return result;
-	}
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineCreationEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineCreationEditPolicy.java
@@ -24,7 +24,6 @@ import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
 import org.eclipse.gmf.runtime.emf.type.core.IHintedType;
 import org.eclipse.gmf.runtime.notation.View;
-import org.eclipse.papyrus.uml.diagram.sequence.figure.HeaderFigure;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.util.SequenceTypeSwitch;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
@@ -58,11 +57,6 @@ public class LifelineCreationEditPolicy extends LogicalModelCreationEditPolicy {
 						Optional<MElement<?>> before = lifeline.elementAt(location.y());
 
 						int offset = location.y();
-
-						// Account for the header's margin to ensure that the execution is placed
-						// exactly where the mouse cursor put it.
-						// FIXME: Locate where this margin actually is; don't assume the default
-						offset = offset - HeaderFigure.DEFAULT_MARGIN_HEIGHT;
 
 						if (before.isPresent()) {
 							// We know the top exists because that's how we found the 'before' element

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LogicalModelCreationEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LogicalModelCreationEditPolicy.java
@@ -17,13 +17,9 @@ import java.util.Optional;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
-import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.gef.EditPart;
-import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.UnexecutableCommand;
 import org.eclipse.gmf.runtime.diagram.core.util.ViewUtil;
-import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editpolicies.CreationEditPolicy;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateViewAndElementRequest;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateViewRequest;
@@ -68,20 +64,6 @@ public abstract class LogicalModelCreationEditPolicy extends CreationEditPolicy 
 	protected abstract Optional<org.eclipse.emf.common.command.Command> getCreationCommand(
 			MInteraction interaction, Element parentElement, View parentView, Point location, Dimension size,
 			IElementType type);
-
-	protected Point getRelativeLocation(Point location) {
-		Point result = location.getCopy();
-
-		for (EditPart parent = getHost().getParent(); (parent instanceof GraphicalEditPart)
-				&& !(parent instanceof DiagramEditPart); parent = parent.getParent()) {
-
-			GraphicalEditPart graphicalParent = (GraphicalEditPart)parent;
-			Rectangle parentBounds = graphicalParent.getFigure().getBounds();
-			result = result.translate(parentBounds.getLocation().getNegated());
-		}
-
-		return result;
-	}
 
 	@Override
 	protected Command getCreateCommand(CreateViewRequest request) {

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/providers/SequenceElementTypes.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/providers/SequenceElementTypes.java
@@ -49,6 +49,15 @@ public final class SequenceElementTypes {
 	public static final IElementType Lifeline_Shape = getElementTypeByUniqueId(
 			"org.eclipse.papyrus.umldi.Lifeline_Shape"); //$NON-NLS-1$
 
+	public static final IElementType Action_Execution_Shape = getElementTypeByUniqueId(
+			"org.eclipse.papyrus.umldi.ActionExecutionSpecification_Shape"); //$NON-NLS-1$
+
+	public static final IElementType Behavior_Execution_Shape = getElementTypeByUniqueId(
+			"org.eclipse.papyrus.umldi.BehaviorExecutionSpecification_Shape"); //$NON-NLS-1$
+
+	public static final IElementType Async_Message_Edge = getElementTypeByUniqueId(
+			"org.eclipse.papyrus.umldi.Message_AsynchEdge"); //$NON-NLS-1$
+
 	public static ImageDescriptor getImageDescriptor(ENamedElement element) {
 		return elementTypeImages.getImageDescriptor(element);
 	}
@@ -104,10 +113,10 @@ public final class SequenceElementTypes {
 	public static IElementType getElementType(String visualID) {
 		if (visualID != null) {
 			switch (visualID) {
-			case RepresentationKind.DIAGRAM_ID:
-				return Package_SequenceDiagram;
-			case RepresentationKind.INTERACTION_ID:
-				return Interaction_Shape;
+				case RepresentationKind.DIAGRAM_ID:
+					return Package_SequenceDiagram;
+				case RepresentationKind.INTERACTION_ID:
+					return Interaction_Shape;
 			}
 		}
 		return null;

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/util/Suppliers.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/util/Suppliers.java
@@ -12,6 +12,7 @@
 
 package org.eclipse.papyrus.uml.interaction.graph.util;
 
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -41,4 +42,26 @@ public class Suppliers {
 		return () -> function.apply(supplier.get());
 	}
 
+	/**
+	 * Memoize a {@code supplier} so that it is only accessed once and that result cached, with best-effort
+	 * support for concurrent access.
+	 * 
+	 * @param supplier
+	 *            a supplier
+	 * @return a memoizing wrapper for the {@code supplier}
+	 */
+	public static <V> Supplier<V> memoize(Supplier<V> supplier) {
+		final AtomicReference<V> memo = new AtomicReference<V>();
+		return () -> {
+			V result = memo.get();
+			if (result == null) {
+				result = supplier.get();
+				if (!memo.compareAndSet(null, result)) {
+					// Somebody else set it
+					result = memo.get();
+				}
+			}
+			return result;
+		};
+	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/AddLifelineCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/AddLifelineCommand.java
@@ -15,6 +15,8 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 import java.util.Optional;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.gmf.runtime.notation.Compartment;
+import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MInteractionImpl;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
@@ -65,11 +67,16 @@ public class AddLifelineCommand extends ModelCommand<MInteractionImpl> implement
 				UMLPackage.Literals.INTERACTION__LIFELINE);
 		resultCommand = semantics.createLifeline(params);
 
+		Shape frame = diagramHelper().getInteractionFrame(getTarget().getDiagramView().get());
+		Compartment compartment = diagramHelper().getShapeCompartment(frame);
+
+		int absoluteX = layoutHelper().toAbsoluteX(null, compartment, xOffset);
+
 		Command result = resultCommand.chain(diagramHelper().createLifelineShape(resultCommand,
-				getTarget().getDiagramView().get(), xOffset, height));
+				getTarget().getDiagramView().get(), absoluteX, height));
 
 		// Are we inserting this amongst existing lifelines?
-		Optional<MLifeline> existing = getTarget().getLifelineAt(xOffset);
+		Optional<MLifeline> existing = getTarget().getLifelineAt(absoluteX);
 		if (existing.isPresent()) {
 			// Make room for it
 			int spaceRequired = 90; // FIXME: LayoutHelper should compute space needed

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
@@ -137,7 +137,8 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 		OptionalInt referenceY;
 		if (before instanceof MLifeline) {
 			// The reference is to the lifeline *head*
-			referenceY = OptionalInt.of(0);
+			Shape lifelineHead = ((MLifeline)before).getDiagramView().get();
+			referenceY = OptionalInt.of(layoutHelper().getBottom(lifelineHead));
 		} else {
 			referenceY = layoutHelper().getBottom(reference);
 		}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/impl/LogicalModelPlugin.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/impl/LogicalModelPlugin.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.common.EMFPlugin;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultDiagramHelper;
+import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutConstraints;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutHelper;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultSemanticHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
@@ -76,7 +77,8 @@ public class LogicalModelPlugin extends EMFPlugin {
 	 * @return its layout helper
 	 */
 	public LayoutHelper getLayoutHelper(EditingDomain editingDomain) {
-		return layoutHelpers.computeIfAbsent(editingDomain, DefaultLayoutHelper::new);
+		return layoutHelpers.computeIfAbsent(editingDomain, //
+				domain -> new DefaultLayoutHelper(domain, DefaultLayoutConstraints::new));
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.gmf.runtime.diagram.core.util.ViewUtil;
 import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.Compartment;
 import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.IdentityAnchor;
@@ -78,14 +79,34 @@ public class DefaultDiagramHelper implements DiagramHelper {
 	}
 
 	@Override
+	public Shape getInteractionFrame(Diagram diagram) {
+		return (Shape)ViewUtil.getChildBySemanticHint(diagram, "Shape_Interaction");
+	}
+
+	@Override
+	public Compartment getShapeCompartment(Shape shape) {
+		Compartment result;
+
+		switch (shape.getType()) {
+			case "Shape_Interaction":
+				result = (Compartment)ViewUtil.getChildBySemanticHint(shape, "Interaction_Contents");
+				break;
+			default:
+				result = null;
+				break;
+		}
+
+		return result;
+	}
+
+	@Override
 	public CreationCommand<Shape> createLifelineShape(Supplier<? extends Lifeline> lifeline, Diagram diagram,
 			int xPosition, int height) {
 
 		// TODO: The Logical Model is required to have no dependencies on the diagram editor,
 		// but this is usually the responsibility of a View Provider. That should be okay ...
 
-		Node frame = (Node)ViewUtil.getChildBySemanticHint(diagram, "Shape_Interaction");
-		Node compartment = (Node)ViewUtil.getChildBySemanticHint(frame, "Interaction_Contents");
+		Node compartment = getShapeCompartment(getInteractionFrame(diagram));
 
 		Supplier<Shape> shape = () -> {
 			Shape result = NotationFactory.eINSTANCE.createShape();
@@ -94,15 +115,9 @@ public class DefaultDiagramHelper implements DiagramHelper {
 
 			Bounds bounds = NotationFactory.eINSTANCE.createBounds();
 			Bounds proposedBounds = NotationFactory.eINSTANCE.createBounds();
-			proposedBounds.setX(xPosition);
+			proposedBounds.setX(layoutHelper().toRelativeX(result, compartment, xPosition));
 			proposedBounds.setHeight(height);
 			bounds = layoutHelper().getNewBounds(UMLPackage.Literals.LIFELINE, proposedBounds, compartment);
-
-			// Adjust for insets. Always relative to parent
-			bounds.setX(layoutHelper().toRelativeX(result,
-					bounds.getX() - layoutHelper().getConstraints().getLeftInset(result)));
-			bounds.setY(layoutHelper().toRelativeY(result,
-					bounds.getY() - layoutHelper().getConstraints().getTopInset(result)));
 
 			result.setLayoutConstraint(bounds);
 
@@ -165,7 +180,7 @@ public class DefaultDiagramHelper implements DiagramHelper {
 
 			Bounds bounds = NotationFactory.eINSTANCE.createBounds();
 			bounds.setX((width - execWidth) / 2); // Relative to the parent
-			bounds.setY(layoutHelper().toRelativeY(result, yPosition)); // Always relative to parent
+			bounds.setY(layoutHelper().toRelativeY(result, lifelineBody, yPosition)); // Relative to parent
 			bounds.setWidth(execWidth);
 			bounds.setHeight(height);
 			result.setLayoutConstraint(bounds);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
@@ -98,6 +98,12 @@ public class DefaultDiagramHelper implements DiagramHelper {
 			proposedBounds.setHeight(height);
 			bounds = layoutHelper().getNewBounds(UMLPackage.Literals.LIFELINE, proposedBounds, compartment);
 
+			// Adjust for insets. Always relative to parent
+			bounds.setX(layoutHelper().toRelativeX(result,
+					bounds.getX() - layoutHelper().getConstraints().getLeftInset(result)));
+			bounds.setY(layoutHelper().toRelativeY(result,
+					bounds.getY() - layoutHelper().getConstraints().getTopInset(result)));
+
 			result.setLayoutConstraint(bounds);
 
 			// create compartment for name
@@ -158,8 +164,8 @@ public class DefaultDiagramHelper implements DiagramHelper {
 			result.setElement(execution.get());
 
 			Bounds bounds = NotationFactory.eINSTANCE.createBounds();
-			bounds.setX((width - execWidth) / 2);
-			bounds.setY(yPosition - layoutHelper().getTop(lifelineBody)); // Always relative to parent
+			bounds.setX((width - execWidth) / 2); // Relative to the parent
+			bounds.setY(layoutHelper().toRelativeY(result, yPosition)); // Always relative to parent
 			bounds.setWidth(execWidth);
 			bounds.setHeight(height);
 			result.setLayoutConstraint(bounds);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
@@ -1,0 +1,132 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.spi.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.gmf.runtime.notation.Compartment;
+import org.eclipse.gmf.runtime.notation.Shape;
+import org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints;
+
+/**
+ * Encoding of the default layout constraints for shapes, compartments, etc.
+ *
+ * @author Christian W. Damus
+ */
+public class DefaultLayoutConstraints implements LayoutConstraints {
+	private static Integer ZERO = Integer.valueOf(0);
+
+	private final Map<String, Integer> standardXOffsets;
+
+	private final Map<String, Integer> standardYOffsets;
+
+	private final Map<String, Integer> standardLeftInsets;
+
+	private final Map<String, Integer> standardTopInsets;
+
+	private final Map<String, Integer> standardRightInsets;
+
+	private final Map<String, Integer> standardBottomInsets;
+
+	/**
+	 * Initializes me.
+	 */
+	public DefaultLayoutConstraints() {
+		super();
+
+		standardXOffsets = loadXOffsets();
+		standardYOffsets = loadYOffsets();
+
+		standardLeftInsets = loadLeftInsets();
+		standardTopInsets = loadTopInsets();
+		standardRightInsets = loadRightInsets();
+		standardBottomInsets = loadBottomInsets();
+	}
+
+	@Override
+	public int getXOffset(Compartment shapeCompartment) {
+		return standardXOffsets.getOrDefault(shapeCompartment.getType(), ZERO).intValue();
+	}
+
+	@Override
+	public int getYOffset(Compartment shapeCompartment) {
+		return standardYOffsets.getOrDefault(shapeCompartment.getType(), ZERO).intValue();
+	}
+
+	@Override
+	public int getLeftInset(Shape shape) {
+		return standardLeftInsets.getOrDefault(shape.getType(), ZERO).intValue();
+	}
+
+	@Override
+	public int getTopInset(Shape shape) {
+		return standardTopInsets.getOrDefault(shape.getType(), ZERO).intValue();
+	}
+
+	@Override
+	public int getRightInset(Shape shape) {
+		return standardRightInsets.getOrDefault(shape.getType(), ZERO).intValue();
+	}
+
+	@Override
+	public int getBottomInset(Shape shape) {
+		return standardBottomInsets.getOrDefault(shape.getType(), ZERO).intValue();
+	}
+
+	private static Map<String, Integer> loadXOffsets() {
+		Map<String, Integer> result = new HashMap<>();
+		return result;
+	}
+
+	@SuppressWarnings("boxing")
+	private static Map<String, Integer> loadYOffsets() {
+		Map<String, Integer> result = new HashMap<>();
+
+		// The size of the interaction frame's pentagon label
+		result.put("Interaction_Contents", 30);
+
+		return result;
+	}
+
+	private static Map<String, Integer> loadLeftInsets() {
+		Map<String, Integer> result = new HashMap<>();
+
+		return result;
+	}
+
+	@SuppressWarnings("boxing")
+	private static Map<String, Integer> loadTopInsets() {
+		Map<String, Integer> result = new HashMap<>();
+
+		result.put("Shape_Lifeline_Header", 5);
+
+		return result;
+	}
+
+	private static Map<String, Integer> loadRightInsets() {
+		Map<String, Integer> result = new HashMap<>();
+
+		return result;
+	}
+
+	@SuppressWarnings("boxing")
+	private static Map<String, Integer> loadBottomInsets() {
+		Map<String, Integer> result = new HashMap<>();
+
+		result.put("Shape_Lifeline_Header", 5);
+
+		return result;
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.gmf.runtime.notation.Compartment;
-import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints;
 
 /**
@@ -31,14 +30,6 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 
 	private final Map<String, Integer> standardYOffsets;
 
-	private final Map<String, Integer> standardLeftInsets;
-
-	private final Map<String, Integer> standardTopInsets;
-
-	private final Map<String, Integer> standardRightInsets;
-
-	private final Map<String, Integer> standardBottomInsets;
-
 	/**
 	 * Initializes me.
 	 */
@@ -47,11 +38,6 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 
 		standardXOffsets = loadXOffsets();
 		standardYOffsets = loadYOffsets();
-
-		standardLeftInsets = loadLeftInsets();
-		standardTopInsets = loadTopInsets();
-		standardRightInsets = loadRightInsets();
-		standardBottomInsets = loadBottomInsets();
 	}
 
 	@Override
@@ -64,28 +50,12 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 		return standardYOffsets.getOrDefault(shapeCompartment.getType(), ZERO).intValue();
 	}
 
-	@Override
-	public int getLeftInset(Shape shape) {
-		return standardLeftInsets.getOrDefault(shape.getType(), ZERO).intValue();
-	}
-
-	@Override
-	public int getTopInset(Shape shape) {
-		return standardTopInsets.getOrDefault(shape.getType(), ZERO).intValue();
-	}
-
-	@Override
-	public int getRightInset(Shape shape) {
-		return standardRightInsets.getOrDefault(shape.getType(), ZERO).intValue();
-	}
-
-	@Override
-	public int getBottomInset(Shape shape) {
-		return standardBottomInsets.getOrDefault(shape.getType(), ZERO).intValue();
-	}
-
 	private static Map<String, Integer> loadXOffsets() {
 		Map<String, Integer> result = new HashMap<>();
+
+		// Inset of the viewpoint figure
+		result.put("Interaction_Contents", 5);
+
 		return result;
 	}
 
@@ -95,36 +65,6 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 
 		// The size of the interaction frame's pentagon label
 		result.put("Interaction_Contents", 30);
-
-		return result;
-	}
-
-	private static Map<String, Integer> loadLeftInsets() {
-		Map<String, Integer> result = new HashMap<>();
-
-		return result;
-	}
-
-	@SuppressWarnings("boxing")
-	private static Map<String, Integer> loadTopInsets() {
-		Map<String, Integer> result = new HashMap<>();
-
-		result.put("Shape_Lifeline_Header", 5);
-
-		return result;
-	}
-
-	private static Map<String, Integer> loadRightInsets() {
-		Map<String, Integer> result = new HashMap<>();
-
-		return result;
-	}
-
-	@SuppressWarnings("boxing")
-	private static Map<String, Integer> loadBottomInsets() {
-		Map<String, Integer> result = new HashMap<>();
-
-		result.put("Shape_Lifeline_Header", 5);
 
 		return result;
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
@@ -162,9 +162,6 @@ public class DefaultLayoutHelper implements LayoutHelper {
 			LayoutConstraint constraint = shape.getLayoutConstraint();
 			if (constraint != null) {
 				result = getTopFunction().applyAsInt(constraint);
-				if (result != DEFAULT_TOP) {
-					result = result - getConstraints().getTopInset(shape);
-				}
 			}
 		}
 
@@ -177,8 +174,8 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	}
 
 	@Override
-	public int toAbsoluteX(Shape shape, int x) {
-		EObject containerView = shape.eContainer();
+	public int toAbsoluteX(Shape shape, View parent, int x) {
+		EObject containerView = parent;
 		int compartmentX = 0;
 		if (containerView instanceof Compartment) {
 			// It's in a shape compartment. Where is it in the parent shape?
@@ -198,8 +195,8 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	}
 
 	@Override
-	public int toRelativeX(Shape shape, int x) {
-		EObject containerView = shape.eContainer();
+	public int toRelativeX(Shape shape, View parent, int x) {
+		EObject containerView = parent;
 		int compartmentX = 0;
 		if (containerView instanceof Compartment) {
 			// It's in a shape compartment. Where is it in the parent shape?
@@ -219,8 +216,8 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	}
 
 	@Override
-	public int toAbsoluteY(Shape shape, int y) {
-		EObject containerView = shape.eContainer();
+	public int toAbsoluteY(Shape shape, View parent, int y) {
+		EObject containerView = parent;
 		int compartmentY = 0;
 		if (containerView instanceof Compartment) {
 			// It's in a shape compartment. Where is it in the parent shape?
@@ -240,8 +237,8 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	}
 
 	@Override
-	public int toRelativeY(Shape shape, int y) {
-		EObject containerView = shape.eContainer();
+	public int toRelativeY(Shape shape, View parent, int y) {
+		EObject containerView = parent;
 		int compartmentY = 0;
 		if (containerView instanceof Compartment) {
 			// It's in a shape compartment. Where is it in the parent shape?
@@ -378,11 +375,6 @@ public class DefaultLayoutHelper implements LayoutHelper {
 		LayoutConstraint constraint = shape.getLayoutConstraint();
 		if (constraint != null) {
 			result = getBottomFunction().applyAsInt(constraint);
-			if (result != DEFAULT_BOTTOM) {
-				// Account for both Y insets
-				result = result - getConstraints().getTopInset(shape)
-						- getConstraints().getBottomInset(shape);
-			}
 		}
 
 		if (result != DEFAULT_BOTTOM) {
@@ -440,9 +432,6 @@ public class DefaultLayoutHelper implements LayoutHelper {
 			LayoutConstraint constraint = shape.getLayoutConstraint();
 			if (constraint != null) {
 				result = getLeftFunction().applyAsInt(constraint);
-				if (result != DEFAULT_LEFT) {
-					result = result - getConstraints().getLeftInset(shape);
-				}
 			}
 		}
 
@@ -478,11 +467,6 @@ public class DefaultLayoutHelper implements LayoutHelper {
 			LayoutConstraint constraint = shape.getLayoutConstraint();
 			if (constraint != null) {
 				result = getRightFunction().applyAsInt(constraint);
-				if (result != DEFAULT_RIGHT) {
-					// Account for both X insets
-					result = result - getConstraints().getLeftInset(shape)
-							- getConstraints().getRightInset(shape);
-				}
 			}
 		}
 
@@ -703,10 +687,10 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	public Command setTop(Shape shape, int yPosition) {
 		Command result = UnexecutableCommand.INSTANCE;
 		if (shape.getLayoutConstraint() instanceof Location) {
-			// Account for insets
-			int adjustedY = toRelativeY(shape, yPosition) - getConstraints().getTopInset(shape);
+			// Compute relative position
+			int relativeY = toRelativeY(shape, yPosition);
 			result = SetCommand.create(editingDomain, shape.getLayoutConstraint(),
-					NotationPackage.Literals.LOCATION__Y, adjustedY);
+					NotationPackage.Literals.LOCATION__Y, relativeY);
 		}
 		return result;
 	}
@@ -798,10 +782,10 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	public Command setLeft(Shape shape, int xPosition) {
 		Command result = UnexecutableCommand.INSTANCE;
 		if (shape.getLayoutConstraint() instanceof Location) {
-			// Account for insets
-			int adjustedX = toRelativeX(shape, xPosition) - getConstraints().getLeftInset(shape);
+			// Compute relative position
+			int relativeX = toRelativeX(shape, xPosition);
 			result = SetCommand.create(editingDomain, shape.getLayoutConstraint(),
-					NotationPackage.Literals.LOCATION__X, adjustedX);
+					NotationPackage.Literals.LOCATION__X, relativeX);
 		}
 		return result;
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
@@ -16,6 +16,7 @@ import static org.eclipse.papyrus.uml.interaction.graph.util.CrossReferenceUtil.
 
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -30,6 +31,7 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.gmf.runtime.diagram.core.util.ViewUtil;
 import org.eclipse.gmf.runtime.notation.Anchor;
 import org.eclipse.gmf.runtime.notation.Bounds;
+import org.eclipse.gmf.runtime.notation.Compartment;
 import org.eclipse.gmf.runtime.notation.Edge;
 import org.eclipse.gmf.runtime.notation.IdentityAnchor;
 import org.eclipse.gmf.runtime.notation.LayoutConstraint;
@@ -42,6 +44,8 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.gmf.runtime.notation.util.NotationSwitch;
 import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.graph.util.CrossReferenceUtil;
+import org.eclipse.papyrus.uml.interaction.graph.util.Suppliers;
+import org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.GeneralOrdering;
@@ -82,18 +86,23 @@ public class DefaultLayoutHelper implements LayoutHelper {
 
 	private static final Pattern EXEC_START_FINISH_ANCHOR_PATTERN = Pattern.compile("(start)|(end)"); //$NON-NLS-1$
 
+	private final Supplier<LayoutConstraints> layoutConstraints;
+
 	private final EditingDomain editingDomain;
 
 	/**
-	 * Initializes me with my contextual editing domain.
+	 * Initializes me with my constraints and contextual editing domain.
 	 * 
 	 * @param editingDomain
 	 *            my editing domain
+	 * @param layoutConstraints
+	 *            my constraints supplier
 	 */
-	public DefaultLayoutHelper(EditingDomain editingDomain) {
+	public DefaultLayoutHelper(EditingDomain editingDomain, Supplier<LayoutConstraints> layoutConstraints) {
 		super();
 
 		this.editingDomain = editingDomain;
+		this.layoutConstraints = Suppliers.memoize(layoutConstraints);
 	}
 
 	@Override
@@ -153,18 +162,99 @@ public class DefaultLayoutHelper implements LayoutHelper {
 			LayoutConstraint constraint = shape.getLayoutConstraint();
 			if (constraint != null) {
 				result = getTopFunction().applyAsInt(constraint);
+				if (result != DEFAULT_TOP) {
+					result = result - getConstraints().getTopInset(shape);
+				}
 			}
 		}
 
-		// And is this shape in a shape?
-		if (result != DEFAULT_TOP && shape.eContainer() instanceof Shape) {
+		if (result != DEFAULT_TOP) {
 			// Its position is relative to the containing shape
-			int relativeTop = getTop((Shape)shape.eContainer());
-			if (relativeTop == DEFAULT_TOP) {
-				result = DEFAULT_TOP;
-			} else {
-				result = relativeTop + result;
-			}
+			result = toAbsoluteY(shape, result);
+		}
+
+		return result;
+	}
+
+	@Override
+	public int toAbsoluteX(Shape shape, int x) {
+		EObject containerView = shape.eContainer();
+		int compartmentX = 0;
+		if (containerView instanceof Compartment) {
+			// It's in a shape compartment. Where is it in the parent shape?
+			Compartment compartment = (Compartment)containerView;
+			compartmentX = getConstraints().getXOffset(compartment);
+			containerView = compartment.eContainer();
+		}
+
+		int result = x;
+
+		if (containerView instanceof Shape) {
+			int relativeLeft = getLeft((Shape)containerView);
+			result = relativeLeft == DEFAULT_LEFT ? DEFAULT_LEFT : relativeLeft + compartmentX + result;
+		}
+
+		return result;
+	}
+
+	@Override
+	public int toRelativeX(Shape shape, int x) {
+		EObject containerView = shape.eContainer();
+		int compartmentX = 0;
+		if (containerView instanceof Compartment) {
+			// It's in a shape compartment. Where is it in the parent shape?
+			Compartment compartment = (Compartment)containerView;
+			compartmentX = getConstraints().getXOffset(compartment);
+			containerView = compartment.eContainer();
+		}
+
+		int result = x;
+
+		if (containerView instanceof Shape) {
+			int relativeLeft = getLeft((Shape)containerView);
+			result = relativeLeft == DEFAULT_LEFT ? DEFAULT_LEFT : result - compartmentX - relativeLeft;
+		}
+
+		return result;
+	}
+
+	@Override
+	public int toAbsoluteY(Shape shape, int y) {
+		EObject containerView = shape.eContainer();
+		int compartmentY = 0;
+		if (containerView instanceof Compartment) {
+			// It's in a shape compartment. Where is it in the parent shape?
+			Compartment compartment = (Compartment)containerView;
+			compartmentY = getConstraints().getYOffset(compartment);
+			containerView = compartment.eContainer();
+		}
+
+		int result = y;
+
+		if (containerView instanceof Shape) {
+			int relativeTop = getTop((Shape)containerView);
+			result = relativeTop == DEFAULT_TOP ? DEFAULT_TOP : relativeTop + compartmentY + result;
+		}
+
+		return result;
+	}
+
+	@Override
+	public int toRelativeY(Shape shape, int y) {
+		EObject containerView = shape.eContainer();
+		int compartmentY = 0;
+		if (containerView instanceof Compartment) {
+			// It's in a shape compartment. Where is it in the parent shape?
+			Compartment compartment = (Compartment)containerView;
+			compartmentY = getConstraints().getYOffset(compartment);
+			containerView = compartment.eContainer();
+		}
+
+		int result = y;
+
+		if (containerView instanceof Shape) {
+			int relativeTop = getTop((Shape)containerView);
+			result = relativeTop == DEFAULT_TOP ? DEFAULT_TOP : result - compartmentY - relativeTop;
 		}
 
 		return result;
@@ -288,17 +378,16 @@ public class DefaultLayoutHelper implements LayoutHelper {
 		LayoutConstraint constraint = shape.getLayoutConstraint();
 		if (constraint != null) {
 			result = getBottomFunction().applyAsInt(constraint);
+			if (result != DEFAULT_BOTTOM) {
+				// Account for both Y insets
+				result = result - getConstraints().getTopInset(shape)
+						- getConstraints().getBottomInset(shape);
+			}
 		}
 
-		// And is this shape in a shape?
-		if (result != DEFAULT_BOTTOM && shape.eContainer() instanceof Shape) {
+		if (result != DEFAULT_BOTTOM) {
 			// Its position is relative to the containing shape
-			int relativeTop = getTop((Shape)shape.eContainer());
-			if (relativeTop == DEFAULT_TOP) {
-				result = DEFAULT_BOTTOM;
-			} else {
-				result = relativeTop + result;
-			}
+			result = toAbsoluteY(shape, result);
 		}
 
 		return result;
@@ -351,18 +440,15 @@ public class DefaultLayoutHelper implements LayoutHelper {
 			LayoutConstraint constraint = shape.getLayoutConstraint();
 			if (constraint != null) {
 				result = getLeftFunction().applyAsInt(constraint);
+				if (result != DEFAULT_LEFT) {
+					result = result - getConstraints().getLeftInset(shape);
+				}
 			}
 		}
 
-		// And is this shape in a shape?
-		if (result != DEFAULT_LEFT && shape.eContainer() instanceof Shape) {
+		if (result != DEFAULT_LEFT) {
 			// Its position is relative to the containing shape
-			int relativeLeft = getLeft((Shape)shape.eContainer());
-			if (relativeLeft == DEFAULT_LEFT) {
-				result = DEFAULT_LEFT;
-			} else {
-				result = relativeLeft + result;
-			}
+			result = toAbsoluteX(shape, result);
 		}
 
 		return result;
@@ -392,18 +478,17 @@ public class DefaultLayoutHelper implements LayoutHelper {
 			LayoutConstraint constraint = shape.getLayoutConstraint();
 			if (constraint != null) {
 				result = getRightFunction().applyAsInt(constraint);
+				if (result != DEFAULT_RIGHT) {
+					// Account for both X insets
+					result = result - getConstraints().getLeftInset(shape)
+							- getConstraints().getRightInset(shape);
+				}
 			}
 		}
 
-		// And is this shape in a shape?
-		if (result != DEFAULT_RIGHT && shape.eContainer() instanceof Shape) {
+		if (result != DEFAULT_RIGHT) {
 			// Its position is relative to the containing shape
-			int relativeLeft = getLeft((Shape)shape.eContainer());
-			if (relativeLeft == DEFAULT_LEFT) {
-				result = DEFAULT_RIGHT;
-			} else {
-				result = relativeLeft + result;
-			}
+			result = toAbsoluteX(shape, result);
 		}
 
 		return result;
@@ -618,9 +703,10 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	public Command setTop(Shape shape, int yPosition) {
 		Command result = UnexecutableCommand.INSTANCE;
 		if (shape.getLayoutConstraint() instanceof Location) {
-			int parentTop = shape.eContainer() instanceof Shape ? getTop((Shape)shape.eContainer()) : 0;
+			// Account for insets
+			int adjustedY = toRelativeY(shape, yPosition) - getConstraints().getTopInset(shape);
 			result = SetCommand.create(editingDomain, shape.getLayoutConstraint(),
-					NotationPackage.Literals.LOCATION__Y, yPosition - parentTop);
+					NotationPackage.Literals.LOCATION__Y, adjustedY);
 		}
 		return result;
 	}
@@ -712,9 +798,10 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	public Command setLeft(Shape shape, int xPosition) {
 		Command result = UnexecutableCommand.INSTANCE;
 		if (shape.getLayoutConstraint() instanceof Location) {
-			int parentLeft = shape.eContainer() instanceof Shape ? getLeft((Shape)shape.eContainer()) : 0;
+			// Account for insets
+			int adjustedX = toRelativeX(shape, xPosition) - getConstraints().getLeftInset(shape);
 			result = SetCommand.create(editingDomain, shape.getLayoutConstraint(),
-					NotationPackage.Literals.LOCATION__X, xPosition - parentLeft);
+					NotationPackage.Literals.LOCATION__X, adjustedX);
 		}
 		return result;
 	}
@@ -770,5 +857,10 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	 */
 	protected static <T> Optional<T> coerce(Object object, Class<T> type) {
 		return Optional.ofNullable(object).filter(type::isInstance).map(type::cast);
+	}
+
+	@Override
+	public LayoutConstraints getConstraints() {
+		return layoutConstraints.get();
 	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DiagramHelper.java
@@ -16,6 +16,7 @@ import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.gmf.runtime.notation.Compartment;
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.gmf.runtime.notation.View;
@@ -32,6 +33,24 @@ import org.eclipse.uml2.uml.Message;
  * @author Christian W. Damus
  */
 public interface DiagramHelper {
+
+	/**
+	 * Get the interaction frame of a sequence {@code diagram}.
+	 * 
+	 * @param diagram
+	 *            a sequence diagram
+	 * @return its interaction frame
+	 */
+	Shape getInteractionFrame(Diagram diagram);
+
+	/**
+	 * Get the shape compartment of a {@code shape}.
+	 * 
+	 * @param shape
+	 *            a shape view
+	 * @return its shape compartment
+	 */
+	Compartment getShapeCompartment(Shape shape);
 
 	/**
 	 * Obtain a command to create a shape for the given {@code lifeline} as a child of an {@link interaction}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutConstraints.java
@@ -1,0 +1,81 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model.spi;
+
+import org.eclipse.gmf.runtime.notation.Compartment;
+import org.eclipse.gmf.runtime.notation.Shape;
+
+/**
+ * Encoding of the layout constraints for shapes, compartments, etc.
+ *
+ * @author Christian W. Damus
+ */
+public interface LayoutConstraints {
+
+	/**
+	 * Queries the x-coördinate offset of a shape compartment within its parent shape, accounting for name
+	 * labels etc. that take up space but which size is not encoded in the notation.
+	 * 
+	 * @param shapeCompartment
+	 *            a shape compartment
+	 * @return its X offset within the parent shape
+	 */
+	int getXOffset(Compartment shapeCompartment);
+
+	/**
+	 * Queries the y-coördinate offset of a shape compartment within its parent shape, accounting for name
+	 * labels etc. that take up space but which size is not encoded in the notation.
+	 * 
+	 * @param shapeCompartment
+	 *            a shape compartment
+	 * @return its Y offset within the parent shape
+	 */
+	int getYOffset(Compartment shapeCompartment);
+
+	/**
+	 * Queries the left inset of a {@code shape}.
+	 * 
+	 * @param shape
+	 *            a shape in the diagram
+	 * @return its left inset
+	 */
+	int getLeftInset(Shape shape);
+
+	/**
+	 * Queries the top inset of a {@code shape}.
+	 * 
+	 * @param shape
+	 *            a shape in the diagram
+	 * @return its top inset
+	 */
+	int getTopInset(Shape shape);
+
+	/**
+	 * Queries the right inset of a {@code shape}.
+	 * 
+	 * @param shape
+	 *            a shape in the diagram
+	 * @return its right inset
+	 */
+	int getRightInset(Shape shape);
+
+	/**
+	 * Queries the bottom inset of a {@code shape}.
+	 * 
+	 * @param shape
+	 *            a shape in the diagram
+	 * @return its bottom inset
+	 */
+	int getBottomInset(Shape shape);
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutConstraints.java
@@ -13,7 +13,6 @@
 package org.eclipse.papyrus.uml.interaction.model.spi;
 
 import org.eclipse.gmf.runtime.notation.Compartment;
-import org.eclipse.gmf.runtime.notation.Shape;
 
 /**
  * Encoding of the layout constraints for shapes, compartments, etc.
@@ -41,41 +40,5 @@ public interface LayoutConstraints {
 	 * @return its Y offset within the parent shape
 	 */
 	int getYOffset(Compartment shapeCompartment);
-
-	/**
-	 * Queries the left inset of a {@code shape}.
-	 * 
-	 * @param shape
-	 *            a shape in the diagram
-	 * @return its left inset
-	 */
-	int getLeftInset(Shape shape);
-
-	/**
-	 * Queries the top inset of a {@code shape}.
-	 * 
-	 * @param shape
-	 *            a shape in the diagram
-	 * @return its top inset
-	 */
-	int getTopInset(Shape shape);
-
-	/**
-	 * Queries the right inset of a {@code shape}.
-	 * 
-	 * @param shape
-	 *            a shape in the diagram
-	 * @return its right inset
-	 */
-	int getRightInset(Shape shape);
-
-	/**
-	 * Queries the bottom inset of a {@code shape}.
-	 * 
-	 * @param shape
-	 *            a shape in the diagram
-	 * @return its bottom inset
-	 */
-	int getBottomInset(Shape shape);
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
@@ -224,4 +224,60 @@ public interface LayoutHelper {
 	 */
 	Bounds getAdjustedBounds(EObject semanticObject, Node view, Bounds proposedBounds);
 
+	/**
+	 * Obtain an {@code x} coördinate in absolute space from one that is relative to the parent of a
+	 * {@code shape}, if it has one.
+	 * 
+	 * @param shape
+	 *            a shape
+	 * @param x
+	 *            an X position in relative coördinate space of the {@code shape}'s parent
+	 * @return the corresponding position in absolute coördinate space, or the relative {@code x} if none
+	 */
+	int toAbsoluteX(Shape shape, int x);
+
+	/**
+	 * Obtain an {@code x} coördinate in the space of the parent of a {@code shape}, if it has one, from one
+	 * that is in absolute space.
+	 * 
+	 * @param shape
+	 *            a shape
+	 * @param x
+	 *            an X position in absolute coördinate space
+	 * @return the corresponding position in the {@code shape}'s parent's space, or the absolute {@code x} if
+	 *         none
+	 */
+	int toRelativeX(Shape shape, int x);
+
+	/**
+	 * Obtain a {@code y} coördinate in absolute space from one that is relative to the parent of a
+	 * {@code shape}, if it has one.
+	 * 
+	 * @param shape
+	 *            a shape
+	 * @param y
+	 *            a Y position in relative coördinate space of the {@code shape}'s parent
+	 * @return the corresponding position in absolute coördinate space, or the relative {@code y} if none
+	 */
+	int toAbsoluteY(Shape shape, int y);
+
+	/**
+	 * Obtain a {@code y} coördinate in the space of the parent of a {@code shape}, if it has one, from one
+	 * that is in absolute space.
+	 * 
+	 * @param shape
+	 *            a shape
+	 * @param y
+	 *            a Y position in absolute coördinate space
+	 * @return the corresponding position in the {@code shape}'s parent's space, or the absolute {@code y} if
+	 *         none
+	 */
+	int toRelativeY(Shape shape, int y);
+
+	/**
+	 * Obtain the layout constraints.
+	 * 
+	 * @return the pluggable layout constraints
+	 */
+	LayoutConstraints getConstraints();
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
@@ -21,6 +21,7 @@ import org.eclipse.gmf.runtime.notation.Anchor;
 import org.eclipse.gmf.runtime.notation.Bounds;
 import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.Shape;
+import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 
 /**
@@ -225,6 +226,20 @@ public interface LayoutHelper {
 	Bounds getAdjustedBounds(EObject semanticObject, Node view, Bounds proposedBounds);
 
 	/**
+	 * Obtain an {@code x} coördinate in absolute space from one that is relative to the {@code parent} of a
+	 * {@code shape}.
+	 * 
+	 * @param shape
+	 *            a shape
+	 * @param parent
+	 *            its parent view (shape or compartment, usually)
+	 * @param x
+	 *            an X position in relative coördinate space of the {@code parent}
+	 * @return the corresponding position in absolute coördinate space
+	 */
+	int toAbsoluteX(Shape shape, View parent, int x);
+
+	/**
 	 * Obtain an {@code x} coördinate in absolute space from one that is relative to the parent of a
 	 * {@code shape}, if it has one.
 	 * 
@@ -234,7 +249,24 @@ public interface LayoutHelper {
 	 *            an X position in relative coördinate space of the {@code shape}'s parent
 	 * @return the corresponding position in absolute coördinate space, or the relative {@code x} if none
 	 */
-	int toAbsoluteX(Shape shape, int x);
+	default int toAbsoluteX(Shape shape, int x) {
+		EObject container = shape.eContainer();
+		return (container instanceof View) ? toAbsoluteX(shape, (View)container, x) : x;
+	}
+
+	/**
+	 * Obtain an {@code x} coördinate in the space of the parent of a {@code shape}, from one that is in
+	 * absolute space.
+	 * 
+	 * @param shape
+	 *            a shape
+	 * @param parent
+	 *            its parent view (shape or compartment, usually)
+	 * @param x
+	 *            an X position in absolute coördinate space
+	 * @return the corresponding position in the {@code parent}'s space
+	 */
+	int toRelativeX(Shape shape, View parent, int x);
 
 	/**
 	 * Obtain an {@code x} coördinate in the space of the parent of a {@code shape}, if it has one, from one
@@ -246,8 +278,26 @@ public interface LayoutHelper {
 	 *            an X position in absolute coördinate space
 	 * @return the corresponding position in the {@code shape}'s parent's space, or the absolute {@code x} if
 	 *         none
+	 * @see #toRelativeX(Shape, View, int)
 	 */
-	int toRelativeX(Shape shape, int x);
+	default int toRelativeX(Shape shape, int x) {
+		EObject container = shape.eContainer();
+		return (container instanceof View) ? toRelativeX(shape, (View)container, x) : x;
+	}
+
+	/**
+	 * Obtain a {@code y} coördinate in absolute space from one that is relative to the {@code parent} of a
+	 * {@code shape}.
+	 * 
+	 * @param shape
+	 *            a shape
+	 * @param parent
+	 *            its parent view (shape or compartment, usually)
+	 * @param y
+	 *            a Y position in relative coördinate space of the {@code parent}
+	 * @return the corresponding position in absolute coördinate space
+	 */
+	int toAbsoluteY(Shape shape, View parent, int y);
 
 	/**
 	 * Obtain a {@code y} coördinate in absolute space from one that is relative to the parent of a
@@ -255,11 +305,28 @@ public interface LayoutHelper {
 	 * 
 	 * @param shape
 	 *            a shape
-	 * @param y
+	 * @param x
 	 *            a Y position in relative coördinate space of the {@code shape}'s parent
-	 * @return the corresponding position in absolute coördinate space, or the relative {@code y} if none
+	 * @return the corresponding position in absolute coördinate space, or the relative {@code x} if none
 	 */
-	int toAbsoluteY(Shape shape, int y);
+	default int toAbsoluteY(Shape shape, int y) {
+		EObject container = shape.eContainer();
+		return (container instanceof View) ? toAbsoluteY(shape, (View)container, y) : y;
+	}
+
+	/**
+	 * Obtain a {@code y} coördinate in the space of the {@code parent} of a {@code shape}, from one that is
+	 * in absolute space.
+	 * 
+	 * @param shape
+	 *            a shape
+	 * @param parent
+	 *            its parent view (shape or compartment, usually)
+	 * @param y
+	 *            a Y position in absolute coördinate space
+	 * @return the corresponding position in the {@code parent}'s space
+	 */
+	int toRelativeY(Shape shape, View parent, int y);
 
 	/**
 	 * Obtain a {@code y} coördinate in the space of the parent of a {@code shape}, if it has one, from one
@@ -271,8 +338,12 @@ public interface LayoutHelper {
 	 *            a Y position in absolute coördinate space
 	 * @return the corresponding position in the {@code shape}'s parent's space, or the absolute {@code y} if
 	 *         none
+	 * @see #toRelativeY(Shape, View, int)
 	 */
-	int toRelativeY(Shape shape, int y);
+	default int toRelativeY(Shape shape, int y) {
+		EObject container = shape.eContainer();
+		return (container instanceof View) ? toRelativeY(shape, (View)container, y) : y;
+	}
 
 	/**
 	 * Obtain the layout constraints.

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/META-INF/MANIFEST.MF
@@ -11,6 +11,13 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.uml2.uml.resources;bundle-version="[5.3.0,6.0.0)",
  org.eclipse.papyrus.uml.interaction.graph;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.papyrus.uml.interaction.graph.tests;bundle-version="[1.0.0,2.0.0)",
- org.eclipse.draw2d;bundle-version="[3.10.100,4.0.0)"
+ org.eclipse.draw2d;bundle-version="[3.10.100,4.0.0)",
+ org.eclipse.core.resources,
+ org.eclipse.ui.ide,
+ org.eclipse.emf.edit,
+ org.eclipse.papyrus.infra.core.sashwindows.di,
+ org.eclipse.gef,
+ org.eclipse.gmf.runtime.emf.type.core,
+ org.eclipse.papyrus.infra.gmfdiag.common
 Bundle-Description: Tests of the core run-time APIs of the sequence diagram.
 Export-Package: org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers;version="1.0.0"

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AbstractGraphicalEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AbstractGraphicalEditPolicyUITest.java
@@ -1,0 +1,157 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import java.util.Optional;
+
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.Switch;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.gmf.runtime.emf.type.core.IElementType;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Message;
+import org.eclipse.uml2.uml.util.UMLSwitch;
+import org.junit.After;
+import org.junit.Rule;
+
+/**
+ * Abstract skeleton of a test that exercises graphical edit-policies.
+ *
+ * @author Christian W. Damus
+ */
+public abstract class AbstractGraphicalEditPolicyUITest {
+
+	@Rule
+	public final EditorFixture editor = new EditorFixture();
+
+	private EditPart lastCreatedEditPart;
+
+	/**
+	 * Initializes me.
+	 */
+	public AbstractGraphicalEditPolicyUITest() {
+		super();
+	}
+
+	@After
+	public void cleanUp() {
+		lastCreatedEditPart = null;
+	}
+
+	/**
+	 * Create a new shape in the current diagram by automating the creation tool.
+	 * Fails if the shape cannot be created or cannot be found in the diagram after
+	 * creation.
+	 *
+	 * @param type
+	 *            the type of shape to create
+	 * @param location
+	 *            the location (mouse pointer) at which to create the shape
+	 * @param size
+	 *            the size of the shape to create, or {@code null} for the default
+	 *            size as would be created when just clicking in the diagram
+	 * @return the newly created shape edit-part
+	 */
+	protected EditPart createShape(IElementType type, Point location, Dimension size) {
+		lastCreatedEditPart = editor.createShape(type, location, size);
+		return lastCreatedEditPart;
+	}
+
+	/**
+	 * Create a new connection in the current diagram by automating the creation
+	 * tool. Fails if the connection cannot be created or cannot be found in the
+	 * diagram after creation.
+	 *
+	 * @param type
+	 *            the type of shape to create
+	 * @param start
+	 *            the location (mouse pointer) at which to start drawing the
+	 *            connection
+	 * @param finish
+	 *            the location (mouse pointer) at which to finish drawing the
+	 *            connection
+	 * @return the newly created connection edit-part
+	 */
+	protected EditPart createConnection(IElementType type, Point start, Point finish) {
+		lastCreatedEditPart = editor.createConnection(type, start, finish);
+		return lastCreatedEditPart;
+	}
+
+	/**
+	 * Obtain a possibly corrected (for layout weirdness) expected x coördinate for
+	 * assertion of a measured location.
+	 * 
+	 * @param x
+	 *            an expected x coördinate
+	 * @return the proper x coördinate to assert, corrected if necessary for the
+	 *         object being verified
+	 */
+	protected final int x(int x) {
+		return x;
+	}
+
+	/**
+	 * Obtain a possibly corrected (for layout weirdness) expected y coördinate for
+	 * assertion of a measured location.
+	 * 
+	 * @param y
+	 *            an expected y coördinate
+	 * @return the proper y coördinate to assert, corrected if necessary for the
+	 *         object being verified
+	 */
+	protected final int y(int y) {
+		return y + yCorrection();
+	}
+
+	/**
+	 * There are 5 units of vertical error somehow introduced in the calculation of
+	 * the absolute location of a message connection figure attached to the lifeline
+	 * body figure, probably in the calculation of the lifeline body figure's own
+	 * location. Suffice it to say that manual testing shows message connections
+	 * actually being created at the mouse pointer location.
+	 *
+	 * TODO: Find and fix this error which presumably breaks layout calculations
+	 *
+	 * @param y
+	 *            an expected y location for layout assertion
+	 * @return the corrected y location to assert
+	 */
+	protected int yCorrection() {
+		Optional<EObject> semantic = Optional.ofNullable(lastCreatedEditPart)
+				.filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast)
+				.map(IGraphicalEditPart::resolveSemanticElement);
+
+		Switch<Integer> yCorrectionSwitch = new UMLSwitch<Integer>() {
+			@Override
+			public Integer caseExecutionSpecification(ExecutionSpecification object) {
+				return +5;
+			}
+
+			@Override
+			public Integer caseMessage(Message object) {
+				return +5;
+			}
+
+			@Override
+			public Integer defaultCase(EObject object) {
+				return 0;
+			}
+		};
+
+		return semantic.map(yCorrectionSwitch::doSwitch).orElse(0);
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AbstractGraphicalEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AbstractGraphicalEditPolicyUITest.java
@@ -12,19 +12,11 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
 
-import java.util.Optional;
-
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.util.Switch;
 import org.eclipse.gef.EditPart;
-import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture;
-import org.eclipse.uml2.uml.ExecutionSpecification;
-import org.eclipse.uml2.uml.Message;
-import org.eclipse.uml2.uml.util.UMLSwitch;
 import org.junit.After;
 import org.junit.Rule;
 
@@ -92,66 +84,11 @@ public abstract class AbstractGraphicalEditPolicyUITest {
 	}
 
 	/**
-	 * Obtain a possibly corrected (for layout weirdness) expected x coördinate for
-	 * assertion of a measured location.
-	 * 
-	 * @param x
-	 *            an expected x coördinate
-	 * @return the proper x coördinate to assert, corrected if necessary for the
-	 *         object being verified
-	 */
-	protected final int x(int x) {
-		return x;
-	}
-
-	/**
-	 * Obtain a possibly corrected (for layout weirdness) expected y coördinate for
-	 * assertion of a measured location.
-	 * 
-	 * @param y
-	 *            an expected y coördinate
-	 * @return the proper y coördinate to assert, corrected if necessary for the
-	 *         object being verified
-	 */
-	protected final int y(int y) {
-		return y + yCorrection();
-	}
-
-	/**
-	 * There are 5 units of vertical error somehow introduced in the calculation of
-	 * the absolute location of a message connection figure attached to the lifeline
-	 * body figure, probably in the calculation of the lifeline body figure's own
-	 * location. Suffice it to say that manual testing shows message connections
-	 * actually being created at the mouse pointer location.
+	 * Query the last created edit-part.
 	 *
-	 * TODO: Find and fix this error which presumably breaks layout calculations
-	 *
-	 * @param y
-	 *            an expected y location for layout assertion
-	 * @return the corrected y location to assert
+	 * @return the last edit-part created by the test
 	 */
-	protected int yCorrection() {
-		Optional<EObject> semantic = Optional.ofNullable(lastCreatedEditPart)
-				.filter(IGraphicalEditPart.class::isInstance).map(IGraphicalEditPart.class::cast)
-				.map(IGraphicalEditPart::resolveSemanticElement);
-
-		Switch<Integer> yCorrectionSwitch = new UMLSwitch<Integer>() {
-			@Override
-			public Integer caseExecutionSpecification(ExecutionSpecification object) {
-				return +5;
-			}
-
-			@Override
-			public Integer caseMessage(Message object) {
-				return +5;
-			}
-
-			@Override
-			public Integer defaultCase(EObject object) {
-				return 0;
-			}
-		};
-
-		return semantic.map(yCorrectionSwitch::doSwitch).orElse(0);
+	protected EditPart getLastCreatedEditPart() {
+		return lastCreatedEditPart;
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/InteractionCreationEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/InteractionCreationEditPolicyUITest.java
@@ -1,0 +1,52 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isAt;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.DEFAULT_SIZE;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.at;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.isNear;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.InteractionCreationEditPolicy;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.Test;
+
+/**
+ * Integration test cases for the {@link InteractionCreationEditPolicy} class.
+ *
+ * @author Christian W. Damus
+ */
+@SuppressWarnings("restriction")
+@ModelResource("empty.di")
+public class InteractionCreationEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
+
+	/**
+	 * Initializes me.
+	 *
+	 */
+	public InteractionCreationEditPolicyUITest() {
+		super();
+	}
+
+	@Test
+	public void createLifeline() {
+		EditPart lifelineEP = createShape(SequenceElementTypes.Lifeline_Shape, at(99, 90), DEFAULT_SIZE);
+
+		// the Y position is not determined by the input
+		assertThat(lifelineEP, isAt(isNear(99), not(90)));
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineBodyGraphicalNodeEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineBodyGraphicalNodeEditPolicyUITest.java
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.runs;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.at;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineBodyGraphicalNodeEditPolicy;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.Test;
+
+/**
+ * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy}
+ * class.
+ *
+ * @author Christian W. Damus
+ */
+@SuppressWarnings("restriction")
+@ModelResource("two-lifelines.di")
+@Maximized
+public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
+	// Horizontal position of the first lifeline's body
+	private static final int LIFELINE_1_BODY_X = 121;
+
+	// Horizontal position of the second lifeline's body
+	private static final int LIFELINE_2_BODY_X = 281;
+
+	/**
+	 * Initializes me.
+	 *
+	 */
+	public LifelineBodyGraphicalNodeEditPolicyUITest() {
+		super();
+	}
+
+	@Test
+	public void createAsyncMessage() {
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge,
+				at(LIFELINE_1_BODY_X, 115), at(LIFELINE_2_BODY_X, 115));
+
+		assertThat(messageEP, runs(x(LIFELINE_1_BODY_X), y(115), x(LIFELINE_2_BODY_X), y(115), 2));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineBodyGraphicalNodeEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineBodyGraphicalNodeEditPolicyUITest.java
@@ -52,7 +52,7 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge,
 				at(LIFELINE_1_BODY_X, 115), at(LIFELINE_2_BODY_X, 115));
 
-		assertThat(messageEP, runs(x(LIFELINE_1_BODY_X), y(115), x(LIFELINE_2_BODY_X), y(115), 2));
+		assertThat(messageEP, runs(LIFELINE_1_BODY_X, 115, LIFELINE_2_BODY_X, 115, 2));
 	}
 
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineCreationEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineCreationEditPolicyUITest.java
@@ -50,7 +50,7 @@ public class LifelineCreationEditPolicyUITest extends AbstractGraphicalEditPolic
 				at(LIFELINE_2_BODY_X, 115), DEFAULT_SIZE);
 
 		// The 10-unit-wide shape is centred on the lifeline body
-		assertThat(executionEP, isAt(x(LIFELINE_2_BODY_X) - 5, y(115), 2));
+		assertThat(executionEP, isAt(LIFELINE_2_BODY_X - 5, 115, 2));
 	}
 
 	@Test
@@ -59,7 +59,7 @@ public class LifelineCreationEditPolicyUITest extends AbstractGraphicalEditPolic
 				at(LIFELINE_2_BODY_X, 115), DEFAULT_SIZE);
 
 		// The 10-unit-wide shape is centred on the lifeline body
-		assertThat(executionEP, isAt(x(LIFELINE_2_BODY_X) - 5, y(115), 2));
+		assertThat(executionEP, isAt(LIFELINE_2_BODY_X - 5, 115, 2));
 	}
 
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineCreationEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineCreationEditPolicyUITest.java
@@ -1,0 +1,65 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isAt;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.DEFAULT_SIZE;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.at;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineCreationEditPolicy;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.Test;
+
+/**
+ * Integration test cases for the {@link LifelineCreationEditPolicy} class.
+ *
+ * @author Christian W. Damus
+ */
+@SuppressWarnings("restriction")
+@ModelResource("two-lifelines.di")
+@Maximized
+public class LifelineCreationEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
+	// Horizontal position of the second lifeline's body
+	private static final int LIFELINE_2_BODY_X = 281;
+
+	/**
+	 * Initializes me.
+	 *
+	 */
+	public LifelineCreationEditPolicyUITest() {
+		super();
+	}
+
+	@Test
+	public void createActionExecutionSpecification() {
+		EditPart executionEP = createShape(SequenceElementTypes.Action_Execution_Shape,
+				at(LIFELINE_2_BODY_X, 115), DEFAULT_SIZE);
+
+		// The 10-unit-wide shape is centred on the lifeline body
+		assertThat(executionEP, isAt(x(LIFELINE_2_BODY_X) - 5, y(115), 2));
+	}
+
+	@Test
+	public void createBehaviorExecutionSpecification() {
+		EditPart executionEP = createShape(SequenceElementTypes.Behavior_Execution_Shape,
+				at(LIFELINE_2_BODY_X, 115), DEFAULT_SIZE);
+
+		// The 10-unit-wide shape is centred on the lifeline body
+		assertThat(executionEP, isAt(x(LIFELINE_2_BODY_X) - 5, y(115), 2));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/empty.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/empty.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/empty.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/empty.notation
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_SnR90EppEeiB_O7ig5LXPg" type="LightweightSequenceDiagram" name="seq1" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_SnR90UppEeiB_O7ig5LXPg" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_SnR90kppEeiB_O7ig5LXPg" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_SnR900ppEeiB_O7ig5LXPg" type="Interaction_Contents"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SnR91EppEeiB_O7ig5LXPg" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_SnR91UppEeiB_O7ig5LXPg" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_SnR91kppEeiB_O7ig5LXPg"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_SnR910ppEeiB_O7ig5LXPg" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="empty.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="empty.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/empty.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/empty.uml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Oy8JgEppEeiB_O7ig5LXPg" name="lightweight">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_O45nkEppEeiB_O7ig5LXPg">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_R_u1oEppEeiB_O7ig5LXPg" name="DoIt"/>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/two-lifelines.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/two-lifelines.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/two-lifelines.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/two-lifelines.notation
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_SnR90EppEeiB_O7ig5LXPg" type="LightweightSequenceDiagram" name="seq1" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_SnR90UppEeiB_O7ig5LXPg" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_SnR90kppEeiB_O7ig5LXPg" type="Label_Interaction_Name">
+      <element xmi:type="uml:Interaction" href="two-lifelines.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+    </children>
+    <children xmi:type="notation:Compartment" xmi:id="_SnR900ppEeiB_O7ig5LXPg" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_FTODwGpHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_FTODwWpHEeiIJqtZNCF3Dw" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_FTODwmpHEeiIJqtZNCF3Dw" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_FTODw2pHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_FTODxGpHEeiIJqtZNCF3Dw" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="two-lifelines.uml#_FMyroGpHEeiIJqtZNCF3Dw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTODxWpHEeiIJqtZNCF3Dw" x="30" y="20" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_F8jUoGpHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_F8jUoWpHEeiIJqtZNCF3Dw" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_F8jUompHEeiIJqtZNCF3Dw" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_F8jUo2pHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_F8jUpGpHEeiIJqtZNCF3Dw" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="two-lifelines.uml#_F4rhQGpHEeiIJqtZNCF3Dw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F8jUpWpHEeiIJqtZNCF3Dw" x="190" y="20" width="100" height="28"/>
+      </children>
+      <element xmi:type="uml:Interaction" href="two-lifelines.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+    </children>
+    <element xmi:type="uml:Interaction" href="two-lifelines.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SnR91EppEeiB_O7ig5LXPg" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_SnR91UppEeiB_O7ig5LXPg" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_SnR91kppEeiB_O7ig5LXPg"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_SnR910ppEeiB_O7ig5LXPg" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="two-lifelines.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="two-lifelines.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/two-lifelines.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/two-lifelines.notation
@@ -12,7 +12,7 @@
           <layoutConstraint xmi:type="notation:Size" xmi:id="_FTODxGpHEeiIJqtZNCF3Dw" width="2" height="150"/>
         </children>
         <element xmi:type="uml:Lifeline" href="two-lifelines.uml#_FMyroGpHEeiIJqtZNCF3Dw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTODxWpHEeiIJqtZNCF3Dw" x="30" y="20" width="100" height="28"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTODxWpHEeiIJqtZNCF3Dw" x="30" y="25" width="100" height="28"/>
       </children>
       <children xmi:type="notation:Shape" xmi:id="_F8jUoGpHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Header">
         <children xmi:type="notation:Shape" xmi:id="_F8jUoWpHEeiIJqtZNCF3Dw" type="Compartment_Lifeline_Header"/>
@@ -21,7 +21,7 @@
           <layoutConstraint xmi:type="notation:Size" xmi:id="_F8jUpGpHEeiIJqtZNCF3Dw" width="2" height="150"/>
         </children>
         <element xmi:type="uml:Lifeline" href="two-lifelines.uml#_F4rhQGpHEeiIJqtZNCF3Dw"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F8jUpWpHEeiIJqtZNCF3Dw" x="190" y="20" width="100" height="28"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F8jUpWpHEeiIJqtZNCF3Dw" x="190" y="25" width="100" height="28"/>
       </children>
       <element xmi:type="uml:Interaction" href="two-lifelines.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
     </children>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/two-lifelines.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/two-lifelines.uml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Oy8JgEppEeiB_O7ig5LXPg" name="lightweight">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_O45nkEppEeiB_O7ig5LXPg">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_R_u1oEppEeiB_O7ig5LXPg" name="DoIt">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_FMyroGpHEeiIJqtZNCF3Dw" name="Lifeline1"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_F4rhQGpHEeiIJqtZNCF3Dw" name="Lifeline2"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/matchers/GEFMatchers.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/matchers/GEFMatchers.java
@@ -12,12 +12,27 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers;
 
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.isNear;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.draw2d.Connection;
+import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.GraphicalEditPart;
 import org.hamcrest.Description;
+import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.SelfDescribing;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -100,18 +115,22 @@ public class GEFMatchers {
 			@Override
 			protected boolean matchesSafely(Rectangle item, Description mismatchDescription) {
 				if ((x != null) && !x.matches(item.x())) {
+					mismatchDescription.appendText("x ");
 					x.describeMismatch(item.x(), mismatchDescription);
 					return false;
 				}
 				if ((y != null) && !y.matches(item.y())) {
+					mismatchDescription.appendText("y ");
 					y.describeMismatch(item.y(), mismatchDescription);
 					return false;
 				}
 				if ((width != null) && !width.matches(item.width())) {
+					mismatchDescription.appendText("width ");
 					width.describeMismatch(item.width(), mismatchDescription);
 					return false;
 				}
 				if ((height != null) && !height.matches(item.height())) {
+					mismatchDescription.appendText("height ");
 					height.describeMismatch(item.height(), mismatchDescription);
 					return false;
 				}
@@ -176,10 +195,12 @@ public class GEFMatchers {
 			@Override
 			protected boolean matchesSafely(Point item, Description mismatchDescription) {
 				if ((x != null) && !x.matches(item.x())) {
+					mismatchDescription.appendText("x ");
 					x.describeMismatch(item.x(), mismatchDescription);
 					return false;
 				}
 				if ((y != null) && !y.matches(item.y())) {
+					mismatchDescription.appendText("y ");
 					y.describeMismatch(item.y(), mismatchDescription);
 					return false;
 				}
@@ -245,10 +266,12 @@ public class GEFMatchers {
 			@Override
 			protected boolean matchesSafely(Dimension item, Description mismatchDescription) {
 				if ((width != null) && !width.matches(item.width())) {
+					mismatchDescription.appendText("width ");
 					width.describeMismatch(item.width(), mismatchDescription);
 					return false;
 				}
 				if ((height != null) && !height.matches(item.height())) {
+					mismatchDescription.appendText("height ");
 					height.describeMismatch(item.height(), mismatchDescription);
 					return false;
 				}
@@ -256,6 +279,438 @@ public class GEFMatchers {
 				return true;
 			}
 		};
+	}
+
+	/**
+	 * Matcher for a point-list. Every matcher must match some point in the list.
+	 *
+	 * @param where
+	 *            the point matchers
+	 *
+	 * @return the point-list matcher
+	 */
+	@SafeVarargs
+	public static Matcher<PointList> hasPoints(Matcher<? super Point>... where) {
+		return new TypeSafeDiagnosingMatcher<PointList>() {
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("point list that all of");
+				description.appendList(" ", ", ", "", Arrays.asList(where));
+			}
+
+			@Override
+			protected boolean matchesSafely(PointList item, Description mismatchDescription) {
+				List<Point> points = new ArrayList<>(item.size());
+				for (int i = 0; i < item.size(); i++) {
+					points.add(item.getPoint(i));
+				}
+
+				boolean result = false;
+				for (Matcher<? super Point> next : where) {
+					Matcher<Iterable<? super Point>> nextMatcher = hasItem(next);
+
+					result = nextMatcher.matches(points);
+					if (!result) {
+						nextMatcher.describeMismatch(item, mismatchDescription);
+						break; // Nothing more to check
+					}
+				}
+				return false;
+			}
+		};
+	}
+
+	/**
+	 * Matcher for the start and end of point-list.
+	 *
+	 * @param from
+	 *            the start matcher
+	 * @param to
+	 *            the end matcher
+	 *
+	 * @return the point-list matcher
+	 */
+	public static Matcher<PointList> runs(Matcher<? super Point> from, Matcher<? super Point> to) {
+		return new TypeSafeDiagnosingMatcher<PointList>() {
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("point list runs from ");
+				description.appendDescriptionOf(from);
+				description.appendText(" to ");
+				description.appendDescriptionOf(to);
+			}
+
+			@Override
+			protected boolean matchesSafely(PointList item, Description mismatchDescription) {
+				boolean result = from.matches(item.getFirstPoint());
+				if (!result) {
+					from.describeMismatch(item.getFirstPoint(), mismatchDescription);
+				} else {
+					result = to.matches(item.getLastPoint());
+					if (!result) {
+						to.describeMismatch(item.getLastPoint(), mismatchDescription);
+					}
+				}
+				return result;
+			}
+		};
+	}
+
+	/**
+	 * Matcher for the start and end of point-list.
+	 *
+	 * @param fromX,&nbsp;fromY
+	 *            the start point
+	 * @param toX,&nbsp;toY
+	 *            the end point
+	 *
+	 * @return the point-list matcher
+	 */
+	public static Matcher<PointList> runs(int fromX, int fromY, int toX, int toY) {
+		return runs(isPoint(fromX, fromY), isPoint(toX, toY));
+	}
+
+	/**
+	 * Fuzzy matcher for a point.
+	 *
+	 * @param x
+	 *            the expected x location
+	 * @param y
+	 *            the expected y location
+	 * @param tolerance
+	 *            a tolerance for errors in the point coördinate values
+	 *
+	 * @return the point matcher
+	 */
+	public static Matcher<Point> isPoint(int x, int y, int tolerance) {
+		return isPoint(isNear(x, tolerance), isNear(y, tolerance));
+	}
+
+	/**
+	 * Fuzzy matcher for a dimension.
+	 *
+	 * @param width
+	 *            the expected width
+	 * @param height
+	 *            the expected height
+	 * @param tolerance
+	 *            a tolerance for errors in the dimension measures
+	 *
+	 * @return the point matcher
+	 */
+	public static Matcher<Dimension> isSize(int width, int height, int tolerance) {
+		return isSize(isNear(width, tolerance), isNear(height, tolerance));
+	}
+
+	/**
+	 * Fuzzy matcher for a rectangle.
+	 *
+	 * @param x
+	 *            the expected x location
+	 * @param y
+	 *            the expected y location
+	 * @param width
+	 *            the expected width
+	 * @param height
+	 *            the expected height
+	 * @param tolerance
+	 *            a tolerance for errors in the rectangle coördinate values
+	 *
+	 * @return the rectangle matcher
+	 */
+	public static Matcher<Rectangle> isRect(int x, int y, int width, int height, int tolerance) {
+		return isRect(isNear(x, tolerance), isNear(y, tolerance), isNear(width, tolerance),
+				isNear(height, tolerance));
+	}
+
+	/**
+	 * Fuzzy matcher for the start and end of point-list.
+	 *
+	 * @param fromX,&nbsp;fromY
+	 *            the start point
+	 * @param toX,&nbsp;toY
+	 *            the end point
+	 * @param tolerance
+	 *            a tolerance for errors in the point coördinate values
+	 *
+	 * @return the point-list matcher
+	 */
+	public static Matcher<PointList> runs(int fromX, int fromY, int toX, int toY, int tolerance) {
+		return runs(isPoint(fromX, fromY, tolerance), isPoint(toX, toY, tolerance));
+	}
+
+	static <T> Matcher<T> isAt(Matcher<? super Point> where, Function<? super T, ? extends Point> point) {
+		return new FeatureMatcher<T, Point>(where, "location", "location") {
+			@Override
+			protected Point featureValueOf(T actual) {
+				return point.apply(actual);
+			}
+		};
+	}
+
+	static <T> Matcher<T> isSized(Matcher<? super Dimension> what,
+			Function<? super T, ? extends Dimension> dimension) {
+		return new FeatureMatcher<T, Dimension>(what, "size", "size") {
+			@Override
+			protected Dimension featureValueOf(T actual) {
+				return dimension.apply(actual);
+			}
+		};
+	}
+
+	static <T> Matcher<T> isBounded(Matcher<? super Rectangle> how,
+			Function<? super T, ? extends Rectangle> rectangle) {
+		return new FeatureMatcher<T, Rectangle>(how, "bounds", "bounds") {
+			@Override
+			protected Rectangle featureValueOf(T actual) {
+				return rectangle.apply(actual);
+			}
+		};
+	}
+
+	static <T> Matcher<T> runs(Matcher<? super PointList> where,
+			Function<? super T, ? extends PointList> points) {
+		return new FeatureMatcher<T, PointList>(where, "points", "points") {
+			@Override
+			protected PointList featureValueOf(T actual) {
+				return points.apply(actual);
+			}
+		};
+	}
+
+	static Function<Rectangle, Point> location() {
+		return Rectangle::getLocation;
+	}
+
+	static Function<Rectangle, Dimension> size() {
+		return Rectangle::getSize;
+	}
+
+	static Function<IFigure, Rectangle> bounds() {
+		return figure -> {
+			Rectangle result = figure.getBounds().getCopy();
+			figure.getParent().translateToAbsolute(result); // Assertions are in absolute terms
+			return result;
+		};
+	}
+
+	static Function<IFigure, Point> figureLocation() {
+		return location().compose(bounds());
+	}
+
+	static Function<IFigure, Dimension> figureSize() {
+		return size().compose(bounds());
+	}
+
+	static Function<Object, GraphicalEditPart> graphical() {
+		return cast(GraphicalEditPart.class);
+	}
+
+	private static <T> Function<Object, T> cast(Class<? extends T> type) {
+		return obj -> {
+			assertThat(obj, instanceOf(type));
+			return type.cast(obj);
+		};
+	}
+
+	static Function<GraphicalEditPart, IFigure> figure() {
+		return GraphicalEditPart::getFigure;
+	}
+
+	static Function<EditPart, IFigure> editPartFigure() {
+		return figure().compose(graphical());
+	}
+
+	static Function<EditPart, Rectangle> editPartBounds() {
+		return bounds().compose(editPartFigure());
+	}
+
+	static Function<EditPart, Point> editPartLocation() {
+		return figureLocation().compose(editPartFigure());
+	}
+
+	static Function<EditPart, Dimension> editPartSize() {
+		return figureSize().compose(editPartFigure());
+	}
+
+	static Function<Connection, PointList> points() {
+		return Connection::getPoints;
+	}
+
+	static Function<Object, Connection> connection() {
+		return cast(Connection.class);
+	}
+
+	static Function<IFigure, PointList> figurePoints() {
+		return points().compose(connection());
+	}
+
+	static Function<EditPart, Connection> editPartConnection() {
+		return connection().compose(editPartFigure());
+	}
+
+	static Function<EditPart, PointList> editPartPoints() {
+		return points().compose(editPartConnection());
+	}
+
+	/**
+	 * Assertions on the geometry of GEF figures. All coördinates are in absolute
+	 * space, as is the convention of the <em>Logical Model</em>.
+	 */
+	public static class Figures {
+
+		private Figures() {
+			super();
+		}
+
+		public static Matcher<IFigure> isAt(Matcher<? super Point> where) {
+			return GEFMatchers.isAt(where, figureLocation());
+		}
+
+		public static Matcher<IFigure> isAt(int x, int y) {
+			return isAt(isPoint(x, y));
+		}
+
+		public static Matcher<IFigure> isAt(int x, int y, int tolerance) {
+			return isAt(isPoint(x, y, tolerance));
+		}
+
+		public static Matcher<IFigure> isAt(Matcher<? super Integer> x, Matcher<? super Integer> y) {
+			return isAt(isPoint(x, y));
+		}
+
+		public static Matcher<IFigure> isSized(Matcher<? super Dimension> what) {
+			return isSized(what);
+		}
+
+		public static Matcher<IFigure> isSized(int width, int height) {
+			return isSized(isSize(width, height));
+		}
+
+		public static Matcher<IFigure> isSized(int width, int height, int tolerance) {
+			return isSized(isSize(width, height, tolerance));
+		}
+
+		public static Matcher<IFigure> isSized(Matcher<? super Integer> width,
+				Matcher<? super Integer> height) {
+			return isSized(isSize(width, height));
+		}
+
+		public static Matcher<IFigure> isBounded(Matcher<? super Rectangle> how) {
+			return GEFMatchers.isBounded(how, bounds());
+		}
+
+		public static Matcher<IFigure> isBounded(int x, int y, int width, int height) {
+			return isBounded(isRect(x, y, width, height));
+		}
+
+		public static Matcher<IFigure> isBounded(int x, int y, int width, int height, int tolerance) {
+			return isBounded(isRect(x, y, width, height, tolerance));
+		}
+
+		public static Matcher<IFigure> isBounded(Matcher<? super Integer> x, Matcher<? super Integer> y,
+				Matcher<? super Integer> width, Matcher<? super Integer> height) {
+			return isBounded(isRect(x, y, width, height));
+		}
+
+		@SafeVarargs
+		public static Matcher<IFigure> hasPoints(Matcher<? super Point>... where) {
+			return GEFMatchers.runs(GEFMatchers.hasPoints(where), figurePoints());
+		}
+
+		public static Matcher<IFigure> runs(Matcher<? super Point> from, Matcher<? super Point> to) {
+			return GEFMatchers.runs(GEFMatchers.runs(from, to), figurePoints());
+		}
+
+		public static Matcher<IFigure> runs(int fromX, int fromY, int toX, int toY) {
+			return GEFMatchers.runs(GEFMatchers.runs(fromX, fromY, toX, toY), figurePoints());
+		}
+
+		public static Matcher<IFigure> runs(int fromX, int fromY, int toX, int toY, int tolerance) {
+			return GEFMatchers.runs(GEFMatchers.runs(fromX, fromY, toX, toY, tolerance), figurePoints());
+		}
+
+	}
+
+	/**
+	 * Assertions on the geometry of GEF edit-parts. All coördinates are in absolute
+	 * space, as is the convention of the <em>Logical Model</em>.
+	 */
+	public static class EditParts {
+
+		private EditParts() {
+			super();
+		}
+
+		public static Matcher<EditPart> isAt(Matcher<? super Point> where) {
+			return GEFMatchers.isAt(where, editPartLocation());
+		}
+
+		public static Matcher<EditPart> isAt(int x, int y) {
+			return isAt(isPoint(x, y));
+		}
+
+		public static Matcher<EditPart> isAt(int x, int y, int tolerance) {
+			return isAt(isPoint(x, y, tolerance));
+		}
+
+		public static Matcher<EditPart> isAt(Matcher<? super Integer> x, Matcher<? super Integer> y) {
+			return isAt(isPoint(x, y));
+		}
+
+		public static Matcher<EditPart> isSized(Matcher<? super Dimension> what) {
+			return GEFMatchers.isSized(what, editPartSize());
+		}
+
+		public static Matcher<EditPart> isSized(int width, int height) {
+			return isSized(isSize(width, height));
+		}
+
+		public static Matcher<EditPart> isSized(int width, int height, int tolerance) {
+			return isSized(isSize(width, height, tolerance));
+		}
+
+		public static Matcher<EditPart> isSized(Matcher<? super Integer> width,
+				Matcher<? super Integer> height) {
+			return isSized(isSize(width, height));
+		}
+
+		public static Matcher<EditPart> isBounded(Matcher<? super Rectangle> how) {
+			return GEFMatchers.isBounded(how, editPartBounds());
+		}
+
+		public static Matcher<EditPart> isBounded(int x, int y, int width, int height) {
+			return isBounded(isRect(x, y, width, height));
+		}
+
+		public static Matcher<EditPart> isBounded(int x, int y, int width, int height, int tolerance) {
+			return isBounded(isRect(x, y, width, height, tolerance));
+		}
+
+		public static Matcher<EditPart> isBounded(Matcher<? super Integer> x, Matcher<? super Integer> y,
+				Matcher<? super Integer> width, Matcher<? super Integer> height) {
+			return isBounded(isRect(x, y, width, height));
+		}
+
+		@SafeVarargs
+		public static Matcher<EditPart> hasPoints(Matcher<? super Point>... where) {
+			return GEFMatchers.runs(GEFMatchers.hasPoints(where), editPartPoints());
+		}
+
+		public static Matcher<EditPart> runs(Matcher<? super Point> from, Matcher<? super Point> to) {
+			return GEFMatchers.runs(GEFMatchers.runs(from, to), editPartPoints());
+		}
+
+		public static Matcher<EditPart> runs(int fromX, int fromY, int toX, int toY) {
+			return GEFMatchers.runs(GEFMatchers.runs(fromX, fromY, toX, toY), editPartPoints());
+		}
+
+		public static Matcher<EditPart> runs(int fromX, int fromY, int toX, int toY, int tolerance) {
+			return GEFMatchers.runs(GEFMatchers.runs(fromX, fromY, toX, toY, tolerance), editPartPoints());
+		}
+
 	}
 
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/EditorFixture.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/EditorFixture.java
@@ -1,0 +1,472 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.fail;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.gef.ConnectionEditPart;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramEditor;
+import org.eclipse.gmf.runtime.emf.type.core.IElementType;
+import org.eclipse.gmf.runtime.notation.Diagram;
+import org.eclipse.papyrus.infra.core.sasheditor.di.contentprovider.utils.IPageUtils;
+import org.eclipse.papyrus.infra.core.sasheditor.editor.IEditorPage;
+import org.eclipse.papyrus.infra.core.sasheditor.editor.IPage;
+import org.eclipse.papyrus.infra.core.sasheditor.editor.ISashWindowsContainer;
+import org.eclipse.papyrus.infra.core.sashwindows.di.service.IPageManager;
+import org.eclipse.papyrus.infra.gmfdiag.common.service.palette.AspectUnspecifiedTypeConnectionTool;
+import org.eclipse.papyrus.infra.gmfdiag.common.service.palette.AspectUnspecifiedTypeCreationTool;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IViewReference;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+import org.junit.runner.Description;
+
+/**
+ * This is the {@code EditorFixture} type. Enjoy.
+ *
+ * @author Christian W. Damus
+ */
+public class EditorFixture extends ModelFixture {
+
+	/** Default size of a shape to create or set. */
+	public static final Dimension DEFAULT_SIZE = null;
+
+	private IProject project;
+	private IFile diFile;
+	private IEditorPart editor;
+	private boolean isMaximized;
+
+	/**
+	 * Initializes me.
+	 *
+	 * @param testClass
+	 * @param path
+	 */
+	public EditorFixture(Class<?> testClass, String path) {
+		super(testClass, path);
+	}
+
+	/**
+	 * Initializes me.
+	 *
+	 * @param path
+	 */
+	public EditorFixture(String path) {
+		super(path);
+	}
+
+	/**
+	 * Initializes me.
+	 *
+	 */
+	public EditorFixture() {
+		super();
+	}
+
+	//
+	// Test fixture lifecycle
+	//
+
+	@Override
+	protected String[] getPaths(Description description) {
+		String[] result = super.getPaths(description);
+
+		if ((result.length == 1) && result[0].endsWith(".di")) {
+			String base = result[0].substring(0, result[0].lastIndexOf('.'));
+			result = Stream.of(".di", ".uml", ".notation").map(ext -> base + ext).toArray(String[]::new);
+
+			// Initialize the project resources
+			for (String path : result) {
+				getResourceURL(description, path);
+			}
+		} else {
+			fail("Test does not specify exactly one DI resource.");
+		}
+
+		return result;
+	}
+
+	@Override
+	protected void starting(Description description) {
+		Optional<Maximized> maximized = getAnnotation(description, Maximized.class);
+		maximized.ifPresent(max -> isMaximized = max.value());
+
+		super.starting(description);
+
+		try {
+			// Open the diagram
+			IPageManager pageManager = editor.getAdapter(IPageManager.class);
+			Diagram diagram = requireSequenceDiagram();
+
+			if (pageManager.isOpen(diagram)) {
+				pageManager.selectPage(diagram);
+			} else {
+				pageManager.openPage(diagram);
+			}
+		} finally {
+			flushDisplayEvents();
+		}
+	}
+
+	@Override
+	protected ResourceSet createResourceSet() {
+		IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+
+		try {
+			// Close the Welcome view
+			IViewReference welcome = page.findViewReference("org.eclipse.ui.internal.introview");
+			if (welcome != null) {
+				page.hideView(welcome);
+			}
+
+			// Open the editor
+			editor = IDE.openEditor(page, diFile);
+			if (isMaximized) {
+				page.setPartState(page.getReference(editor), IWorkbenchPage.STATE_MAXIMIZED);
+			}
+		} catch (PartInitException e) {
+			e.printStackTrace();
+			fail("Failed to open Papyrus editor: " + e.getMessage());
+		} finally {
+			flushDisplayEvents();
+		}
+
+		EditingDomain editingDomain = editor.getAdapter(EditingDomain.class);
+		return editingDomain.getResourceSet();
+	}
+
+	@Override
+	protected URL getResourceURL(Description description, String path) {
+		IProject project = getProject(description);
+		IFile file = project.getFile(path);
+
+		if (!file.exists()) {
+			URL sourceURL = super.getResourceURL(description, path);
+
+			try {
+				try (InputStream input = sourceURL.openStream()) {
+					file.create(input, true, null);
+				}
+
+				if ("di".equals(file.getFileExtension())) {
+					// Remember it
+					diFile = file;
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+				fail("Failed to create or access test resource: " + e.getMessage());
+				return null; // Unreachable
+			}
+		}
+
+		try {
+			return new URL(URI.createPlatformResourceURI(file.getFullPath().toString(), true).toString());
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail("Failed to access test resource: " + e.getMessage());
+			return null; // Unreachable
+		}
+	}
+
+	protected IProject getProject(Description description) {
+		if (project == null) {
+			project = ResourcesPlugin.getWorkspace().getRoot().getProject(description.getMethodName());
+
+			try {
+				if (!project.exists()) {
+					project.create(null);
+				}
+				if (!project.isAccessible()) {
+					project.open(null);
+				}
+			} catch (CoreException e) {
+				e.printStackTrace();
+				fail("Failed to create/open project: " + e.getMessage());
+			}
+		}
+
+		return project;
+	}
+
+	@Override
+	protected void finished(Description description) {
+		super.finished(description);
+
+		if (editor != null) {
+			editor.getSite().getPage().closeEditor(editor, false);
+		}
+		if (project != null) {
+			try {
+				project.delete(true, true, null);
+			} catch (CoreException e) {
+				e.printStackTrace();
+				// Best effort
+			}
+		}
+	}
+
+	//
+	// Test step operations
+	//
+
+	/**
+	 * Create a new shape in the current diagram by automating the creation tool.
+	 * Fails if the shape cannot be created or cannot be found in the diagram after
+	 * creation.
+	 *
+	 * @param type
+	 *            the type of shape to create
+	 * @param location
+	 *            the location (mouse pointer) at which to create the shape
+	 * @param size
+	 *            the size of the shape to create, or {@code null} for the default
+	 *            size as would be created when just clicking in the diagram
+	 * @return the newly created shape edit-part
+	 */
+	public EditPart createShape(IElementType type, Point location, Dimension size) {
+		DiagramEditPart diagram = getDiagramEditPart();
+		EditPartViewer viewer = diagram.getViewer();
+
+		@SuppressWarnings("unchecked")
+		Set<EditPart> originalEditParts = new HashSet<EditPart>(viewer.getEditPartRegistry().values());
+
+		AspectUnspecifiedTypeCreationTool tool = new AspectUnspecifiedTypeCreationTool(singletonList(type));
+
+		Event mouse = new Event();
+		mouse.display = editor.getSite().getShell().getDisplay();
+		mouse.widget = viewer.getControl();
+		mouse.x = location.x();
+		mouse.y = location.y();
+
+		viewer.getEditDomain().setActiveTool(tool);
+		tool.setViewer(viewer);
+
+		// Move the mouse to the click location
+		mouse.type = SWT.MouseMove;
+		tool.mouseMove(new MouseEvent(mouse), viewer);
+
+		// Start the click
+		mouse.button = 1;
+		mouse.type = SWT.MouseDown;
+		tool.mouseDown(new MouseEvent(mouse), viewer);
+
+		flushDisplayEvents();
+
+		if (size == DEFAULT_SIZE) {
+			// Just a click
+			mouse.type = SWT.MouseUp;
+			tool.mouseUp(new MouseEvent(mouse), viewer);
+		} else {
+			// Drag and release
+			mouse.type = SWT.MouseMove;
+			mouse.x = location.x() + size.width();
+			mouse.y = location.y() + size.height();
+			tool.mouseDrag(new MouseEvent(mouse), viewer);
+
+			flushDisplayEvents();
+
+			mouse.type = SWT.MouseUp;
+			tool.mouseUp(new MouseEvent(mouse), viewer);
+		}
+
+		flushDisplayEvents();
+
+		// Find the new edit-part
+		@SuppressWarnings("unchecked")
+		Set<EditPart> newEditParts = new HashSet<EditPart>(viewer.getEditPartRegistry().values());
+		newEditParts.removeAll(originalEditParts);
+		while (newEditParts.removeIf(ep -> newEditParts.contains(ep.getParent()))) {
+			// Keep only the topmost new edit-parts (that aren't nested in other new
+			// edit-parts)
+		}
+
+		return newEditParts.stream().findFirst().orElseGet(failOnAbsence("New edit-part not found"));
+	}
+
+	/**
+	 * Create a new connection in the current diagram by automating the creation
+	 * tool. Fails if the connection cannot be created or cannot be found in the
+	 * diagram after creation.
+	 *
+	 * @param type
+	 *            the type of shape to create
+	 * @param start
+	 *            the location (mouse pointer) at which to start drawing the
+	 *            connection
+	 * @param finish
+	 *            the location (mouse pointer) at which to finish drawing the
+	 *            connection
+	 * @return the newly created connection edit-part
+	 */
+	public EditPart createConnection(IElementType type, Point start, Point finish) {
+		DiagramEditPart diagram = getDiagramEditPart();
+		EditPartViewer viewer = diagram.getViewer();
+
+		@SuppressWarnings("unchecked")
+		Set<EditPart> originalEditParts = new HashSet<EditPart>(viewer.getEditPartRegistry().values());
+
+		AspectUnspecifiedTypeConnectionTool tool = new AspectUnspecifiedTypeConnectionTool(
+				singletonList(type));
+
+		Event mouse = new Event();
+		mouse.display = editor.getSite().getShell().getDisplay();
+		mouse.widget = viewer.getControl();
+		mouse.x = start.x();
+		mouse.y = start.y();
+
+		viewer.getEditDomain().setActiveTool(tool);
+		tool.setViewer(viewer);
+
+		// Move the mouse to the start location
+		mouse.type = SWT.MouseMove;
+		tool.mouseMove(new MouseEvent(mouse), viewer);
+
+		// Click
+		mouse.button = 1;
+		mouse.type = SWT.MouseDown;
+		tool.mouseDown(new MouseEvent(mouse), viewer);
+		mouse.type = SWT.MouseUp;
+		tool.mouseUp(new MouseEvent(mouse), viewer);
+
+		flushDisplayEvents();
+
+		// Move and click again
+		mouse.type = SWT.MouseMove;
+		mouse.button = 0;
+		mouse.x = finish.x();
+		mouse.y = finish.y();
+		tool.mouseMove(new MouseEvent(mouse), viewer);
+
+		flushDisplayEvents();
+
+		mouse.button = 1;
+		mouse.type = SWT.MouseDown;
+		tool.mouseDown(new MouseEvent(mouse), viewer);
+		mouse.type = SWT.MouseUp;
+		tool.mouseUp(new MouseEvent(mouse), viewer);
+
+		flushDisplayEvents();
+
+		// Find the new edit-part
+		@SuppressWarnings("unchecked")
+		Set<EditPart> newEditParts = new HashSet<EditPart>(viewer.getEditPartRegistry().values());
+		newEditParts.removeAll(originalEditParts);
+		while (newEditParts.removeIf(ep -> !(ep instanceof ConnectionEditPart))) {
+			// Keep only the topmost new edit-parts (that aren't nested in other new
+			// edit-parts)
+		}
+
+		return newEditParts.stream().findFirst()
+				.orElseGet(failOnAbsence("New connection edit-part not found"));
+	}
+
+	//
+	// Utilities
+	//
+
+	public final void flushDisplayEvents() {
+		Display display = Display.getCurrent();
+		while (display.readAndDispatch()) {
+			// Pass
+		}
+	}
+
+	public void maximize() {
+		IWorkbenchPage page = editor.getSite().getPage();
+		page.setPartState(page.getReference(editor), IWorkbenchPage.STATE_MAXIMIZED);
+		flushDisplayEvents();
+	}
+
+	public final Diagram requireSequenceDiagram() {
+		return getSequenceDiagram().orElseGet(failOnAbsence("No sequence diagram in the test model."));
+	}
+
+	public DiagramEditPart getDiagramEditPart() {
+		ISashWindowsContainer sashContainer = editor.getAdapter(ISashWindowsContainer.class);
+		IPage page = IPageUtils.lookupModelPage(sashContainer, requireSequenceDiagram());
+		return Optional.ofNullable(page).filter(IEditorPage.class::isInstance).map(IEditorPage.class::cast)
+				.map(IEditorPage::getIEditorPart).filter(DiagramEditor.class::isInstance)
+				.map(DiagramEditor.class::cast).map(DiagramEditor::getDiagramEditPart)
+				.orElseGet(failOnAbsence("Sequence diagram not open."));
+	}
+
+	/**
+	 * Obtain a fake supplier that just fails the test with the given
+	 * {@code message} instead of supplying a result.
+	 *
+	 * @param message
+	 *            the failure message
+	 * @return the fake supplier
+	 */
+	private static <T> Supplier<T> failOnAbsence(String message) {
+		return () -> {
+			fail(message);
+			return null;
+		};
+	}
+
+	/**
+	 * Create a point location (useful as a static import for test readability).
+	 *
+	 * @param x
+	 *            the x coördinate
+	 * @param y
+	 *            the y coördinate
+	 * @return the point
+	 */
+	public static Point at(int x, int y) {
+		return new Point(x, y);
+	}
+
+	/**
+	 * Create a size dimension (useful as a static import for test readability).
+	 *
+	 * @param width
+	 *            the size width
+	 * @param height
+	 *            the the size height
+	 * @return the size
+	 */
+	public static Dimension sized(int width, int height) {
+		return new Dimension(width, height);
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/Maximized.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/Maximized.java
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation indicating whether the editor is to be maximized for the test.
+ *
+ * @author Christian W. Damus
+ */
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+public @interface Maximized {
+	/** Whether to maximize the editor. */
+	boolean value() default true;
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/matchers/NumberMatchers.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/matchers/NumberMatchers.java
@@ -1,0 +1,156 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.tests.matchers;
+
+import static java.lang.Math.abs;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+/**
+ * Matchers for numeric values.
+ *
+ * @author Christian W. Damus
+ */
+public class NumberMatchers {
+
+	private static AtomicReference<Double> standardTolerance = new AtomicReference<>(1.0);
+
+	/**
+	 * Not instantiable by clients.
+	 */
+	private NumberMatchers() {
+		super();
+	}
+
+	/**
+	 * Obtain a matcher asserting that a number is near to some expected quantity (a
+	 * fuzzy match).
+	 *
+	 * @param expected
+	 *            the expected value
+	 * @param tolerance
+	 *            a non-negative tolerance for error
+	 * @return the fuzzy matcher
+	 */
+	public static <N extends Number & Comparable<N>> Matcher<N> isNear(N expected, N tolerance) {
+		String message = String.format("%s ± %s", expected, requireNonNegative(tolerance));
+
+		if ((expected instanceof Double) || (expected instanceof Float)) {
+			return NumberMatchers.<N>isNear(message,
+					nearDouble(expected.doubleValue(), tolerance.doubleValue()));
+		}
+
+		return NumberMatchers.<N>isNear(message, nearLong(expected.longValue(), tolerance.longValue()));
+	}
+
+	private static <N extends Number & Comparable<N>> N requireNonNegative(N value) {
+		// Assume not (we don't work with BigDecimals etc.)
+		N result = null;
+
+		if ((value instanceof Double) || (value instanceof Float)) {
+			result = value.doubleValue() >= 0.0 ? value : null;
+		} else if ((value instanceof Long) || (value instanceof Integer) || (value instanceof Short)
+				|| (value instanceof Byte)) {
+			result = value.intValue() >= 0 ? value : null;
+		}
+
+		if (result == null) {
+			throw new IllegalArgumentException("negative tolerance " + value);
+		}
+
+		return result;
+	}
+
+	private static <N extends Number & Comparable<N>> Matcher<N> isNear(String message,
+			Predicate<? super N> predicate) {
+
+		return new BaseMatcher<N>() {
+			@Override
+			public void describeTo(Description description) {
+				description.appendText(message);
+			}
+
+			@Override
+			public boolean matches(Object item) {
+				@SuppressWarnings("unchecked")
+				N actual = (N) item;
+				return predicate.test(actual);
+			}
+		};
+	}
+
+	private static <N extends Number & Comparable<N>> Predicate<N> nearDouble(double expected,
+			double tolerance) {
+		return actual -> abs(actual.doubleValue() - expected) <= tolerance;
+	}
+
+	private static <N extends Number & Comparable<N>> Predicate<N> nearLong(long expected, long tolerance) {
+		return actual -> abs(actual.longValue() - expected) <= tolerance;
+	}
+
+	/**
+	 * Obtain a matcher asserting that a number is within the
+	 * {@linkplain #getStandardTolerance() standard tolerance} of some expected
+	 * quantity.
+	 *
+	 * @param expected
+	 *            the expected value
+	 * @return the fuzzy matcher
+	 */
+	public static <N extends Number & Comparable<N>> Matcher<N> isNear(N expected) {
+
+		if ((expected instanceof Double) || (expected instanceof Float)) {
+			String message = String.format("%s ± %s", expected, getStandardTolerance());
+			return NumberMatchers.<N>isNear(message,
+					nearDouble(expected.doubleValue(), getStandardTolerance()));
+		}
+
+		String message = String.format("%s ± %s", expected, (long) getStandardTolerance());
+		return NumberMatchers.<N>isNear(message,
+				nearLong(expected.longValue(), (long) getStandardTolerance()));
+	}
+
+	/**
+	 * Queries the standard tolerance for fuzzy assertions, especially for such
+	 * common tasks as verifying geometries in diagrams that can be off according to
+	 * HW/SW platform variability. The default standard tolerance is one
+	 * (<tt>1.0</tt>).
+	 *
+	 * @return the current standard tolerance
+	 *
+	 * @see #setStandardTolerance(double)
+	 */
+	public static double getStandardTolerance() {
+		return standardTolerance.get();
+	}
+
+	/**
+	 * Changes the standard tolerance for fuzzy assertions, especially for such
+	 * common tasks as verifying geometries in diagrams that can be off according to
+	 * HW/SW platform variability.
+	 *
+	 * @param tolerance
+	 *            the new current standard tolerance
+	 * @return the previous value of the standard tolerance
+	 *
+	 * @see #getStandardTolerance()
+	 */
+	public static double setStandardTolerance(double tolerance) {
+		return standardTolerance.getAndSet(requireNonNegative(tolerance));
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionOccurrenceTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionOccurrenceTest.java
@@ -135,7 +135,8 @@ public class MExecutionOccurrenceTest extends MOccurrenceTest {
 
 	@Override
 	public void testGetTop() {
-		assertThat(getFixture().getTop(), isPresent(75));
+		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {execution y}
+		assertThat(getFixture().getTop(), isPresent(117));
 	}
 
 	@Override

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionTest.java
@@ -114,17 +114,18 @@ public class MExecutionTest extends MElementTest {
 
 	@Override
 	public void testGetTop() {
-		assertThat(getFixture().getTop(), isPresent(75));
+		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {y}
+		assertThat(getFixture().getTop(), isPresent(117));
 	}
 
 	@Override
 	public void testGetBottom() {
-		assertThat(getFixture().getBottom(), isPresent(225));
+		assertThat(getFixture().getBottom(), isPresent(267)); // 117 {top} + 150 {height}
 	}
 
 	@Override
 	public void testVerticalDistance__MElement() {
-		// The lifeline header has a specified height
+		// Distance from the bottom of the lifeline header is just the y position in the notation
 		assertThat(getFixture().verticalDistance(getFixture().getOwner()), isPresent(25));
 		assertThat(getFixture().verticalDistance(getFixture().getStart().get()), isPresent(0));
 	}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MInteractionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MInteractionTest.java
@@ -248,11 +248,11 @@ public class MInteractionTest extends MElementTest {
 		MLifeline left = getFixture().getLifeline(umlInteraction.getLifeline("LeftLine")).get();
 		MLifeline right = getFixture().getLifeline(umlInteraction.getLifeline("RightLine")).get();
 
-		assertThat("Direct hit on right not found", getFixture().getLifelineAt(200), isPresent(is(right)));
-		assertThat("Between the lifelines not found", getFixture().getLifelineAt(160), isPresent(is(right)));
-		assertThat("Direct hit on left not found	", getFixture().getLifelineAt(100), isPresent(is(left)));
-		assertThat("Left of the leftmost not found", getFixture().getLifelineAt(15), isPresent(is(left)));
-		assertThat("Right of the righmost was found", getFixture().getLifelineAt(400), not(isPresent()));
+		assertThat("Direct hit on right not found", getFixture().getLifelineAt(237), isPresent(is(right)));
+		assertThat("Between the lifelines not found", getFixture().getLifelineAt(197), isPresent(is(right)));
+		assertThat("Direct hit on left not found	", getFixture().getLifelineAt(137), isPresent(is(left)));
+		assertThat("Left of the leftmost not found", getFixture().getLifelineAt(52), isPresent(is(left)));
+		assertThat("Right of the righmost was found", getFixture().getLifelineAt(437), not(isPresent()));
 	}
 
 } // MInteractionTest

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MLifelineTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MLifelineTest.java
@@ -156,7 +156,7 @@ public class MLifelineTest extends MElementTest {
 	 * @generated NOT
 	 */
 	public void testGetLeft() {
-		assertThat(getFixture().getLeft(), isPresent(173));
+		assertThat(getFixture().getLeft(), isPresent(215)); // 37 {frame} + 5 {viewport} + 173 {x}
 	}
 
 	/**
@@ -167,7 +167,7 @@ public class MLifelineTest extends MElementTest {
 	 * @generated NOT
 	 */
 	public void testGetRight() {
-		assertThat(getFixture().getRight(), isPresent(257)); // 173 {left} + 88 {width}
+		assertThat(getFixture().getRight(), isPresent(299)); // 215 {left} + 84 {width}
 	}
 
 	@Override
@@ -210,13 +210,13 @@ public class MLifelineTest extends MElementTest {
 
 	@Override
 	public void testGetTop() {
-		assertThat(getFixture().getTop(), isPresent(25));
+		assertThat(getFixture().getTop(), isPresent(67)); // 12 {frame} + 30 {title} + {25} y
 	}
 
 	@Override
 	public void testGetBottom() {
 		// The lifeline header has a specified height
-		assertThat(getFixture().getBottom(), isPresent(50));
+		assertThat(getFixture().getBottom(), isPresent(92)); // 67 {top} + 25 {height}
 	}
 
 	@Override
@@ -305,8 +305,9 @@ public class MLifelineTest extends MElementTest {
 		ExecutionSpecification execSpec = create(command);
 		MExecution exec = getFixture().getExecution(execSpec).get();
 
-		assertThat(exec.getTop(), isPresent(240));
-		assertThat(exec.getBottom(), isPresent(290));
+		// 267 {message} + 15 {offset}
+		assertThat(exec.getTop(), isPresent(282));
+		assertThat(exec.getBottom(), isPresent(332));
 		assertThat(exec.getElement(), instanceOf(ActionExecutionSpecification.class));
 		assertThat(((ActionExecutionSpecification)exec.getElement()).getAction(), is(action));
 	}
@@ -329,8 +330,9 @@ public class MLifelineTest extends MElementTest {
 		ExecutionSpecification execSpec = create(command);
 		MExecution exec = getFixture().getExecution(execSpec).get();
 
-		assertThat(exec.getTop(), isPresent(240));
-		assertThat(exec.getBottom(), isPresent(290));
+		// 267 {message} + 15 {offset}
+		assertThat(exec.getTop(), isPresent(282));
+		assertThat(exec.getBottom(), isPresent(332));
 		assertThat(exec.getElement(), instanceOf(ActionExecutionSpecification.class));
 
 		// We didn't actually supply the action, as such
@@ -358,8 +360,9 @@ public class MLifelineTest extends MElementTest {
 		Message umlMessage = create(command);
 		MMessage message = interaction.getMessage(umlMessage).get();
 
-		assertThat(message.getTop(), isPresent(240));
-		assertThat(message.getBottom(), isPresent(240));
+		// 267 {message} + 15 {offset}
+		assertThat(message.getTop(), isPresent(282));
+		assertThat(message.getBottom(), isPresent(282));
 		assertThat(umlMessage.getSignature(), is(operation));
 		assertThat(umlMessage.getMessageSort(), is(MessageSort.ASYNCH_CALL_LITERAL));
 		assertThat(umlMessage.getMessageKind(), is(MessageKind.COMPLETE_LITERAL));

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageEndTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageEndTest.java
@@ -121,7 +121,8 @@ public class MMessageEndTest extends MOccurrenceTest {
 
 	@Override
 	public void testGetTop() {
-		assertThat(getFixture().getTop(), isPresent(75));
+		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {anchor}
+		assertThat(getFixture().getTop(), isPresent(117));
 	}
 
 	@Override

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageTest.java
@@ -116,12 +116,14 @@ public class MMessageTest extends MElementTest {
 
 	@Override
 	public void testGetTop() {
-		assertThat(getFixture().getTop(), isPresent(75));
+		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {anchor}
+		assertThat(getFixture().getTop(), isPresent(117));
 	}
 
 	@Override
 	public void testGetBottom() {
-		assertThat(getFixture().getBottom(), isPresent(75));
+		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {anchor}
+		assertThat(getFixture().getBottom(), isPresent(117));
 	}
 
 	@Override

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/DefaultLayoutHelperTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/DefaultLayoutHelperTest.java
@@ -20,6 +20,7 @@ import org.eclipse.gmf.runtime.notation.Bounds;
 import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.NotationFactory;
 import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutConstraints;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutHelper;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
@@ -66,7 +67,7 @@ public class DefaultLayoutHelperTest {
 
 	@Before
 	public void createSUT() {
-		helper = new DefaultLayoutHelper(model.getEditingDomain());
+		helper = new DefaultLayoutHelper(model.getEditingDomain(), DefaultLayoutConstraints::new);
 	}
 
 	@After

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -72,5 +72,48 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	
+	<profiles>
+		<profile>
+			<id>with-papyrus</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<dependency-resolution>
+								<!--  Testing the diagram editor needs the Papyrus SDK
+								      and the LW SeqD contributions to GMF and Papyrus
+								      extension points of various kinds. -->
+								<extraRequirements>
+									<requirement>
+										<type>eclipse-feature</type>
+										<id>org.eclipse.papyrus.sdk.feature</id>
+										<versionRange>0.0.0</versionRange>
+									</requirement>
+									<requirement>
+										<type>eclipse-feature</type>
+										<id>org.eclipse.papyrus.uml.diagram.sequence.contribution.feature</id>
+										<versionRange>0.0.0</versionRange>
+									</requirement>
+									<requirement>
+										<type>eclipse-feature</type>
+										<id>org.eclipse.papyrus.uml.diagram.lightweightsequence.feature</id>
+										<versionRange>0.0.0</versionRange>
+									</requirement>
+								</extraRequirements>
+							</dependency-resolution>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+	
 	<packaging>pom</packaging>
 </project>


### PR DESCRIPTION
*This pull request is based on #301, which now includes the diagram notation objects in the **Logical Model** view.  I found access to the notation details quite helpful in debugging the diagram and developing these tests.*

This pull request comprises two commits:  one that fixes up inconsistencies in translation between local coördinate spaces in the edit-parts and the absolute coördinate space of the *Logical Model*, and one for addition of JUnit tests.

With the first commit, now the placement of elements is more accurate to where the mouse pointer was clicked by the user:

- the left edge of a new lifeline header is now put exactly at the horizontal position of the mouse pointer, and moreover the feed-back rectangle tracks properly with it
- the top edge of a new execution occurrence specification is put exactly at the vertical position of the mouse pointer
- likewise for messages (currently only supporting horizontal messages, so the message is created at the vertical location of the mouse pointer at the source end initiating the message creation)

The JUnit tests comprise three distinct parts:

- a new `EditorFixture` extending the `ModelFixture` to provide test automation and assertions in the diagram editor
- an expansion of the `GEFMatchers` class for assertions on the geometry of *figures* and *edit-parts*
- a suite of tests for the graphical edit-policies responsible for the creation of new lifeline, execution, and message elements in the diagram using these fixtures and assertions

## Help Wanted

One problem that I identified in the development of the tests is that the calculation of the absolute location of execution specification and message *figures* in the diagram (in GEF terms) is off by 5 pixels in the y dimension.  There is no such error in the location of lifeline figures; only figures that are children of or attached to lifeline bodies, so it seems to be some bug in the calculation of the absolute location of the lifeline body, itself.  I have no experience in the geometry of GEF figures and even less with border items, so I would appreciate help in finding where is the root cause of this error.

Currently, the tests account for this error with a `yCorrection` API used in formulation of the assertions.  There is a `TODO` comment to track down and fix the root cause so that we can remove this work-around in the assertions.