### PR TITLE
#308-Rename anchor height property & refactor ISequenceEditPolicy

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/LifelineBodyFigure.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/LifelineBodyFigure.java
@@ -31,7 +31,7 @@ public class LifelineBodyFigure extends NodeFigure {
 
 	private static final int TOLERANCE = 5;
 
-	private int anchorHeight;
+	private int defaultAnchorDistance;
 
 	@Override
 	protected void paintFigure(Graphics graphics) {
@@ -82,7 +82,7 @@ public class LifelineBodyFigure extends NodeFigure {
 
 	@Override
 	protected ConnectionAnchor createDefaultAnchor() {
-		return new LifelineBodyAnchor(this, anchorHeight);
+		return new LifelineBodyAnchor(this, defaultAnchorDistance);
 	}
 
 	@Override
@@ -135,12 +135,12 @@ public class LifelineBodyFigure extends NodeFigure {
 		return true;
 	}
 
-	public int getAnchorHeight() {
-		return anchorHeight;
+	public int getDefaultAnchorDistance() {
+		return defaultAnchorDistance;
 	}
 
-	public void setAnchorHeight(int anchorHeight) {
-		this.anchorHeight = anchorHeight;
+	public void setDefaultAnchorDistance(int distance) {
+		this.defaultAnchorDistance = distance;
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/LifelineBodyAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/LifelineBodyAnchor.java
@@ -19,33 +19,33 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.LifelineBodyFigure;
 
 /**
- * An Anchor on the Lifeline body. The anchor is configured with a Height position relative to the top of the
- * lifeline body.
+ * An Anchor on the Lifeline body. The anchor is configured with a Distance position relative to the top of
+ * the lifeline body.
  */
 public class LifelineBodyAnchor extends AbstractConnectionAnchor {
 
 	private final LifelineBodyFigure lifelinebodyFigure;
 
-	private int height;
+	private int distance;
 
-	public LifelineBodyAnchor(LifelineBodyFigure lifelinebodyFigure, int height) {
+	public LifelineBodyAnchor(LifelineBodyFigure lifelinebodyFigure, int distance) {
 		super(lifelinebodyFigure);
 		// We actually attach the anchor to the BodyFigure of the Lifeline
 		// Note: this causes issues for policies/interaction, because the body is far away
 		// from the Lifeline's Bounds. However, we're only interested in rendering here, and this works fine
-		this.height = height;
+		this.distance = distance;
 		this.lifelinebodyFigure = lifelinebodyFigure;
 	}
 
 	public String getTerminal() {
-		return String.valueOf(height);
+		return String.valueOf(distance);
 	}
 
 	@Override
 	public Point getLocation(Point reference) {
 		Rectangle body = lifelinebodyFigure.getBounds().getCopy();
 		lifelinebodyFigure.translateToAbsolute(body);
-		int boundedHeight = Math.min(height, body.height);
+		int boundedHeight = Math.min(distance, body.height);
 		int realHeight = (int)Math.round(boundedHeight * getScale(lifelinebodyFigure));
 		Point location = new Point(0, realHeight);
 		location.translate(body.getTopLeft());

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineBodyEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineBodyEditPart.java
@@ -56,7 +56,7 @@ public class LifelineBodyEditPart extends BorderedBorderItemEditPart implements 
 	@Override
 	protected NodeFigure createMainFigure() {
 		LifelineBodyFigure fig = new LifelineBodyFigure();
-		fig.setAnchorHeight(getMinimumHeight(ANCHOR));
+		fig.setDefaultAnchorDistance(getMinimumHeight(ANCHOR));
 		return fig;
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ISequenceEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ISequenceEditPolicy.java
@@ -94,4 +94,13 @@ public interface ISequenceEditPolicy extends EditPolicy {
 
 		return result;
 	}
+
+	default int getMinimumWidth() {
+		return getLayoutConstraints().getMinimumWidth(__getHostView(this));
+	}
+
+	default int getMinimumHeight() {
+		return getLayoutConstraints().getMinimumHeight(__getHostView(this));
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/InteractionLayoutEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/InteractionLayoutEditPolicy.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
 
-import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.ISequenceEditPolicy.__getHostView;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil.asBounds;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.GeometryUtil.asRectangle;
 import static org.eclipse.papyrus.uml.service.types.utils.ElementUtil.isTypeOf;
@@ -103,8 +102,8 @@ public class InteractionLayoutEditPolicy extends XYLayoutEditPolicy implements I
 			Dimension proposedSize = createRequest.getSize();
 			if (proposedSize == null) {
 				// This will be null until the user draws out a rect
-				int minWidth = getLayoutConstraints().getMinimumHeight(__getHostView(this));
-				int minHeight = getLayoutConstraints().getMinimumHeight(__getHostView(this));
+				int minWidth = getMinimumWidth();
+				int minHeight = getMinimumHeight();
 				proposedSize = new Dimension(minWidth, minHeight);
 			}
 


### PR DESCRIPTION
Addresses review comments by Christian.

* Rename the anchor height property (and corresponding API Methods) to
anchor width

* Add getMinimumWidth() and getMinimumHeight methods to
ISequenceEditPoliy (similar to the ISequenceEditPart counterpart). This
enables the intended private use of the __getHostView() method

Signed-off-by: Tobias Ortmayr <tortmayr.ext@eclipsesource.com>