### PR TITLE
Issue 308 -Migrate additional constants to layout constraints

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/LifelineBodyFigure.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/LifelineBodyFigure.java
@@ -31,6 +31,8 @@ public class LifelineBodyFigure extends NodeFigure {
 
 	private static final int TOLERANCE = 5;
 
+	private int anchorHeight;
+
 	@Override
 	protected void paintFigure(Graphics graphics) {
 		Polyline line = new Polyline();
@@ -80,7 +82,7 @@ public class LifelineBodyFigure extends NodeFigure {
 
 	@Override
 	protected ConnectionAnchor createDefaultAnchor() {
-		return new LifelineBodyAnchor(this);
+		return new LifelineBodyAnchor(this, anchorHeight);
 	}
 
 	@Override
@@ -131,6 +133,14 @@ public class LifelineBodyFigure extends NodeFigure {
 	@Override
 	protected boolean useLocalCoordinates() {
 		return true;
+	}
+
+	public int getAnchorHeight() {
+		return anchorHeight;
+	}
+
+	public void setAnchorHeight(int anchorHeight) {
+		this.anchorHeight = anchorHeight;
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/RightArrowDecoration.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/RightArrowDecoration.java
@@ -22,9 +22,8 @@ public class RightArrowDecoration extends PolylineDecoration {
 
 	public RightArrowDecoration() {
 		setTemplate(TRIANGLE_TIP);
-		setScale(5.0, 5.0);
 		setLineWidth(1);
 		setBackgroundColor(ColorConstants.blue);
 	}
-	
+
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/LifelineBodyAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/LifelineBodyAnchor.java
@@ -28,10 +28,6 @@ public class LifelineBodyAnchor extends AbstractConnectionAnchor {
 
 	private int height;
 
-	public LifelineBodyAnchor(LifelineBodyFigure lifelinebodyFigure) {
-		this(lifelinebodyFigure, 10);
-	}
-
 	public LifelineBodyAnchor(LifelineBodyFigure lifelinebodyFigure, int height) {
 		super(lifelinebodyFigure);
 		// We actually attach the anchor to the BodyFigure of the Lifeline

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/GeneralOrderingEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/GeneralOrderingEditPart.java
@@ -11,12 +11,15 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts;
 
+import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.ARROW;
+
 import org.eclipse.draw2d.Connection;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.ConnectionNodeEditPart;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.GeneralOrderingFigure;
+import org.eclipse.papyrus.uml.diagram.sequence.figure.RightArrowDecoration;
 
-public class GeneralOrderingEditPart extends ConnectionNodeEditPart {
+public class GeneralOrderingEditPart extends ConnectionNodeEditPart implements ISequenceEditPart {
 
 	public GeneralOrderingEditPart(View view) {
 		super(view);
@@ -24,7 +27,11 @@ public class GeneralOrderingEditPart extends ConnectionNodeEditPart {
 
 	@Override
 	protected Connection createConnectionFigure() {
-		return new GeneralOrderingFigure();
+		GeneralOrderingFigure connection = new GeneralOrderingFigure();
+		RightArrowDecoration targetDecoration = new RightArrowDecoration();
+		targetDecoration.setScale(getMinimumWidth(ARROW), getMinimumHeight(ARROW));
+		connection.setTargetDecoration(targetDecoration);
+		return connection;
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineBodyEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineBodyEditPart.java
@@ -15,6 +15,7 @@ package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts;
 import static org.eclipse.gmf.runtime.notation.NotationPackage.Literals.LINE_STYLE__LINE_WIDTH;
 import static org.eclipse.gmf.runtime.notation.NotationPackage.Literals.LOCATION__X;
 import static org.eclipse.gmf.runtime.notation.NotationPackage.Literals.LOCATION__Y;
+import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.ANCHOR;
 
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -55,6 +56,7 @@ public class LifelineBodyEditPart extends BorderedBorderItemEditPart implements 
 	@Override
 	protected NodeFigure createMainFigure() {
 		LifelineBodyFigure fig = new LifelineBodyFigure();
+		fig.setAnchorHeight(getMinimumHeight(ANCHOR));
 		return fig;
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ISequenceEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ISequenceEditPolicy.java
@@ -23,6 +23,7 @@ import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.UnexecutableCommand;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.commands.wrappers.OperationToGEFCommandWrapper;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.Activator;
@@ -67,6 +68,12 @@ public interface ISequenceEditPolicy extends EditPolicy {
 	static IFigure __getHostFigure(ISequenceEditPolicy __this) {
 		EditPart host = __this.getHost();
 		return (host instanceof GraphicalEditPart) ? ((GraphicalEditPart)host).getFigure() : null;
+	}
+
+	// This should be a private 'getHostView' method in Java 9
+	static View __getHostView(ISequenceEditPolicy __this) {
+		EditPart host = __this.getHost();
+		return (host instanceof IGraphicalEditPart) ? ((IGraphicalEditPart)host).getNotationView() : null;
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/InteractionLayoutEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/InteractionLayoutEditPolicy.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
 
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.ISequenceEditPolicy.__getHostView;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil.asBounds;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil.asRectangle;
 import static org.eclipse.papyrus.uml.service.types.utils.ElementUtil.isTypeOf;
@@ -58,7 +59,7 @@ import org.eclipse.uml2.uml.UMLPackage;
 /**
  * Specific {@link LayoutEditPolicy} that relies on the logical model to draw feedback.
  */
-public class InteractionLayoutEditPolicy extends XYLayoutEditPolicy {
+public class InteractionLayoutEditPolicy extends XYLayoutEditPolicy implements ISequenceEditPolicy {
 
 	private Shape feedback;
 
@@ -102,7 +103,9 @@ public class InteractionLayoutEditPolicy extends XYLayoutEditPolicy {
 			Dimension proposedSize = createRequest.getSize();
 			if (proposedSize == null) {
 				// This will be null until the user draws out a rect
-				proposedSize = new Dimension(45, 180); // TODO
+				int minWidth = getLayoutConstraints().getMinimumHeight(__getHostView(this));
+				int minHeight = getLayoutConstraints().getMinimumHeight(__getHostView(this));
+				proposedSize = new Dimension(minWidth, minHeight);
 			}
 
 			translateFromAbsoluteToLayoutRelative(proposedLocation);
@@ -166,7 +169,8 @@ public class InteractionLayoutEditPolicy extends XYLayoutEditPolicy {
 		return super.createChangeConstraintCommand(request, child, newConstraint);
 	}
 
-	protected Point getRelativeLocation(Point location) {
+	@Override
+	public Point getRelativeLocation(Point location) {
 		Point absolute = location.getCopy();
 		Rectangle parentBounds = getParentBounds();
 		Point insideLocation = absolute.translate(parentBounds.getLocation().negate());

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
@@ -13,6 +13,7 @@ package org.eclipse.papyrus.uml.interaction.internal.model.spi.impl;
 
 import static java.lang.Math.abs;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.applyModifier;
+import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.ANCHOR;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.ARROW;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.NO_MODIFIER;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.BOTTOM;
@@ -164,6 +165,8 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 		result.put("Shape_Lifeline_Body", 400);
 		result.put(applyModifier(ARROW, "Edge_Message"), 5);
 		result.put("Shape_Execution_Specification", 40);
+		result.put("Interaction_Contents", 180);
+		result.put(applyModifier(ANCHOR, "Shape_Lifeline_Body"), 10);
 
 		return result;
 	}
@@ -174,7 +177,7 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 
 		result.put("Shape_Lifeline_Body", 1);
 		result.put(applyModifier(ARROW, "Edge_Message"), 5);
-
+		result.put("Interaction_Contents", 45);
 		return result;
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutConstraints.java
@@ -31,6 +31,8 @@ public interface LayoutConstraints {
 		public static String NO_MODIFIER = ""; //$NON-NLS-1$
 
 		public static final String ARROW = "arrow"; //$NON-NLS-1$
+
+		public static final String ANCHOR = "anchor"; //$NON-NLS-1$
 	}
 
 	/**
@@ -180,11 +182,11 @@ public interface LayoutConstraints {
 
 	/**
 	 * Applies a {@link Modifiers modifier} to the given <code>viewType</code> and returns the resulting key.
+	 * 
 	 * @param modifier
 	 *            the modifier.
 	 * @param viewType
 	 *            the view type.
-	 * 
 	 * @return The key representing the view type with the given modifier applied.
 	 */
 	public static String applyModifier(String modifier, String viewType) {


### PR DESCRIPTION
Centralizes the magic numbers of figures, anchors & edit policies in the
layout
constraints.

The magic numbers of HeaderFigure are not included in this change. The class is curerntly not used and seems to be obsolete


Signed-off-by: Tobias Ortmayr <tortmayr.ext@eclipsesource.com>