### PR TITLE
Extend #295: Figures, EditParts and Notation Views

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/plugin.xml
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/plugin.xml
@@ -11,17 +11,44 @@
  
  Contributors:
    Christian W. Damus - Initial API and implementation
+   Antonio Campesino - Figures View, EditParts View and Notation View
  
 -->
 
 <plugin>
    <extension
          point="org.eclipse.ui.views">
+      <category
+            id="org.eclipse.papyrus.uml.interaction.model"
+            name="GMF/Papyrus Development Tools">
+      </category>
       <view
+            category="org.eclipse.papyrus.uml.interaction.model"
             class="org.eclipse.papyrus.uml.interaction.model.internal.view.LogicalModelView"
             icon="$nl$/icons/full/view16/logical_model.gif"
             id="org.eclipse.papyrus.uml.interaction.model.view.view1"
             name="Logical Model"
+            restorable="true">
+      </view>
+      <view
+            category="org.eclipse.papyrus.uml.interaction.model"
+            class="org.eclipse.papyrus.uml.interaction.model.internal.view.GMFFigureView"
+            id="org.eclipse.papyrus.uml.interaction.model.internal.view.figures"
+            name="GEF Figures Explorer"
+            restorable="true">
+      </view>
+      <view
+            category="org.eclipse.papyrus.uml.interaction.model"
+            class="org.eclipse.papyrus.uml.interaction.model.internal.view.GMFEditPartView"
+            id="org.eclipse.papyrus.uml.interaction.model.internal.view.editparts"
+            name="GEF EditParts Explorer"
+            restorable="true">
+      </view>
+      <view
+            category="org.eclipse.papyrus.uml.interaction.model"
+            class="org.eclipse.papyrus.uml.interaction.model.internal.view.GMFNotationView"
+            id="org.eclipse.papyrus.uml.interaction.model.internal.view.notation"
+            name="GMF Notation Explorer"
             restorable="true">
       </view>
    </extension>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFEditPartPage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFEditPartPage.java
