### PR TITLE
Lifeline resize: Ensure strict compound

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/InteractionLayoutEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/InteractionLayoutEditPolicy.java
@@ -26,7 +26,6 @@ import org.eclipse.draw2d.Shape;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.transaction.util.TransactionUtil;
@@ -54,6 +53,7 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.Life
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.InteractionUtil;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.NoopCommand;
 import org.eclipse.papyrus.uml.service.types.element.UMLElementTypes;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Interaction;
@@ -164,20 +164,20 @@ public class InteractionLayoutEditPolicy extends XYLayoutEditPolicy {
 										mLifeline.nudgeHorizontally(request.getMoveDelta().x))))
 						.orElse(null);
 			} else if (RequestConstants.REQ_RESIZE_CHILDREN.equals(request.getType())) {
-				org.eclipse.emf.common.command.Command cmd = IdentityCommand.INSTANCE;
+				org.eclipse.emf.common.command.Command cmd = NoopCommand.INSTANCE;
 				if (request.getMoveDelta().x != 0) {
 					cmd = cmd.chain(mInteraction.getLifeline(lifeline)
 							.map(mLifeline -> mLifeline.nudgeHorizontally(request.getMoveDelta().x))
-							.orElse(IdentityCommand.INSTANCE));
+							.orElse(NoopCommand.INSTANCE));
 				}
 
 				if (request.getSizeDelta().width != 0) {
 					cmd = cmd.chain(mInteraction.getLifeline(lifeline)
 							.map(mLifeline -> mLifeline.resizeHorizontally(request.getSizeDelta().width))
-							.orElse(IdentityCommand.INSTANCE));
+							.orElse(NoopCommand.INSTANCE));
 				}
 
-				if (cmd == IdentityCommand.INSTANCE) {
+				if (cmd == NoopCommand.INSTANCE) {
 					return null;
 				}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
@@ -15,7 +15,6 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 import java.util.Optional;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.gmf.runtime.notation.Connector;
@@ -29,6 +28,7 @@ import org.eclipse.papyrus.uml.interaction.graph.GroupKind;
 import org.eclipse.papyrus.uml.interaction.graph.Tag;
 import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
+import org.eclipse.papyrus.uml.interaction.model.spi.NoopCommand;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Message;
 
@@ -76,7 +76,7 @@ public class NudgeCommand extends ModelCommand<MElementImpl<?>> {
 	@Override
 	protected Command createCommand() {
 		if (deltaY == 0) {
-			return IdentityCommand.INSTANCE;
+			return NoopCommand.INSTANCE;
 		}
 
 		// Note that a move up is just a negative move down

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeHorizontallyCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeHorizontallyCommand.java
@@ -16,10 +16,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.papyrus.uml.interaction.graph.GraphPredicates;
 import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MLifelineImpl;
+import org.eclipse.papyrus.uml.interaction.model.spi.NoopCommand;
 import org.eclipse.uml2.uml.UMLPackage;
 
 /**
@@ -49,7 +49,7 @@ public class NudgeHorizontallyCommand extends ModelCommand<MLifelineImpl> {
 	@Override
 	protected Command createCommand() {
 		if (deltaX == 0) {
-			return IdentityCommand.INSTANCE;
+			return NoopCommand.INSTANCE;
 		}
 
 		// Note that a move left is just a negative move right

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeOnRemovalCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeOnRemovalCommand.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
@@ -34,6 +33,7 @@ import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.spi.NoopCommand;
 import org.eclipse.uml2.uml.Element;
 
 /**
@@ -70,7 +70,7 @@ public class NudgeOnRemovalCommand extends ModelCommand<MInteractionImpl> {
 
 		/* create the command */
 		if (nudgeCommands.isEmpty()) {
-			command = IdentityCommand.INSTANCE;
+			command = NoopCommand.INSTANCE;
 		} else {
 			command = CompoundModelCommand.compose(editingDomain, nudgeCommands);
 		}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/NoopCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/NoopCommand.java
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model.spi;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.IdentityCommand;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.ModelCommand;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
+
+/**
+ * A no-op command that is always executable because it does nothing. This is to be preferred as an
+ * alternative to the {@link IdentityCommand} for two reasons:
+ * <ul>
+ * <li>{@linkplain #chain(Command) chaining} further commands onto this optimizes the chain by simply
+ * returning the chained command, the no-op being redundant</li>
+ * <li>as a consequence of the previous, if the chained command is some kind of {@link ModelCommand} or
+ * {@link CreationCommand} or other command that composes itself using the {@link CompoundModelCommand}, then
+ * further chaining will allow that command to employ this more logical-model-friendly variant of the EMF
+ * compound</li>
+ * </ul>
+ *
+ * @author Christian W. Damus
+ * @see CompoundModelCommand
+ */
+public class NoopCommand extends IdentityCommand {
+
+	/**
+	 * The shared instance of the no-op command.
+	 */
+	@SuppressWarnings("hiding")
+	public static final NoopCommand INSTANCE = new NoopCommand();
+
+	/**
+	 * Initializes me.
+	 */
+	protected NoopCommand() {
+		super();
+	}
+
+	@Override
+	public final Command chain(Command command) {
+		// We don't need to have the no-op command in the chain. This has the
+		// benefit also of letting the 'command', if it is a ModelCommand,
+		// compose itself further using the CompoundModelCommand
+		return command;
+	}
+}


### PR DESCRIPTION
Introduce a `NoopCommand` as alternative to the `IdentityCommand` API that lets logical model commands compose themselves using the *pessimistic strict* `CompoundModelCommand`.  This ensures that in commands such as the `ResizeHorizontallyCommand`, chains beginning on the no-op will not lose the benefit of the strict compound that lets each command in sequence calculate its parameters on the basis of the results of the previous command.

A couple of points worth noting:
* we don't really need a `NoopCommand` type because we could just conventionally replace the `IdentityCommand` instead of chaining onto it in client code, but it's nice to have the consistency and fluency of chaining.  But that does mean that we need to remember to use the `NoopCommand` instead of `IdentityCommand` in all such cases.  We may rather decide not to require a new `NoopCommand` API
* this pull request fixes the calculation of moving the lifelines to the right in the particular scenario of resizing some lifeline on the left side because the entire chain of commands is calculated in the context of a `ResizeHorizontallyCommand` invoked by one edit-policy.  The scenario raised in pull request #315 in which multiple edit-policies contribute commands that need the pessimistic strict compounding treatment is not addressed here.  That will require introducing a *strict* variant of GEF's `CompoundCommand` that our edit-policies can use.  Happily, the `AbstractEditPart` of GEF relies on the self-chaining capability of commands so we could effect this by providing GEF command wrappers in our edit-policies that create strict compounds

This pull request also fixes commands to resize/move the rightmost lifeline not being executable because the move visitor doesn’t compute anything as there are no lifelines further to the right for it to operate on.