### PR TITLE
acampesino/issue 34

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/InteractionLayoutEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/InteractionLayoutEditPolicy.java
@@ -26,7 +26,6 @@ import org.eclipse.draw2d.Shape;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.transaction.util.TransactionUtil;
@@ -54,6 +53,7 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.Life
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.InteractionUtil;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.NoopCommand;
 import org.eclipse.papyrus.uml.service.types.element.UMLElementTypes;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Interaction;
@@ -164,20 +164,20 @@ public class InteractionLayoutEditPolicy extends XYLayoutEditPolicy {
 										mLifeline.nudgeHorizontally(request.getMoveDelta().x))))
 						.orElse(null);
 			} else if (RequestConstants.REQ_RESIZE_CHILDREN.equals(request.getType())) {
-				org.eclipse.emf.common.command.Command cmd = IdentityCommand.INSTANCE;
+				org.eclipse.emf.common.command.Command cmd = NoopCommand.INSTANCE;
 				if (request.getMoveDelta().x != 0) {
 					cmd = cmd.chain(mInteraction.getLifeline(lifeline)
 							.map(mLifeline -> mLifeline.nudgeHorizontally(request.getMoveDelta().x))
-							.orElse(IdentityCommand.INSTANCE));
+							.orElse(NoopCommand.INSTANCE));
 				}
 
 				if (request.getSizeDelta().width != 0) {
 					cmd = cmd.chain(mInteraction.getLifeline(lifeline)
 							.map(mLifeline -> mLifeline.resizeHorizontally(request.getSizeDelta().width))
-							.orElse(IdentityCommand.INSTANCE));
+							.orElse(NoopCommand.INSTANCE));
 				}
 