@@ -1,0 +1,156 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.ConnectionEditPart;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.ui.parts.GraphicalEditor;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.jface.viewers.IContentProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.ui.views.properties.IPropertyDescriptor;
+import org.eclipse.ui.views.properties.IPropertySource;
+
+public class GMFEditPartPage extends GMFExplorerPage {
+	
+	public GMFEditPartPage(GraphicalEditor editor) {
+		super(editor);
+	}
+
+	@Override
+	protected EditPart getEditPart(Object obj) {
+		return (EditPart)obj;
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ericsson.papyrus.nwa.devtools.views.GMFExplorerView#getInputObject(org.eclipse.gef.GraphicalEditPart)
+	 */
+	@Override
+	protected Object getInputObject(GraphicalEditPart graphicalEP) {
+		return graphicalEP.getRoot();
+			
+	}
+
+
+	/* (non-Javadoc)
+	 * @see com.ericsson.papyrus.nwa.devtools.views.GMFExplorerView#getSelectedObject(org.eclipse.gef.GraphicalEditPart)
+	 */
+	@Override
+	protected Object getSelectedObject(GraphicalEditPart graphicalEP) {
+		return graphicalEP;
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ericsson.papyrus.nwa.devtools.views.GMFExplorerView#getExplorerLabelProvider()
+	 */
+	@Override
+	protected LabelProvider getExplorerLabelProvider() {
+		return new LabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return GMFExplorerUtils.getClassName(element.getClass()); 
+			}
+			
+		};
+	}
+
+
+	/* (non-Javadoc)
+	 * @see com.ericsson.papyrus.nwa.devtools.views.GMFExplorerView#getExplorerContentProvider()
+	 */
+	@Override
+	protected IContentProvider getExplorerContentProvider() {
+		return new ITreeContentProvider() {
+
+			@Override
+			public Object[] getElements(final Object inputElement) {
+				if (inputElement instanceof Object[]) {
+					return (Object[]) inputElement;
+				} 
+				return null;
+			}
+
+			@Override
+			public void inputChanged(final Viewer viewer, final Object oldInput, final Object newInput) {}
+
+			@Override
+			public void dispose() {}
+
+			@Override
+			public boolean hasChildren(final Object element) {
+				return getChildren(element).length != 0;
+			}
+
+			@Override
+			public Object getParent(final Object element) {
+				if (element instanceof EditPart) {
+					return ((EditPart) element).getParent();
+				}
+				return null;
+			}
+
+			@Override
+			public Object[] getChildren(final Object parentElement) {
+				if (parentElement instanceof EditPart) {
+					return ((EditPart) parentElement).getChildren().toArray();
+				}
+				return new Object[0];
+			}
+		};
+	}
+
+	protected IPropertySource createPropertySource(Object object) {
+		return new GMFExplorerPropertySource(object) {
+
+			@Override
+			public IPropertyDescriptor[] getPropertyDescriptors() {
+				List<IPropertyDescriptor> res =  new ArrayList<IPropertyDescriptor>();				
+				if (object instanceof GraphicalEditPart) {
+					GraphicalEditPart ep = (GraphicalEditPart)object;
+					View view = null;
+					if (ep != null && ep.getModel() instanceof View)
+						view = (View)ep.getModel();
+					
+					EObject el = null;
+					if (view != null)
+						el = view.getElement();
+					
+					res.add(new PropertyDescriptor("Class", GMFExplorerUtils.getClassName(object.getClass())));
+					res.add(new PropertyDescriptor("EObject", el));
+					res.add(new PropertyDescriptor("View", view));
+					res.add(new PropertyDescriptor("Figure", ep.getFigure()));
+					res.add(new PropertyDescriptor("Content Pane", ep.getContentPane()));
+					res.add(new PropertyDescriptor("Active", ep.isActive()));
+					res.add(new PropertyDescriptor("Selectable", ep.isSelectable()));
+					
+					if (object instanceof ConnectionEditPart) {
+						ConnectionEditPart c = (ConnectionEditPart)object;					
+						res.add(new PropertyDescriptor("Source", c.getSource()));
+						res.add(new PropertyDescriptor("Target", c.getTarget()));
+					} 			
+				}
+				res.addAll(Arrays.asList(super.getPropertyDescriptors()));
+				return res.toArray(new IPropertyDescriptor[0]);
+			}
+		};
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFEditPartView.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFEditPartView.java
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import org.eclipse.papyrus.uml.diagram.common.part.UmlGmfDiagramEditor;
+import org.eclipse.ui.part.IPage;
+import org.eclipse.ui.part.IPageBookViewPage;
+
+public class GMFEditPartView extends GMFExplorerView {
+
+	@Override
+	protected IPageBookViewPage doCreateSubPage(UmlGmfDiagramEditor diagramEditor) {
+		return new GMFEditPartPage(diagramEditor);
+	}
+
+	@Override
+	protected void doDestroySubPage(UmlGmfDiagramEditor part, IPage page) {
+		page.dispose();
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFExplorerPage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFExplorerPage.java
@@ -1,0 +1,264 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import java.util.EventObject;
+
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.emf.common.command.CommandStack;
+import org.eclipse.emf.common.command.CommandStackListener;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.emf.transaction.util.TransactionUtil;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.ui.parts.GraphicalEditor;
+import org.eclipse.jface.viewers.IContentProvider;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.ui.part.IPageBookViewPage;
+import org.eclipse.ui.part.Page;
+import org.eclipse.ui.views.properties.IPropertySheetEntry;
+import org.eclipse.ui.views.properties.IPropertySheetPage;
+import org.eclipse.ui.views.properties.IPropertySource;
+import org.eclipse.ui.views.properties.IPropertySourceProvider;
+import org.eclipse.ui.views.properties.PropertySheetPage;
+import org.eclipse.ui.views.properties.PropertySheetSorter;
+
+public abstract class GMFExplorerPage extends Page implements IPageBookViewPage, ISelectionProvider, IAdaptable {
+
+	private TreeViewer explorerViewer;
+
+	private EditPartViewer editPartViewer;	
+	private ISelectionChangedListener diagramSelectionListener = this::diagramSelectionChanged;
+	
+	private CommandStack commandStack;
+	private CommandStackListener commandStackListener = this::commandStackChanged;
+	
+	private PropertySheetPage propertySheetPage;
+
+	public GMFExplorerPage(GraphicalEditor editor) {
+		super();
+
+		editPartViewer = (GraphicalViewer)editor.getAdapter(GraphicalViewer.class);
+		editPartViewer.addSelectionChangedListener(diagramSelectionListener);		
+	}
+
+	public EditPartViewer getEditPartViewer() {
+		return editPartViewer;
+	}
+	
+	protected abstract ILabelProvider getExplorerLabelProvider();
+	protected abstract IContentProvider getExplorerContentProvider();
+	
+	protected abstract EditPart getEditPart(Object obj);
+	protected abstract Object getInputObject(GraphicalEditPart graphicalEP);
+	protected abstract Object getSelectedObject(GraphicalEditPart graphicalEP);
+
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter == IPropertySheetPage.class) {
+			return (T)getPropertySheetPage();
+		} else {
+			return Platform.getAdapterManager().getAdapter(this, adapter);
+		}
+	}
+	
+	@Override
+	public void addSelectionChangedListener(ISelectionChangedListener listener) {
+		explorerViewer.addSelectionChangedListener(listener);
+	}
+
+	@Override
+	public ISelection getSelection() {
+		return explorerViewer.getSelection();
+	}
+
+	@Override
+	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
+		explorerViewer.removeSelectionChangedListener(listener);
+	}
+
+	@Override
+	public void setSelection(ISelection selection) {
+		explorerViewer.setSelection(selection,true);
+	}
+
+	@Override
+	public void createControl(Composite parent) {
+		explorerViewer = new TreeViewer(createExplorerTree(parent));
+		explorerViewer.setContentProvider(getExplorerContentProvider());
+		explorerViewer.setLabelProvider(getExplorerLabelProvider());				
+		explorerViewer.setInput(new Object[] {getInputObject((GraphicalEditPart)editPartViewer.getRootEditPart())});
+		explorerViewer.addSelectionChangedListener(new ISelectionChangedListener() {			
+			@Override
+			public void selectionChanged(SelectionChangedEvent event) {
+				IStructuredSelection sel = (IStructuredSelection)event.getSelection();
+				Object obj = sel.getFirstElement();
+				if (obj != null) {
+					EditPart ep = getEditPart(obj);
+					if (ep != null) {
+						if (ep.getSelected() == EditPart.SELECTED_NONE)
+							editPartViewer.select(ep);
+					}
+				}				
+			}
+		});
+		
+		ISelection sel = editPartViewer.getSelection();
+		if (sel instanceof IStructuredSelection) {
+			Object obj = getSelectedObject((GraphicalEditPart)((IStructuredSelection) sel).getFirstElement());			
+			explorerViewer.setSelection(new StructuredSelection(obj),true);
+		}
+		getSite().setSelectionProvider(explorerViewer);
+	}
+
+	@Override
+	public Control getControl() {
+		return explorerViewer.getTree();
+	}
+
+	@Override
+	public void setFocus() {
+		Viewer viewer = explorerViewer;
+		if (viewer != null && !viewer.getControl().isDisposed()) {
+			viewer.getControl().setFocus();
+		}
+	}
+
+	public void commandStackChanged(EventObject event) {
+		if (explorerViewer != null)
+			explorerViewer.refresh();
+	}
+	
+	public void diagramSelectionChanged(SelectionChangedEvent event) {	
+		ISelection selection = event.getSelection();
+		if  (!(selection instanceof IStructuredSelection))
+			return;
+
+		Object selectedobject = ((IStructuredSelection) selection).getFirstElement();
+		if (selectedobject == null)
+			return;
+
+		if (selectedobject instanceof GraphicalEditPart) {
+			selectEditPart((GraphicalEditPart) selectedobject);
+			return;
+		}
+
+		selectEditPart(null);
+	}
+	
+	private void selectEditPart(GraphicalEditPart graphicalEP) {
+		if (graphicalEP != null) {
+			if (graphicalEP.getModel() instanceof EObject)
+				hookCommandStackListener((EObject)graphicalEP.getModel());
+
+			Object sel = getSelectedObject(graphicalEP);
+			Object input = getInputObject(graphicalEP);
+			
+			if (explorerViewer != null) {
+				if (!(explorerViewer.getInput() instanceof Object[]) || ((Object[])explorerViewer.getInput())[0] != input) 
+					explorerViewer.setInput(new Object[] {input});
+				IStructuredSelection curSel = (IStructuredSelection)explorerViewer.getSelection(); 
+				if (curSel.getFirstElement() == null || curSel.getFirstElement() != sel) {
+					explorerViewer.reveal(sel);
+					explorerViewer.setSelection(new StructuredSelection(sel), true);
+				}
+			}
+		} else {
+			if (explorerViewer != null) {
+				explorerViewer.setInput(null);
+			}
+		}
+	}
+
+	private void hookCommandStackListener(EObject eObj) {
+		if (commandStack != null)
+			return;
+		
+		TransactionalEditingDomain editingDomain = TransactionUtil.getEditingDomain(eObj);
+		if (editingDomain == null)
+			return;
+		
+		commandStack = editingDomain.getCommandStack();
+		commandStack.addCommandStackListener(commandStackListener);
+		explorerViewer.refresh();
+	}
+	
+	private void unhookCommandStackListener() {
+		if (commandStack == null)
+			return;
+		
+		commandStack.removeCommandStackListener(commandStackListener);		
+		commandStack = null;
+	}
+
+	protected Tree createExplorerTree(Composite parent) {
+		Tree tree = new Tree(parent, SWT.H_SCROLL | SWT.V_SCROLL | SWT.FULL_SELECTION);
+		return tree;
+	}
+
+	@Override
+	public void dispose() {
+		if (editPartViewer != null) {
+			editPartViewer.removeSelectionChangedListener(diagramSelectionListener);
+			editPartViewer = null;
+		}
+		
+		unhookCommandStackListener();
+		super.dispose();
+	}
+
+	protected IPropertySource createPropertySource(Object object) {
+		return new GMFExplorerPropertySource(object);
+	}
+	
+	protected IPropertySheetPage getPropertySheetPage() {
+		propertySheetPage = new PropertySheetPageEx();
+		propertySheetPage.setPropertySourceProvider(new IPropertySourceProvider() {			
+			@Override
+			public IPropertySource getPropertySource(Object object) {
+				return createPropertySource(object);
+			}
+		});
+		return propertySheetPage;
+	}
+	
+	private static class PropertySheetPageEx extends PropertySheetPage {
+		public PropertySheetPageEx() {
+			super();
+			setSorter(new PropertySheetSorter() {
+				@Override
+				public void sort(IPropertySheetEntry[] entries) {
+				}				
+			});
+		}
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFExplorerPropertySource.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFExplorerPropertySource.java
@@ -1,0 +1,179 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.views.properties.IPropertyDescriptor;
+import org.eclipse.ui.views.properties.IPropertySource;
+
+public class GMFExplorerPropertySource implements IPropertySource {
+
+	public GMFExplorerPropertySource(Object object) {
+		super();
+		this.object = object;
+	}
+
+	@Override
+	public Object getEditableValue() {
+		return GMFExplorerUtils.getText(object);
+	}
+
+	@Override
+	public IPropertyDescriptor[] getPropertyDescriptors() {
+		if (object == null || GMFExplorerUtils.isPrimitiveOrWrapperClass(object.getClass()))
+			return new IPropertyDescriptor[0];
+		
+		Class<?> cls = object.getClass();
+		if (cls.isArray()) {
+			IPropertyDescriptor[] desc = new IPropertyDescriptor[Array.getLength(object)];
+			for (int i = 0; i<desc.length; i++) {
+				desc[i] = new PropertyDescriptor("["+i+"]", Array.get(object, i));
+			}
+			return desc;
+		} else if (object instanceof Collection) {
+			Collection<?> it = (Collection<?>)object;
+			IPropertyDescriptor[] desc = new IPropertyDescriptor[it.size()];
+			int i = 0;
+			for (Object obj : it) {
+				desc[i] = new PropertyDescriptor("["+i+"]", obj);
+				i++;
+			}
+			return desc;
+		} 
+		
+		List<Field> fs = new ArrayList<Field>(getFields(object.getClass(), new LinkedHashSet<Field>()));
+		Collections.sort(fs, (a,b)-> a.getName().compareToIgnoreCase(b.getName()));
+		
+		int i=0;
+		IPropertyDescriptor[] res = new IPropertyDescriptor[fs.size()];		
+		for (Field f : fs) {
+			f.setAccessible(true);
+			try {
+				res[i] = new PropertyDescriptor(f.getName(), f.get(object));
+			} catch (Exception e) {
+				res[i] = new PropertyDescriptor(f.getName(), "ERROR: " + e.getMessage());
+			}
+			i++;
+		}
+		return res;
+	}
+
+	@Override
+	public Object getPropertyValue(Object id) {
+		return ((PropertyDescriptor)id).value;
+	}
+
+	@Override
+	public boolean isPropertySet(Object id) {
+		return false;
+	}
+
+	@Override
+	public void resetPropertyValue(Object id) {
+	}
+
+	@Override
+	public void setPropertyValue(Object id, Object value) {
+	}
+
+	private Set<Field> getFields(Class<?> cls, Set<Field> l) {
+		if (cls == Object.class)
+			return l;
+		for (Field f : cls.getDeclaredFields()) {
+			if (f.isEnumConstant() || Modifier.isStatic(f.getModifiers()))
+				continue;
+			l.add(f);
+		}
+		return getFields(cls.getSuperclass(),l);
+	}
+
+	protected static class PropertyDescriptor implements IPropertyDescriptor {
+		private ILabelProvider labelProvider = null;
+		PropertyDescriptor(String name, Object value) {
+			this.name = name;
+			this.value = value;
+		}
+		
+		@Override
+		public CellEditor createPropertyEditor(Composite parent) {
+			return null;
+		}
+
+		@Override
+		public String getCategory() {
+			return null;
+		}
+
+		@Override
+		public String getDescription() {
+			return null;
+		}
+
+		@Override
+		public String getDisplayName() {
+			return name;
+		}
+
+		@Override
+		public String[] getFilterFlags() {
+			return null;
+		}
+
+		@Override
+		public Object getHelpContextIds() {
+			return null;
+		}
+
+		@Override
+		public Object getId() {
+			return this;
+		}
+
+		@Override
+		public ILabelProvider getLabelProvider() {
+			if (labelProvider == null) {
+				labelProvider = new LabelProvider() {
+					@Override
+					public String getText(Object element) {
+						return GMFExplorerUtils.getText(element);
+					}		
+				};
+			}
+			return labelProvider;
+		}
+
+		@Override
+		public boolean isCompatibleWith(IPropertyDescriptor anotherProperty) {
+			return anotherProperty == this;
+		}
+
+		private String name;
+		private Object value;
+	}
+	
+	protected Object object;
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFExplorerUtils.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFExplorerUtils.java
@@ -1,0 +1,82 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class GMFExplorerUtils {
+	 private static Set<Class<?>> PRIMITIVE_WRAPPERS = new HashSet<Class<?>>(Arrays.asList(
+		Boolean.class,
+		Character.class,
+		Byte.class,
+		Short.class,
+		Integer.class,
+		Long.class,
+		Float.class,
+		Double.class,
+		Void.class));
+	 
+	public static boolean isPrimitiveOrWrapperClass(Class<?> cls) {
+		return cls.isPrimitive() || PRIMITIVE_WRAPPERS.contains(cls);
+	}
+
+
+	public static String getClassName(Class<?> cls) {
+		return cls.isAnonymousClass() ? 
+				cls.getName().substring(cls.getName().lastIndexOf('.')+1) :
+				cls.getSimpleName()	;
+	}
+ 
+	public static String getText(Object val) {
+		if (val == null)
+			return "null";
+		if (val.getClass().isArray()) {
+			if (!isPrimitiveOrWrapperClass(val.getClass().getComponentType()))
+				return Arrays.deepToString((Object[])val);
+			try {
+				if (val.getClass().getComponentType() == char.class)
+					return String.valueOf((char[])val);
+				return (String)Arrays.class.getMethod("toString", val.getClass()).invoke(null, val);
+			} catch (Exception e) {}
+			return val.toString();
+		}
+
+		if (val instanceof Collection) {
+			return getText(((Collection<?>)val).toArray());
+		}
+		
+		Class<?> cls = val.getClass();
+		if (isPrimitiveOrWrapperClass(cls) || val instanceof String) {
+			if (cls == char.class) {
+				return "'"+val+"' ("+Integer.toHexString((int)val)+")";
+			}
+			return val.toString();
+		}
+		
+		String str = val.toString();
+		if (!str.startsWith(cls.getName()+"@")) {
+			String className = getClassName(cls); 
+			if (!str.startsWith(cls.getName()) && !str.startsWith(className)) {
+				return className + str;
+			}
+			return str;
+		}
+		
+		return getClassName(cls);		
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFExplorerView.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFExplorerView.java
@@ -1,0 +1,26 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+/**
+ * A view presenting the logical model in the (last) selected lightweight
+ * sequence diagram.
+ * 
+ * @author Christian W. Damus - Original implementation
+ * @author Antonio Campesino - Split the class in a generic class (PapyrusPageBookView) and specific class. 
+ *
+ */
+
+public abstract class GMFExplorerView extends PapyrusPageBookView {
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFFigurePage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFFigurePage.java
@@ -1,0 +1,162 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.draw2d.Connection;
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.ui.parts.GraphicalEditor;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.jface.viewers.IContentProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.ui.views.properties.IPropertyDescriptor;
+import org.eclipse.ui.views.properties.IPropertySource;
+
+public class GMFFigurePage extends GMFExplorerPage {
+	
+	public GMFFigurePage(GraphicalEditor editor) {
+		super(editor);
+	}
+
+	@Override
+	protected EditPart getEditPart(Object obj) {
+		EditPartViewer viewer = getEditPartViewer();
+		if (getEditPartViewer() == null)
+			return null;
+		
+		return (EditPart)viewer.getVisualPartMap().get(obj);
+	}
+	
+	@Override
+	protected Object getInputObject(GraphicalEditPart graphicalEP) {
+		IFigure root = graphicalEP.getFigure();
+		while (root != null && root.getParent() != null)
+			root = root.getParent();
+		return root;	
+	}
+
+
+	@Override
+	protected Object getSelectedObject(GraphicalEditPart graphicalEP) {
+		return graphicalEP.getFigure();
+	}
+
+
+	@Override
+	protected LabelProvider getExplorerLabelProvider() {
+		return new LabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return GMFExplorerUtils.getClassName(element.getClass()); 
+			}
+			
+		};
+	}
+
+	@Override
+	protected IContentProvider getExplorerContentProvider() {
+		return new ITreeContentProvider() {
+
+			@Override
+			public Object[] getElements(final Object inputElement) {
+				if (inputElement instanceof Object[]) {
+					return (Object[]) inputElement;
+				} 
+				return null;
+			}
+
+			@Override
+			public void inputChanged(final Viewer viewer, final Object oldInput, final Object newInput) {}
+
+			@Override
+			public void dispose() {}
+
+			@Override
+			public boolean hasChildren(final Object element) {
+				return getChildren(element).length != 0;
+			}
+
+			@Override
+			public Object getParent(final Object element) {
+				if (element instanceof IFigure) {
+					return ((IFigure) element).getParent();
+				}
+				return null;
+			}
+
+			@Override
+			public Object[] getChildren(final Object parentElement) {
+				if (parentElement instanceof IFigure) {
+					return ((IFigure) parentElement).getChildren().toArray();
+				}
+				return new Object[0];
+			}
+		};
+	}
+	
+	protected IPropertySource createPropertySource(Object object) {
+		return new GMFExplorerPropertySource(object) {
+
+			@Override
+			public IPropertyDescriptor[] getPropertyDescriptors() {
+				List<IPropertyDescriptor> res =  new ArrayList<IPropertyDescriptor>();				
+				if (object instanceof Figure) {
+					IFigure f = (IFigure)object;
+					EditPart ep = (EditPart)getEditPartViewer().getVisualPartMap().get(object);
+					View view = null;
+					if (ep != null && ep.getModel() instanceof View)
+						view = (View)ep.getModel();
+					
+					EObject el = null;
+					if (view != null)
+						el = view.getElement();
+					
+					res.add(new PropertyDescriptor("Class", GMFExplorerUtils.getClassName(object.getClass())));
+					res.add(new PropertyDescriptor("EObject", el));
+					res.add(new PropertyDescriptor("View", view));
+					res.add(new PropertyDescriptor("EditPart", ep));
+					res.add(new PropertyDescriptor("Visible", f.isVisible()));
+					
+					if (object instanceof Connection) {
+						Connection c = (Connection)object;					
+						res.add(new PropertyDescriptor("Source Anchor", c.getSourceAnchor()));
+						res.add(new PropertyDescriptor("Target Anchor", c.getTargetAnchor()));
+						res.add(new PropertyDescriptor("Routing Constraint", c.getRoutingConstraint()));
+					} else if (object instanceof Figure) { 
+						Rectangle absBounds = f.getBounds().getCopy();
+						f.translateToAbsolute(absBounds);
+						res.add(new PropertyDescriptor("Coord Syst", f.isCoordinateSystem()));
+						res.add(new PropertyDescriptor("Bounds", f.getBounds()));
+						res.add(new PropertyDescriptor("Bounds (abs.)", absBounds));
+						res.add(new PropertyDescriptor("Client Area", f.getClientArea()));
+						res.add(new PropertyDescriptor("Border", f.getBorder()));					
+					}				
+				}
+				res.addAll(Arrays.asList(super.getPropertyDescriptors()));
+				return res.toArray(new IPropertyDescriptor[0]);
+			}
+		};
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFFigureView.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFFigureView.java
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import org.eclipse.papyrus.uml.diagram.common.part.UmlGmfDiagramEditor;
+import org.eclipse.ui.part.IPage;
+import org.eclipse.ui.part.IPageBookViewPage;
+
+public class GMFFigureView extends GMFExplorerView {
+
+	@Override
+	protected IPageBookViewPage doCreateSubPage(UmlGmfDiagramEditor diagramEditor) {
+		return new GMFFigurePage(diagramEditor);
+	}
+
+	@Override
+	protected void doDestroySubPage(UmlGmfDiagramEditor part, IPage page) {
+		page.dispose();
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFNotationPage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFNotationPage.java
@@ -1,0 +1,138 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.ui.provider.AdapterFactoryContentProvider;
+import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.RootEditPart;
+import org.eclipse.gef.ui.parts.GraphicalEditor;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramEditor;
+import org.eclipse.gmf.runtime.notation.Edge;
+import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.jface.viewers.IContentProvider;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.ui.views.properties.IPropertyDescriptor;
+import org.eclipse.ui.views.properties.IPropertySource;
+
+public class GMFNotationPage extends GMFExplorerPage {
+	private final AdapterFactory adapterFactory;
+
+	public GMFNotationPage(GraphicalEditor editor) {
+		super(editor);
+		TransactionalEditingDomain editingDomain = ((DiagramEditor)editor).getEditingDomain();
+		adapterFactory = ((AdapterFactoryEditingDomain) editingDomain).getAdapterFactory();;
+	}
+
+	@Override
+	protected EditPart getEditPart(Object obj) {
+		EditPartViewer viewer = getEditPartViewer();
+		if (getEditPartViewer() == null)
+			return null;
+		
+		return (EditPart)viewer.getEditPartRegistry().get(obj);
+	}
+
+	@Override
+	protected Object getInputObject(GraphicalEditPart graphicalEP) {
+		Object obj = graphicalEP instanceof RootEditPart ? 
+				((RootEditPart)graphicalEP).getContents().getModel() : 
+				graphicalEP.getModel();
+		
+		while (!(obj instanceof View)) {
+			if (!(obj instanceof EObject))
+				return null;
+			obj = ((EObject)obj).eContainer();
+		}
+		return obj == null ? null : ((View)obj).getDiagram();	
+	}
+
+
+	@Override
+	protected Object getSelectedObject(GraphicalEditPart graphicalEP) {
+		return graphicalEP.getModel();
+	}
+
+	@Override
+	protected ILabelProvider getExplorerLabelProvider() {
+		return new AdapterFactoryLabelProvider(adapterFactory);
+	}
+
+
+	@Override
+	protected IContentProvider getExplorerContentProvider() {
+		return new AdapterFactoryContentProvider(adapterFactory) {
+			@Override
+			public Object[] getElements(Object object) {	
+				EObject eObj = (EObject)((Object[])object)[0];
+				return new Object[] {eObj};
+			}			
+		};
+	}
+	
+	protected IPropertySource createPropertySource(Object object) {
+		return new GMFExplorerPropertySource(object) {
+
+			@Override
+			public IPropertyDescriptor[] getPropertyDescriptors() {
+				List<IPropertyDescriptor> res =  new ArrayList<IPropertyDescriptor>();				
+				if (object instanceof View) {
+					View view = (View)object;
+
+					EditPart ep = null;
+					if (getEditPartViewer() != null)
+						ep = (EditPart)getEditPartViewer().getEditPartRegistry().get(view);
+					
+					EObject el = null;
+					if (view != null)
+						el = view.getElement();
+					
+					res.add(new PropertyDescriptor("Class", GMFExplorerUtils.getClassName(view.getClass())));
+					res.add(new PropertyDescriptor("EObject", el));
+					res.add(new PropertyDescriptor("EditPart", ep));
+					res.add(new PropertyDescriptor("Figure", ep instanceof IGraphicalEditPart ? ((IGraphicalEditPart)ep).getFigure() : null));
+					res.add(new PropertyDescriptor("Active", view.isVisible()));
+					res.add(new PropertyDescriptor("Persisted", view.eContainer() != null ? ((View)view.eContainer()).getPersistedChildren().contains(view) : null));
+
+					if (object instanceof Edge) {
+						Edge c = (Edge)object;					
+						res.add(new PropertyDescriptor("Source", c.getSource()));
+						res.add(new PropertyDescriptor("SourceAnchor", c.getSourceAnchor()));
+						res.add(new PropertyDescriptor("Target", c.getTarget()));
+						res.add(new PropertyDescriptor("TargetAnchor", c.getTargetAnchor()));
+						res.add(new PropertyDescriptor("Bendpoints", c.getBendpoints()));						
+					} else if (object instanceof Node){ 
+						Node c = (Node)object;					
+						res.add(new PropertyDescriptor("LayoutConstraints", c.getLayoutConstraint()));
+					} 
+				}
+				res.addAll(Arrays.asList(super.getPropertyDescriptors()));
+				return res.toArray(new IPropertyDescriptor[0]);
+			}
+		};
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFNotationView.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/GMFNotationView.java
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * (c) Copyright 2016 Telefonaktiebolaget LM Ericsson
+ *
+ *    
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Antonio Campesino (Ericsson) - Initial API and implementation
+ *
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import org.eclipse.papyrus.uml.diagram.common.part.UmlGmfDiagramEditor;
+import org.eclipse.ui.part.IPage;
+import org.eclipse.ui.part.IPageBookViewPage;
+
+public class GMFNotationView extends GMFExplorerView {
+
+	@Override
+	protected IPageBookViewPage doCreateSubPage(UmlGmfDiagramEditor diagramEditor) {
+		return new GMFNotationPage(diagramEditor);
+	}
+
+	@Override
+	protected void doDestroySubPage(UmlGmfDiagramEditor part, IPage page) {
+		page.dispose();
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/LogicalModelView.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/LogicalModelView.java
@@ -8,240 +8,39 @@
  *
  * Contributors:
  *   Christian W. Damus - Initial API and implementation
+ *   Antonio Campesino - Split the class in a generic class (PapyrusPageBookView) 
+ *                       and specific class.
  *****************************************************************************/
-
 package org.eclipse.papyrus.uml.interaction.model.internal.view;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.eclipse.gmf.runtime.notation.Diagram;
-import org.eclipse.papyrus.infra.core.sasheditor.editor.DefaultPageLifeCycleEventListener;
-import org.eclipse.papyrus.infra.core.sasheditor.editor.IEditorPage;
-import org.eclipse.papyrus.infra.core.sasheditor.editor.IPageLifeCycleEventsListener;
-import org.eclipse.papyrus.infra.core.sasheditor.editor.ISashWindowsContainer;
-import org.eclipse.papyrus.infra.ui.editor.IMultiDiagramEditor;
 import org.eclipse.papyrus.uml.diagram.common.part.UmlGmfDiagramEditor;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.RepresentationKind;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Label;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IEditorReference;
-import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.IPage;
-import org.eclipse.ui.part.Page;
-import org.eclipse.ui.part.PageBook;
-import org.eclipse.ui.part.PageBookView;
+import org.eclipse.ui.part.IPageBookViewPage;
 
 /**
  * A view presenting the logical model in the (last) selected lightweight
  * sequence diagram.
+ * 
+ * @author Christian W. Damus - Original implementation
+ * @author Antonio Campesino - Split the class in a generic class (PapyrusPageBookView) and specific class. 
  *
- * @author Christian W. Damus
  */
-public class LogicalModelView extends PageBookView {
-
-	private final IPageLifeCycleEventsListener papyrusSubEditorListener = new PapyrusSubEditorListener();
-	private final Map<IMultiDiagramEditor, List<PageRec>> multiDiagramPageRecords = new HashMap<>();
-
-	private ISashWindowsContainer sashWindowsContainer;
-	private IMultiDiagramEditor currentPapyrusEditor;
-
-	/**
-	 * Initializes me.
-	 *
-	 */
-	public LogicalModelView() {
-		super();
+@SuppressWarnings("restriction")
+public class LogicalModelView extends PapyrusPageBookView {
+	@Override
+	protected final IPageBookViewPage doCreateSubPage(UmlGmfDiagramEditor part) {
+		return new LogicalModelPage(part);
 	}
 
 	@Override
-	protected IPage createDefaultPage(PageBook book) {
-		return new Page() {
-
-			private Label label;
-
-			@Override
-			public void setFocus() {
-				// Pass
-			}
-
-			@Override
-			public Control getControl() {
-				return label;
-			}
-
-			@Override
-			public void createControl(Composite parent) {
-				label = new Label(parent, SWT.NONE);
-				label.setText("No sequence diagram open.");
-			}
-		};
-	}
-
-	@Override
-	protected PageRec doCreatePage(IWorkbenchPart part) {
-		LogicalModelPage result = new LogicalModelPage((UmlGmfDiagramEditor) part);
-		initPage(result);
-		result.createControl(getPageBook());
-		return currentPapyrusEditor == null
-				? new PageRec(part, result)
-				: new SubPageRec(currentPapyrusEditor, part, result);
-	}
-
-	@Override
-	protected void doDestroyPage(IWorkbenchPart part, PageRec pageRecord) {
-		LogicalModelPage page = (LogicalModelPage) pageRecord.page;
+	protected final void doDestroySubPage(UmlGmfDiagramEditor part, IPage page) {
 		page.dispose();
-		pageRecord.dispose();
 	}
 
-	@Override
-	public void partActivated(IWorkbenchPart part) {
-		if (part instanceof IMultiDiagramEditor) {
-			currentPapyrusEditor = (IMultiDiagramEditor) part;
-			setSashWindowsContainer(part.getAdapter(ISashWindowsContainer.class));
-
-			// This is the part that really activated
-			part = currentPapyrusEditor.getActiveEditor();
-		}
-
-		basicPartActivated(part);
+	protected boolean isSubpageImportant(UmlGmfDiagramEditor editor, Diagram diagram) {
+		return RepresentationKind.MODEL_ID.equals(diagram.getType());
 	}
 
-	private void setSashWindowsContainer(ISashWindowsContainer container) {
-		if (sashWindowsContainer != null) {
-			sashWindowsContainer.removePageLifeCycleListener(papyrusSubEditorListener);
-		}
-
-		sashWindowsContainer = container;
-
-		if (sashWindowsContainer != null) {
-			sashWindowsContainer.addPageLifeCycleListener(papyrusSubEditorListener);
-		}
-	}
-
-	void basicPartActivated(IWorkbenchPart part) {
-		super.partActivated(part);
-	}
-
-	@Override
-	public void partDeactivated(IWorkbenchPart part) {
-		try {
-			super.partDeactivated(part);
-		} finally {
-			if (part == currentPapyrusEditor) {
-				setSashWindowsContainer(null);
-				currentPapyrusEditor = null;
-			}
-		}
-	}
-
-	@Override
-	public void partClosed(IWorkbenchPart part) {
-		super.partClosed(part);
-
-		if (part instanceof IMultiDiagramEditor) {
-			List<PageRec> toDispose = new ArrayList<>(
-					multiDiagramPageRecords.getOrDefault(part, Collections.emptyList()));
-			toDispose.forEach(rec -> partClosed(rec.part));
-		}
-	}
-
-	@Override
-	protected IWorkbenchPart getBootstrapPart() {
-		IWorkbenchPart result = null;
-
-		for (IEditorReference next : getSite().getPage().getEditorReferences()) {
-			IEditorPart activeEditor = next.getEditor(false);
-			if (activeEditor instanceof IMultiDiagramEditor) {
-				result = activeEditor;
-			}
-		}
-
-		return result;
-	}
-
-	@Override
-	protected boolean isImportant(IWorkbenchPart part) {
-		boolean result = false;
-
-		if (part instanceof UmlGmfDiagramEditor) {
-			UmlGmfDiagramEditor diagramEditor = (UmlGmfDiagramEditor) part;
-			Diagram diagram = diagramEditor.getDiagram();
-			result = (diagram != null) && RepresentationKind.MODEL_ID.equals(diagram.getType());
-		}
-
-		return result;
-	}
-
-	//
-	// Nested types
-	//
-
-	class SubPageRec extends PageRec {
-
-		IMultiDiagramEditor parent;
-
-		SubPageRec(IMultiDiagramEditor editor, IWorkbenchPart part, IPage page) {
-			super(part, page);
-
-			parent = editor;
-
-			multiDiagramPageRecords.computeIfAbsent(editor, __ -> new ArrayList<>()).add(this);
-		}
-
-		@Override
-		public void dispose() {
-			List<PageRec> records = multiDiagramPageRecords.get(parent);
-			if (records != null) {
-				records.remove(this);
-				if (records.isEmpty()) {
-					multiDiagramPageRecords.remove(parent);
-				}
-			}
-
-			parent = null;
-
-			super.dispose();
-		}
-
-	}
-
-	class PapyrusSubEditorListener extends DefaultPageLifeCycleEventListener {
-
-		@Override
-		public void pageActivated(org.eclipse.papyrus.infra.core.sasheditor.editor.IPage page) {
-			if (page instanceof IEditorPage) {
-				basicPartActivated(((IEditorPage) page).getIEditorPart());
-			}
-		}
-
-		@Override
-		public void pageDeactivated(org.eclipse.papyrus.infra.core.sasheditor.editor.IPage page) {
-			if (page instanceof IEditorPage) {
-				partDeactivated(((IEditorPage) page).getIEditorPart());
-			}
-		}
-
-		@Override
-		public void pageOpened(org.eclipse.papyrus.infra.core.sasheditor.editor.IPage page) {
-			if (page instanceof IEditorPage) {
-				partOpened(((IEditorPage) page).getIEditorPart());
-			}
-		}
-
-		@Override
-		public void pageClosed(org.eclipse.papyrus.infra.core.sasheditor.editor.IPage page) {
-			if (page instanceof IEditorPage) {
-				partClosed(((IEditorPage) page).getIEditorPart());
-			}
-		}
-
-	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/PapyrusPageBookView.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.view/src/org/eclipse/papyrus/uml/interaction/model/internal/view/PapyrusPageBookView.java
@@ -1,0 +1,266 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *   Antonio Campesino - Split the class in a generic class (PapyrusPageBookView) 
+ *                       and specific class.
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model.internal.view;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.gmf.runtime.notation.Diagram;
+import org.eclipse.papyrus.infra.core.sasheditor.editor.DefaultPageLifeCycleEventListener;
+import org.eclipse.papyrus.infra.core.sasheditor.editor.IEditorPage;
+import org.eclipse.papyrus.infra.core.sasheditor.editor.IPageLifeCycleEventsListener;
+import org.eclipse.papyrus.infra.core.sasheditor.editor.ISashWindowsContainer;
+import org.eclipse.papyrus.infra.ui.editor.IMultiDiagramEditor;
+import org.eclipse.papyrus.uml.diagram.common.part.UmlGmfDiagramEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.part.IPage;
+import org.eclipse.ui.part.IPageBookViewPage;
+import org.eclipse.ui.part.Page;
+import org.eclipse.ui.part.PageBook;
+import org.eclipse.ui.part.PageBookView;
+
+/**
+ * A view presenting the logical model in the (last) selected lightweight
+ * sequence diagram.
+ *
+ * @author Christian W. Damus
+ * @author Antonio Campesino - Generalizing the view (renamed to PapyrusPageBookView) and implementing dispose()
+ */
+public abstract class PapyrusPageBookView extends PageBookView {
+
+	private final IPageLifeCycleEventsListener papyrusSubEditorListener = new PapyrusSubEditorListener();
+	private final Map<IMultiDiagramEditor, List<PageRec>> multiDiagramPageRecords = new HashMap<>();
+
+	private ISashWindowsContainer sashWindowsContainer;
+	private IMultiDiagramEditor currentPapyrusEditor;
+
+	/**
+	 * Initializes me.
+	 *
+	 */
+	public PapyrusPageBookView() {
+		super();
+	}
+
+	@Override
+	protected IPage createDefaultPage(PageBook book) {
+		Page page = new Page() {
+
+			private Label label;
+
+			@Override
+			public void setFocus() {
+				// Pass
+			}
+
+			@Override
+			public Control getControl() {
+				return label;
+			}
+
+			@Override
+			public void createControl(Composite parent) {
+				label = new Label(parent, SWT.NONE);
+				label.setText("No sequence diagram open.");
+			}
+		};
+		initPage(page);
+		page.createControl(book);
+		return page;
+	}
+
+	protected abstract IPageBookViewPage doCreateSubPage(UmlGmfDiagramEditor diagramEditor);
+	
+	@Override
+	protected final PageRec doCreatePage(IWorkbenchPart part) {
+		if (part instanceof UmlGmfDiagramEditor) {
+			UmlGmfDiagramEditor diagramEditor = (UmlGmfDiagramEditor) part;
+			Diagram diagram = diagramEditor.getDiagram();
+			if ((diagram != null) && isSubpageImportant((UmlGmfDiagramEditor)part, diagram)) {	
+				IPageBookViewPage result = doCreateSubPage((UmlGmfDiagramEditor)part);
+				initPage(result);
+				result.createControl(getPageBook());
+				return currentPapyrusEditor == null
+						? new PageRec(part, result)
+						: new SubPageRec(currentPapyrusEditor, part, result);
+			}
+		} 
+		return null;				
+	}
+
+	protected abstract void doDestroySubPage(UmlGmfDiagramEditor part, IPage page);
+
+	@Override
+	protected final void doDestroyPage(IWorkbenchPart part, PageRec pageRecord) {
+		if (part instanceof UmlGmfDiagramEditor)
+			doDestroySubPage((UmlGmfDiagramEditor)part,pageRecord.page);
+		pageRecord.page.dispose();
+		pageRecord.dispose();
+	}
+
+	@Override
+	public void partOpened(IWorkbenchPart part) {
+		super.partOpened(part);
+		partActivated(part);
+	}
+		
+	@Override
+	public void partActivated(IWorkbenchPart part) {
+		if (part instanceof IMultiDiagramEditor) {
+			currentPapyrusEditor = (IMultiDiagramEditor) part;
+			setSashWindowsContainer(part.getAdapter(ISashWindowsContainer.class));
+
+			// This is the part that really activated
+			part = currentPapyrusEditor.getActiveEditor();
+		}
+
+		basicPartActivated(part);
+	}
+
+	private void setSashWindowsContainer(ISashWindowsContainer container) {
+		if (sashWindowsContainer != null) {
+			sashWindowsContainer.removePageLifeCycleListener(papyrusSubEditorListener);
+		}
+
+		sashWindowsContainer = container;
+
+		if (sashWindowsContainer != null) {
+			sashWindowsContainer.addPageLifeCycleListener(papyrusSubEditorListener);
+		}
+	}
+
+	void basicPartActivated(IWorkbenchPart part) {
+		super.partActivated(part);
+	}
+
+	@Override
+	public void partDeactivated(IWorkbenchPart part) {
+		try {
+			super.partDeactivated(part);
+		} finally {
+			if (part == currentPapyrusEditor) {
+				setSashWindowsContainer(null);
+				currentPapyrusEditor = null;
+			}
+		}
+	}
+
+	@Override
+	public void partClosed(IWorkbenchPart part) {
+		super.partClosed(part);
+
+		if (part instanceof IMultiDiagramEditor) {
+			List<PageRec> toDispose = new ArrayList<>(
+					multiDiagramPageRecords.getOrDefault(part, Collections.emptyList()));
+			toDispose.forEach(rec -> partClosed(rec.part));
+		}
+	}
+
+	@Override
+	protected IWorkbenchPart getBootstrapPart() {
+		return getSite().getPage().getActiveEditor();
+	}
+
+	@Override
+	protected boolean isImportant(IWorkbenchPart part) {
+		return (part instanceof IEditorPart);
+	}
+	
+	protected boolean isSubpageImportant(UmlGmfDiagramEditor part, Diagram diagram) {
+		return true;
+	}
+
+	@Override
+	public void dispose() {
+		if (sashWindowsContainer != null && !sashWindowsContainer.isDisposed())
+			setSashWindowsContainer(null);
+		super.dispose();
+	}
+	
+	//
+	// Nested types
+	//
+
+	class SubPageRec extends PageRec {
+
+		IMultiDiagramEditor parent;
+
+		SubPageRec(IMultiDiagramEditor editor, IWorkbenchPart part, IPage page) {
+			super(part, page);
+
+			parent = editor;
+
+			multiDiagramPageRecords.computeIfAbsent(editor, __ -> new ArrayList<>()).add(this);
+		}
+
+		@Override
+		public void dispose() {
+			List<PageRec> records = multiDiagramPageRecords.get(parent);
+			if (records != null) {
+				records.remove(this);
+				if (records.isEmpty()) {
+					multiDiagramPageRecords.remove(parent);
+				}
+			}
+
+			parent = null;
+
+			super.dispose();
+		}
+
+	}
+
+	class PapyrusSubEditorListener extends DefaultPageLifeCycleEventListener {
+
+		@Override
+		public void pageActivated(org.eclipse.papyrus.infra.core.sasheditor.editor.IPage page) {
+			if (page instanceof IEditorPage) {
+				basicPartActivated(((IEditorPage) page).getIEditorPart());
+			} else {
+				basicPartActivated(currentPapyrusEditor);
+			}
+		}
+
+		@Override
+		public void pageDeactivated(org.eclipse.papyrus.infra.core.sasheditor.editor.IPage page) {
+			if (page instanceof IEditorPage) {
+				partDeactivated(((IEditorPage) page).getIEditorPart());
+			} 
+		}
+
+		@Override
+		public void pageOpened(org.eclipse.papyrus.infra.core.sasheditor.editor.IPage page) {
+			if (page instanceof IEditorPage) {
+				partOpened(((IEditorPage) page).getIEditorPart());
+			}
+		}
+
+		@Override
+		public void pageClosed(org.eclipse.papyrus.infra.core.sasheditor.editor.IPage page) {
+			if (page instanceof IEditorPage) {
+				partClosed(((IEditorPage) page).getIEditorPart());
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
This pull request add three new views displaying the full hierarchy of the GEF Figures, the EditParts and the Views (GMF Notation model) of the current active GMF / Papyrus diagram.

All the views are synchronized with the GMF editor and supply a own implementation of a property sheet to display the values of the class fields, providing valuable information for debugging.

Most of the code from LogicalModelView is transfer to a generic view (PapyrusPageBookView). This new class is is extended by all the 4 views.