### PR TITLE
Update Sequence Diagram target definition

### DIFF
--- a/releng/org.eclipse.papyrus.uml.diagram.sequence.targetplatform/org.eclipse.papyrus.uml.diagram.sequence.targetplatform.target
+++ b/releng/org.eclipse.papyrus.uml.diagram.sequence.targetplatform/org.eclipse.papyrus.uml.diagram.sequence.targetplatform.target
@@ -39,7 +39,7 @@
       <unit id="org.junit" version="4.12.0.v201504281640"/>
       <unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
       <unit id="org.mockito" version="1.9.5.v201605172210"/>
-      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/S-builds/S20170804160030/repository"/>
+      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository/"/>
     </location>
   </locations>
 </target>

--- a/releng/org.eclipse.papyrus.uml.diagram.sequence.targetplatform/org.eclipse.papyrus.uml.diagram.sequence.targetplatform.tpd
+++ b/releng/org.eclipse.papyrus.uml.diagram.sequence.targetplatform/org.eclipse.papyrus.uml.diagram.sequence.targetplatform.tpd
@@ -26,7 +26,7 @@ location papyrus-oxygen "http://download.eclipse.org/modeling/mdt/papyrus/update
 	org.eclipse.papyrus.sdk.feature.source.feature.group [3.1.0,4.0.0)
 }
 
-location orbit "http://download.eclipse.org/tools/orbit/S-builds/S20170804160030/repository" {
+location orbit "http://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository" {
 	com.google.guava 21.0.0
 	com.google.guava.source 21.0.0
 	com.google.gson 2.7.0


### PR DESCRIPTION
This changes fixes a target content resolution issue for the "Sequence Diagram" target. Updates the repository location for the Eclipse Orbit project from an outdated (no longer existing) stable (S) repository to the recommended (R) repository for Oxygen.