-				if (cmd == IdentityCommand.INSTANCE) {
+				if (cmd == NoopCommand.INSTANCE) {
 					return null;
 				}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
@@ -38,6 +38,9 @@
       <eParameters name="deltaY" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
     </eOperations>
     <eOperations name="remove" lowerBound="1" eType="#//Command"/>
+    <eOperations name="resize" lowerBound="1" eType="#//Command">
+      <eParameters name="deltaHeight" lowerBound="1" eType="ecore:EDataType platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore#//EInt"/>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="interaction" lowerBound="1"
         eType="#//MInteraction" changeable="false" volatile="true" transient="true"
         derived="true" resolveProxies="false"/>
@@ -298,6 +301,16 @@
         <details key="documentation" value="Nudge the lifeline horizontally, along with all of the layout that depends on it."/>
       </eAnnotations>
       <eParameters name="deltaX" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
+        <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+          <details key="documentation" value="the distance by which to nudge the lifeline in the X axis (negative values nudging to the left, of course)"/>
+        </eAnnotations>
+      </eParameters>
+    </eOperations>
+    <eOperations name="resizeHorizontally" lowerBound="1" eType="#//Command">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Resize the lifeline horizontally, nudging the following lifelines along with all of the layout that depends on it."/>
+      </eAnnotations>
+      <eParameters name="deltaWidth" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
           <details key="documentation" value="the distance by which to nudge the lifeline in the X axis (negative values nudging to the left, of course)"/>
         </eAnnotations>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
@@ -178,13 +178,21 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MELEMENT___REMOVE = 5;
 
 	/**
+	 * The operation id for the '<em>Resize</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MELEMENT___RESIZE__INT = 6;
+
+	/**
 	 * The number of operations of the '<em>MElement</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
 	 * @generated
 	 * @ordered
 	 */
-	int MELEMENT_OPERATION_COUNT = 6;
+	int MELEMENT_OPERATION_COUNT = 7;
 
 	/**
 	 * The meta object id for the
@@ -307,6 +315,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MINTERACTION___REMOVE = MELEMENT___REMOVE;
+
+	/**
+	 * The operation id for the '<em>Resize</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MINTERACTION___RESIZE__INT = MELEMENT___RESIZE__INT;
 
 	/**
 	 * The operation id for the '<em>Get Diagram View</em>' operation. <!-- begin-user-doc --> <!--
@@ -511,6 +527,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MLIFELINE___REMOVE = MELEMENT___REMOVE;
 
 	/**
+	 * The operation id for the '<em>Resize</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MLIFELINE___RESIZE__INT = MELEMENT___RESIZE__INT;
+
+	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -609,13 +633,22 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MLIFELINE___NUDGE_HORIZONTALLY__INT = MELEMENT_OPERATION_COUNT + 10;
 
 	/**
+	 * The operation id for the '<em>Resize Horizontally</em>' operation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MLIFELINE___RESIZE_HORIZONTALLY__INT = MELEMENT_OPERATION_COUNT + 11;
+
+	/**
 	 * The number of operations of the '<em>MLifeline</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
 	 * @generated
 	 * @ordered
 	 */
-	int MLIFELINE_OPERATION_COUNT = MELEMENT_OPERATION_COUNT + 11;
+	int MLIFELINE_OPERATION_COUNT = MELEMENT_OPERATION_COUNT + 12;
 
 	/**
 	 * The meta object id for the
@@ -729,6 +762,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MEXECUTION___REMOVE = MELEMENT___REMOVE;
+
+	/**
+	 * The operation id for the '<em>Resize</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION___RESIZE__INT = MELEMENT___RESIZE__INT;
 
 	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -897,6 +938,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MOCCURRENCE___REMOVE = MELEMENT___REMOVE;
 
 	/**
+	 * The operation id for the '<em>Resize</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MOCCURRENCE___RESIZE__INT = MELEMENT___RESIZE__INT;
+
+	/**
 	 * The number of operations of the '<em>MOccurrence</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
@@ -1027,6 +1076,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MEXECUTION_OCCURRENCE___REMOVE = MOCCURRENCE___REMOVE;
+
+	/**
+	 * The operation id for the '<em>Resize</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION_OCCURRENCE___RESIZE__INT = MOCCURRENCE___RESIZE__INT;
 
 	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1204,6 +1261,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MMESSAGE_END___REMOVE = MOCCURRENCE___REMOVE;
 
 	/**
+	 * The operation id for the '<em>Resize</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MMESSAGE_END___RESIZE__INT = MOCCURRENCE___RESIZE__INT;
+
+	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -1376,6 +1441,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MMESSAGE___REMOVE = MELEMENT___REMOVE;
+
+	/**
+	 * The operation id for the '<em>Resize</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MMESSAGE___RESIZE__INT = MELEMENT___RESIZE__INT;
 
 	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1589,6 +1662,16 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 */
 	EOperation getMElement__Remove();
+
+	/**
+	 * Returns the meta object for the '{@link org.eclipse.papyrus.uml.interaction.model.MElement#resize(int)
+	 * <em>Resize</em>}' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the '<em>Resize</em>' operation.
+	 * @see org.eclipse.papyrus.uml.interaction.model.MElement#resize(int)
+	 * @generated
+	 */
+	EOperation getMElement__Resize__int();
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.papyrus.uml.interaction.model.MInteraction
@@ -1885,6 +1968,17 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 */
 	EOperation getMLifeline__NudgeHorizontally__int();
+
+	/**
+	 * Returns the meta object for the
+	 * '{@link org.eclipse.papyrus.uml.interaction.model.MLifeline#resizeHorizontally(int) <em>Resize
+	 * Horizontally</em>}' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the '<em>Resize Horizontally</em>' operation.
+	 * @see org.eclipse.papyrus.uml.interaction.model.MLifeline#resizeHorizontally(int)
+	 * @generated
+	 */
+	EOperation getMLifeline__ResizeHorizontally__int();
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.papyrus.uml.interaction.model.MExecution
@@ -2382,6 +2476,14 @@ public interface SequenceDiagramPackage extends EPackage {
 		EOperation MELEMENT___REMOVE = eINSTANCE.getMElement__Remove();
 
 		/**
+		 * The meta object literal for the '<em><b>Resize</b></em>' operation. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
+		 * @generated
+		 */
+		EOperation MELEMENT___RESIZE__INT = eINSTANCE.getMElement__Resize__int();
+
+		/**
 		 * The meta object literal for the
 		 * '{@link org.eclipse.papyrus.uml.interaction.internal.model.impl.MInteractionImpl
 		 * <em>MInteraction</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2600,6 +2702,14 @@ public interface SequenceDiagramPackage extends EPackage {
 		 * @generated
 		 */
 		EOperation MLIFELINE___NUDGE_HORIZONTALLY__INT = eINSTANCE.getMLifeline__NudgeHorizontally__int();
+
+		/**
+		 * The meta object literal for the '<em><b>Resize Horizontally</b></em>' operation. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
+		 * @generated
+		 */
+		EOperation MLIFELINE___RESIZE_HORIZONTALLY__INT = eINSTANCE.getMLifeline__ResizeHorizontally__int();
 
 		/**
 		 * The meta object literal for the

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MElementImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MElementImpl.java
@@ -225,6 +225,16 @@ public abstract class MElementImpl<T extends Element> extends MObjectImpl<T> imp
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
+	 * @generated NOT
+	 */
+	@Override
+	public Command resize(int deltaHeight) {
+		return UnexecutableCommand.INSTANCE;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -286,6 +296,8 @@ public abstract class MElementImpl<T extends Element> extends MObjectImpl<T> imp
 				return nudge((Integer)arguments.get(0));
 			case SequenceDiagramPackage.MELEMENT___REMOVE:
 				return remove();
+			case SequenceDiagramPackage.MELEMENT___RESIZE__INT:
+				return resize((Integer)arguments.get(0));
 		}
 		return super.eInvoke(operationID, arguments);
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
@@ -254,15 +254,15 @@ public class MLifelineImpl extends MElementImpl<Lifeline> implements MLifeline {
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
-	 * @generated
+	 * @generated NOT
 	 */
 	@Override
 	public CreationCommand<Message> insertMessageAfter(MElement<?> beforeSend, int sendOffset,
 			MLifeline receiver, MElement<?> beforeRecv, int recvOffset, MessageSort sort,
 			NamedElement signature) {
-		// TODO: implement this method
-		// Ensure that you remove @generated or mark it @generated NOT
-		throw new UnsupportedOperationException();
+
+		return new InsertMessageCommand(this, beforeSend, sendOffset, receiver, beforeRecv, recvOffset, sort,
+				signature);
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.papyrus.uml.interaction.internal.model.commands.InsertExecuti
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.InsertMessageCommand;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.NudgeHorizontallyCommand;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.RemoveLifelineCommand;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.ResizeHorizontallyCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
@@ -259,9 +260,9 @@ public class MLifelineImpl extends MElementImpl<Lifeline> implements MLifeline {
 	public CreationCommand<Message> insertMessageAfter(MElement<?> beforeSend, int sendOffset,
 			MLifeline receiver, MElement<?> beforeRecv, int recvOffset, MessageSort sort,
 			NamedElement signature) {
-
-		return new InsertMessageCommand(this, beforeSend, sendOffset, receiver, beforeRecv, recvOffset, sort,
-				signature);
+		// TODO: implement this method
+		// Ensure that you remove @generated or mark it @generated NOT
+		throw new UnsupportedOperationException();
 	}
 
 	/**
@@ -296,6 +297,16 @@ public class MLifelineImpl extends MElementImpl<Lifeline> implements MLifeline {
 	@Override
 	public Command nudgeHorizontally(int deltaX) {
 		return new NudgeHorizontallyCommand(this, deltaX);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated NOT
+	 */
+	@Override
+	public Command resizeHorizontally(int deltaWidth) {
+		return new ResizeHorizontallyCommand(this, deltaWidth);
 	}
 
 	/**
@@ -401,6 +412,8 @@ public class MLifelineImpl extends MElementImpl<Lifeline> implements MLifeline {
 				return elementAt((Integer)arguments.get(0));
 			case SequenceDiagramPackage.MLIFELINE___NUDGE_HORIZONTALLY__INT:
 				return nudgeHorizontally((Integer)arguments.get(0));
+			case SequenceDiagramPackage.MLIFELINE___RESIZE_HORIZONTALLY__INT:
+				return resizeHorizontally((Integer)arguments.get(0));
 		}
 		return super.eInvoke(operationID, arguments);
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
@@ -334,6 +334,16 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
+	public EOperation getMElement__Resize__int() {
+		return mElementEClass.getEOperations().get(6);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
 	public EClass getMInteraction() {
 		return mInteractionEClass;
 	}
@@ -586,6 +596,16 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	@Override
 	public EOperation getMLifeline__NudgeHorizontally__int() {
 		return mLifelineEClass.getEOperations().get(10);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	public EOperation getMLifeline__ResizeHorizontally__int() {
+		return mLifelineEClass.getEOperations().get(11);
 	}
 
 	/**
@@ -959,6 +979,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		createEOperation(mElementEClass, MELEMENT___FOLLOWING);
 		createEOperation(mElementEClass, MELEMENT___NUDGE__INT);
 		createEOperation(mElementEClass, MELEMENT___REMOVE);
+		createEOperation(mElementEClass, MELEMENT___RESIZE__INT);
 
 		mInteractionEClass = createEClass(MINTERACTION);
 		createEReference(mInteractionEClass, MINTERACTION__LIFELINES);
@@ -990,6 +1011,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 				MLIFELINE___INSERT_MESSAGE_AFTER__MELEMENT_INT_MLIFELINE_MELEMENT_INT_MESSAGESORT_NAMEDELEMENT);
 		createEOperation(mLifelineEClass, MLIFELINE___ELEMENT_AT__INT);
 		createEOperation(mLifelineEClass, MLIFELINE___NUDGE_HORIZONTALLY__INT);
+		createEOperation(mLifelineEClass, MLIFELINE___RESIZE_HORIZONTALLY__INT);
 
 		mExecutionEClass = createEClass(MEXECUTION);
 		createEAttribute(mExecutionEClass, MEXECUTION__START);
@@ -1057,10 +1079,10 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 
 		// Obtain other dependent packages
 		UMLPackage theUMLPackage = (UMLPackage)EPackage.Registry.INSTANCE.getEPackage(UMLPackage.eNS_URI);
-		NotationPackage theNotationPackage = (NotationPackage)EPackage.Registry.INSTANCE
-				.getEPackage(NotationPackage.eNS_URI);
 		EcorePackage theEcorePackage = (EcorePackage)EPackage.Registry.INSTANCE
 				.getEPackage(EcorePackage.eNS_URI);
+		NotationPackage theNotationPackage = (NotationPackage)EPackage.Registry.INSTANCE
+				.getEPackage(NotationPackage.eNS_URI);
 
 		// Create type parameters
 		ETypeParameter mElementEClass_T = addETypeParameter(mElementEClass, "T"); //$NON-NLS-1$
@@ -1164,6 +1186,10 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		addEParameter(op, ecorePackage.getEInt(), "deltaY", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEOperation(getMElement__Remove(), this.getCommand(), "remove", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		op = initEOperation(getMElement__Resize__int(), this.getCommand(), "resize", 1, 1, IS_UNIQUE, //$NON-NLS-1$
+				IS_ORDERED);
+		addEParameter(op, theEcorePackage.getEInt(), "deltaHeight", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(mInteractionEClass, MInteraction.class, "MInteraction", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
 				IS_GENERATED_INSTANCE_CLASS);
@@ -1383,6 +1409,10 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		op = initEOperation(getMLifeline__NudgeHorizontally__int(), this.getCommand(), "nudgeHorizontally", 1, //$NON-NLS-1$
 				1, IS_UNIQUE, IS_ORDERED);
 		addEParameter(op, ecorePackage.getEInt(), "deltaX", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		op = initEOperation(getMLifeline__ResizeHorizontally__int(), this.getCommand(), "resizeHorizontally", //$NON-NLS-1$
+				1, 1, IS_UNIQUE, IS_ORDERED);
+		addEParameter(op, ecorePackage.getEInt(), "deltaWidth", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(mExecutionEClass, MExecution.class, "MExecution", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
 				IS_GENERATED_INSTANCE_CLASS);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
@@ -175,4 +175,13 @@ public interface MElement<T extends Element> extends MObject {
 	 */
 	Command remove();
 
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @model dataType="org.eclipse.papyrus.uml.interaction.model.Command" required="true"
+	 *        deltaHeightRequired="true"
+	 * @generated
+	 */
+	Command resize(int deltaHeight);
+
 } // MElement

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MLifeline.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MLifeline.java
@@ -261,4 +261,17 @@ public interface MLifeline extends MElement<Lifeline> {
 	 */
 	Command nudgeHorizontally(int deltaX);
 
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc --> <!-- begin-model-doc --> Resize the lifeline
+	 * horizontally, nudging the following lifelines along with all of the layout that depends on it.
+	 * 
+	 * @param deltaWidth
+	 *            the distance by which to nudge the lifeline in the X axis (negative values nudging to the
+	 *            left, of course) <!-- end-model-doc -->
+	 * @model dataType="org.eclipse.papyrus.uml.interaction.model.Command" required="true"
+	 *        deltaWidthRequired="true"
+	 * @generated
+	 */
+	Command resizeHorizontally(int deltaWidth);
+
 } // MLifeline

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/MoveRightVisitor.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/MoveRightVisitor.java
@@ -1,0 +1,59 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *   Antonio Campesino (Ericsson AB) - Extracted to its own class  
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import org.eclipse.gmf.runtime.notation.Shape;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.interaction.graph.Group;
+import org.eclipse.papyrus.uml.interaction.graph.Vertex;
+
+/**
+ * <em>Semantic Graph</em> visitor that computes the new locations for the visualizations of elements in the
+ * graph to the right of the one that was selected by the user.
+ *
+ * @author Christian W. Damus
+ */
+class MoveRightVisitor extends CommandBuildingVisitor<Vertex> {
+
+	/**
+	 * 
+	 */
+	private ModelCommand<?> horizontallyCommand;
+
+	private final int delta;
+
+	MoveRightVisitor(ModelCommand<?> horizontallyCommand, int delta) {
+		super();
+		this.horizontallyCommand = horizontallyCommand;
+
+		this.delta = delta;
+	}
+
+	@Override
+	protected void process(Vertex vertex) {
+		// Other kinds of elements don't have to move because they are anchored
+		// to one of these
+		switch (Group.kind(vertex)) {
+			case LIFELINE:
+			case COMBINED_FRAGMENT:
+				View view = vertex.getDiagramView();
+				if (view instanceof Shape) {
+					// Move the shape down
+					Shape shape = (Shape)view;
+					int left = this.horizontallyCommand.layoutHelper().getLeft(shape);
+					chain(this.horizontallyCommand.layoutHelper().setLeft(shape, left + delta));
+				}
+				break;
+		}
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
@@ -15,7 +15,6 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 import java.util.Optional;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.gmf.runtime.notation.Connector;
@@ -29,6 +28,7 @@ import org.eclipse.papyrus.uml.interaction.graph.GroupKind;
 import org.eclipse.papyrus.uml.interaction.graph.Tag;
 import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
+import org.eclipse.papyrus.uml.interaction.model.spi.NoopCommand;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Message;
 
@@ -76,7 +76,7 @@ public class NudgeCommand extends ModelCommand<MElementImpl<?>> {
 	@Override
 	protected Command createCommand() {
 		if (deltaY == 0) {
-			return IdentityCommand.INSTANCE;
+			return NoopCommand.INSTANCE;
 		}
 
 		// Note that a move up is just a negative move down

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeHorizontallyCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeHorizontallyCommand.java
@@ -16,10 +16,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.papyrus.uml.interaction.graph.GraphPredicates;
 import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MLifelineImpl;
+import org.eclipse.papyrus.uml.interaction.model.spi.NoopCommand;
 import org.eclipse.uml2.uml.UMLPackage;
 
 /**
@@ -49,7 +49,7 @@ public class NudgeHorizontallyCommand extends ModelCommand<MLifelineImpl> {
 	@Override
 	protected Command createCommand() {
 		if (deltaX == 0) {
-			return IdentityCommand.INSTANCE;
+			return NoopCommand.INSTANCE;
 		}
 
 		// Note that a move left is just a negative move right

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeOnRemovalCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeOnRemovalCommand.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
@@ -34,6 +33,7 @@ import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.spi.NoopCommand;
 import org.eclipse.uml2.uml.Element;
 
 /**
@@ -70,7 +70,7 @@ public class NudgeOnRemovalCommand extends ModelCommand<MInteractionImpl> {
 
 		/* create the command */
 		if (nudgeCommands.isEmpty()) {
-			command = IdentityCommand.INSTANCE;
+			command = NoopCommand.INSTANCE;
 		} else {
 			command = CompoundModelCommand.compose(editingDomain, nudgeCommands);
 		}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
@@ -791,6 +791,34 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	}
 
 	@Override
+	public Command setRight(Vertex v, int xPosition) {
+		Command result = UnexecutableCommand.INSTANCE;
+
+		View view = v.getDiagramView();
+		if (view instanceof Shape) {
+			result = setRight((Shape)view, xPosition);
+		}
+		return result;
+	}
+
+	@Override
+	@SuppressWarnings("boxing")
+	public Command setRight(Shape shape, int xPosition) {
+		Command result = UnexecutableCommand.INSTANCE;
+		if (isLifelineBody(shape)) {
+			// The lifeline body has no real width: its right is its left
+			return result;
+		}
+
+		if (shape.getLayoutConstraint() instanceof Size) {
+			int left = getLeft(shape);
+			result = SetCommand.create(editingDomain, shape.getLayoutConstraint(),
+					NotationPackage.Literals.SIZE__WIDTH, xPosition - left);
+		}
+		return result;
+	}
+
+	@Override
 	public Bounds getNewBounds(EClass eClass, Bounds proposedBounds, Node container) {
 		// TODO: Implement new bounds optimization
 		Bounds result = EcoreUtil.copy(proposedBounds);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
@@ -8,6 +8,8 @@
  *
  * Contributors:
  *   Christian W. Damus - Initial API and implementation
+ *   Antonio Campesino (Ericsson AB) - Addiding setRight functions
+ *   
  *****************************************************************************/
 
 package org.eclipse.papyrus.uml.interaction.model.spi;
@@ -198,6 +200,29 @@ public interface LayoutHelper {
 	 * @return the command, which may not be executable but will not be {@code null}
 	 */
 	Command setLeft(Shape shape, int xPosition);
+
+	/**
+	 * Obtains a command that sets the right (x-coördinate) of the diagram visual element associated with a
+	 * vertex in the graph.
+	 * 
+	 * @param v
+	 *            a vertex in the semantic dependency graph
+	 * @param xPosition
+	 *            the new right position to set
+	 * @return the command, which may not be executable but will not be {@code null}
+	 */
+	Command setRight(Vertex v, int xPosition);
+
+	/**
+	 * Obtains a command that sets the right (x-coördinate) of a {@code shape} in the sequence diagram.
+	 * 
+	 * @param shape
+	 *            a shape in the sequence diagram
+	 * @param xPosition
+	 *            the new right position to set
+	 * @return the command, which may not be executable but will not be {@code null}
+	 */
+	Command setRight(Shape shape, int xPosition);
 
 	/**
 	 * Returns the bounds for a new representation, given the proposed bounds.

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/NoopCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/NoopCommand.java
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model.spi;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.IdentityCommand;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.ModelCommand;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
+
+/**
+ * A no-op command that is always executable because it does nothing. This is to be preferred as an
+ * alternative to the {@link IdentityCommand} for two reasons:
+ * <ul>
+ * <li>{@linkplain #chain(Command) chaining} further commands onto this optimizes the chain by simply
+ * returning the chained command, the no-op being redundant</li>
+ * <li>as a consequence of the previous, if the chained command is some kind of {@link ModelCommand} or
+ * {@link CreationCommand} or other command that composes itself using the {@link CompoundModelCommand}, then
+ * further chaining will allow that command to employ this more logical-model-friendly variant of the EMF
+ * compound</li>
+ * </ul>
+ *
+ * @author Christian W. Damus
+ * @see CompoundModelCommand
+ */
+public class NoopCommand extends IdentityCommand {
+
+	/**
+	 * The shared instance of the no-op command.
+	 */
+	@SuppressWarnings("hiding")
+	public static final NoopCommand INSTANCE = new NoopCommand();
+
+	/**
+	 * Initializes me.
+	 */
+	protected NoopCommand() {
+		super();
+	}
+
+	@Override
+	public final Command chain(Command command) {
+		// We don't need to have the no-op command in the chain. This has the
+		// benefit also of letting the 'command', if it is a ModelCommand,
+		// compose itself further using the CompoundModelCommand
+		return command;
+	}
+}

--- a/releng/org.eclipse.papyrus.uml.diagram.sequence.targetplatform/org.eclipse.papyrus.uml.diagram.sequence.targetplatform.target
+++ b/releng/org.eclipse.papyrus.uml.diagram.sequence.targetplatform/org.eclipse.papyrus.uml.diagram.sequence.targetplatform.target
@@ -37,9 +37,9 @@
       <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
       <unit id="org.apache.commons.lang3.source" version="3.1.0.v201403281430"/>
       <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
+      <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
       <unit id="org.mockito" version="1.9.5.v201605172210"/>
-      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/S-builds/S20170804160030/repository"/>
+      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/S-builds/S20180730183850/repository"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.papyrus.uml.diagram.sequence.targetplatform/org.eclipse.papyrus.uml.diagram.sequence.targetplatform.tpd
+++ b/releng/org.eclipse.papyrus.uml.diagram.sequence.targetplatform/org.eclipse.papyrus.uml.diagram.sequence.targetplatform.tpd
@@ -26,7 +26,7 @@ location papyrus-oxygen "http://download.eclipse.org/modeling/mdt/papyrus/update
 	org.eclipse.papyrus.sdk.feature.source.feature.group [3.1.0,4.0.0)
 }
 
-location orbit "http://download.eclipse.org/tools/orbit/S-builds/S20170804160030/repository" {
+location orbit "http://download.eclipse.org/tools/orbit/S-builds/S20180730183850/repository" {
 	com.google.guava 21.0.0
 	com.google.guava.source 21.0.0
 	com.google.gson 2.7.0


### PR DESCRIPTION
This a work in progress, 

!!! DO NOT MERGE !!!

This pull request is for discuss the following issue:

. I am implementing the move / resize of lifeline heads. For the resizing case by the left side of the lifeline, the GEF request that comes to the policy is with a move delta (x) and a size delta (-x). So it look to me natural to implement the case as a move + resize cmd as I do not need to distinguish if it is a left or right side resize.
 
The issue come as I nudge the following lifeline in both commands (first to the right (+x) and then back to the left (-x)). As the logical model doesn’t update until the command executes, the position of the second set of nudges part form the original position instead of original + x.
 
I could implement the whole thing in a single command distinguish each case, but I don’t think that is a good solution. Also the problem will arise if two policies contribute to the command chain for the same logical element, the last one will override anything done by the first one, as the changes are done into the commands, instead into the logical model.
