### PR TITLE
Issue #38 Semantic constraint on move

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/META-INF/MANIFEST.MF
@@ -28,5 +28,7 @@ Export-Package: org.eclipse.papyrus.uml.diagram.sequence.runtime.internal;x-frie
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.part;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.preferences;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
+ org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools;x-internal:=true,
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util;x-internal:=true,
  org.eclipse.papyrus.uml.diagram.sequence.runtime.util
+Import-Package: com.google.common.eventbus;version="[21.0.0,22.0.0)"

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
@@ -245,23 +245,21 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 	@Override
 	protected Command getReconnectSourceCommand(ReconnectRequest request) {
 		Command result = super.getReconnectSourceCommand(request);
-
-		if (isForce(request)) {
-			// Just reconnect this end; no sloping constraints required
-			return result;
-		}
-
 		ConnectionEditPart connectionEP = (ConnectionEditPart)request.getConnectionEditPart();
-		Connection connection = (Connection)connectionEP.getFigure();
-		Point targetLocation = getLocation(connection.getTargetAnchor());
 
-		// Apply constraints implemented in the feedback
-		SetConnectionAnchorsCommand scaCommand = getSetConnectionAnchorsCommand(result);
-		INodeEditPart target = (INodeEditPart)connectionEP.getTarget();
-		ReconnectRequest targetRequest = new ReconnectRequest(REQ_RECONNECT_TARGET);
-		targetRequest.setLocation(targetLocation);
-		ConnectionAnchor newTargetAnchor = target.getTargetConnectionAnchor(targetRequest);
-		scaCommand.setNewTargetTerminal(target.mapConnectionAnchorToTerminal(newTargetAnchor));
+		if (!isForce(request)) {
+			// Need feedback constraints in addition to semantic constraints
+			Connection connection = (Connection)connectionEP.getFigure();
+			Point targetLocation = getLocation(connection.getTargetAnchor());
+
+			// Apply constraints implemented in the feedback
+			SetConnectionAnchorsCommand scaCommand = getSetConnectionAnchorsCommand(result);
+			INodeEditPart target = (INodeEditPart)connectionEP.getTarget();
+			ReconnectRequest targetRequest = new ReconnectRequest(REQ_RECONNECT_TARGET);
+			targetRequest.setLocation(targetLocation);
+			ConnectionAnchor newTargetAnchor = target.getTargetConnectionAnchor(targetRequest);
+			scaCommand.setNewTargetTerminal(target.mapConnectionAnchorToTerminal(newTargetAnchor));
+		}
 
 		return getSourceEnd(connectionEP).flatMap(src -> constrainReconnection(request, src)).orElse(result);
 	}
@@ -289,23 +287,21 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 	@Override
 	protected Command getReconnectTargetCommand(ReconnectRequest request) {
 		Command result = super.getReconnectTargetCommand(request);
-
-		if (isForce(request)) {
-			// Just reconnect this end; no sloping constraints required
-			return result;
-		}
-
 		ConnectionEditPart connectionEP = (ConnectionEditPart)request.getConnectionEditPart();
-		Connection connection = (Connection)connectionEP.getFigure();
-		Point sourceLocation = getLocation(connection.getSourceAnchor());
 
-		// Apply constraints implemented in the feedback
-		SetConnectionAnchorsCommand scaCommand = getSetConnectionAnchorsCommand(result);
-		INodeEditPart source = (INodeEditPart)connectionEP.getSource();
-		ReconnectRequest sourceRequest = new ReconnectRequest(REQ_RECONNECT_SOURCE);
-		sourceRequest.setLocation(sourceLocation);
-		ConnectionAnchor newSourceAnchor = source.getSourceConnectionAnchor(sourceRequest);
-		scaCommand.setNewSourceTerminal(source.mapConnectionAnchorToTerminal(newSourceAnchor));
+		if (!isForce(request)) {
+			// Need feedback constraints in addition to semantic constraints
+			Connection connection = (Connection)connectionEP.getFigure();
+			Point sourceLocation = getLocation(connection.getSourceAnchor());
+
+			// Apply constraints implemented in the feedback
+			SetConnectionAnchorsCommand scaCommand = getSetConnectionAnchorsCommand(result);
+			INodeEditPart source = (INodeEditPart)connectionEP.getSource();
+			ReconnectRequest sourceRequest = new ReconnectRequest(REQ_RECONNECT_SOURCE);
+			sourceRequest.setLocation(sourceLocation);
+			ConnectionAnchor newSourceAnchor = source.getSourceConnectionAnchor(sourceRequest);
+			scaCommand.setNewSourceTerminal(source.mapConnectionAnchorToTerminal(newSourceAnchor));
+		}
 
 		return getTargetEnd(connectionEP).flatMap(tgt -> constrainReconnection(request, tgt)).orElse(result);
 	}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/DelegatingDragTracker.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/DelegatingDragTracker.java
@@ -1,0 +1,164 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools;
+
+import java.util.Map;
+
+import org.eclipse.gef.DragTracker;
+import org.eclipse.gef.EditDomain;
+import org.eclipse.gef.EditPartViewer;
+import org.eclipse.swt.dnd.DragSourceEvent;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.TraverseEvent;
+import org.eclipse.swt.widgets.Event;
+
+/**
+ * A simple delegating drag tracker.
+ */
+public class DelegatingDragTracker implements DragTracker {
+
+	private final DragTracker delegate;
+
+	/**
+	 * Initializes me with my {@code delegate}.
+	 *
+	 * @param delegate
+	 *            my delegate
+	 */
+	public DelegatingDragTracker(DragTracker delegate) {
+		super();
+
+		this.delegate = delegate;
+	}
+
+	protected final DragTracker getDelegate() {
+		return delegate;
+	}
+
+	//
+	// Delegation methods
+	//
+
+	@Override
+	public void commitDrag() {
+		delegate.commitDrag();
+	}
+
+	@Override
+	public void activate() {
+		delegate.activate();
+	}
+
+	@Override
+	public void deactivate() {
+		delegate.deactivate();
+	}
+
+	@Override
+	public void focusGained(FocusEvent event, EditPartViewer viewer) {
+		delegate.focusGained(event, viewer);
+	}
+
+	@Override
+	public void focusLost(FocusEvent event, EditPartViewer viewer) {
+		delegate.focusLost(event, viewer);
+	}
+
+	@Override
+	public void keyDown(KeyEvent keyEvent, EditPartViewer viewer) {
+		delegate.keyDown(keyEvent, viewer);
+	}
+
+	@Override
+	public void keyTraversed(TraverseEvent event, EditPartViewer viewer) {
+		delegate.keyTraversed(event, viewer);
+	}
+
+	@Override
+	public void keyUp(KeyEvent keyEvent, EditPartViewer viewer) {
+		delegate.keyUp(keyEvent, viewer);
+	}
+
+	@Override
+	public void mouseDoubleClick(MouseEvent mouseEvent, EditPartViewer viewer) {
+		delegate.mouseDoubleClick(mouseEvent, viewer);
+	}
+
+	@Override
+	public void mouseDown(MouseEvent mouseEvent, EditPartViewer viewer) {
+		delegate.mouseDown(mouseEvent, viewer);
+	}
+
+	@Override
+	public void mouseDrag(MouseEvent mouseEvent, EditPartViewer viewer) {
+		delegate.mouseDrag(mouseEvent, viewer);
+	}
+
+	@Override
+	public void mouseHover(MouseEvent mouseEvent, EditPartViewer viewer) {
+		delegate.mouseHover(mouseEvent, viewer);
+	}
+
+	@Override
+	public void mouseMove(MouseEvent mouseEvent, EditPartViewer viewer) {
+		delegate.mouseMove(mouseEvent, viewer);
+	}
+
+	@Override
+	public void mouseUp(MouseEvent mouseEvent, EditPartViewer viewer) {
+		delegate.mouseUp(mouseEvent, viewer);
+	}
+
+	@Override
+	public void mouseWheelScrolled(Event event, EditPartViewer viewer) {
+		delegate.mouseWheelScrolled(event, viewer);
+	}
+
+	@Override
+	public void nativeDragFinished(DragSourceEvent event, EditPartViewer viewer) {
+		delegate.nativeDragFinished(event, viewer);
+	}
+
+	@Override
+	public void nativeDragStarted(DragSourceEvent event, EditPartViewer viewer) {
+		delegate.nativeDragStarted(event, viewer);
+	}
+
+	@Override
+	public void setEditDomain(EditDomain domain) {
+		delegate.setEditDomain(domain);
+	}
+
+	@Override
+	public void setViewer(EditPartViewer viewer) {
+		delegate.setViewer(viewer);
+	}
+
+	@Override
+	public void viewerEntered(MouseEvent mouseEvent, EditPartViewer viewer) {
+		delegate.viewerEntered(mouseEvent, viewer);
+	}
+
+	@Override
+	public void viewerExited(MouseEvent mouseEvent, EditPartViewer viewer) {
+		delegate.viewerExited(mouseEvent, viewer);
+	}
+
+	@Override
+	public void setProperties(Map properties) {
+		delegate.setProperties(properties);
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/MessageMoveTracker.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/MessageMoveTracker.java
@@ -1,0 +1,104 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+
+import org.eclipse.draw2d.Cursors;
+import org.eclipse.gef.ConnectionEditPart;
+import org.eclipse.gef.DragTracker;
+import org.eclipse.gef.RequestConstants;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.CommandCreatedEvent;
+import org.eclipse.swt.graphics.Cursor;
+
+/**
+ * Drag tracker handling the moving of a message, especially updating the cursor according to whether the move
+ * can validly be effected.
+ *
+ * @author Christian W. Damus
+ */
+public class MessageMoveTracker extends DelegatingDragTracker {
+
+	private final ConnectionEditPart owner;
+
+	private final EventBus bus;
+
+	private Cursor defaultCursor;
+
+	private Cursor disabledCursor;
+
+	private Command command;
+
+	/**
+	 * Initializes me.
+	 *
+	 * @param owner
+	 */
+	public MessageMoveTracker(ConnectionEditPart owner, DragTracker delegate, EventBus bus) {
+		super(delegate);
+
+		this.owner = owner;
+		this.bus = bus;
+
+		setDefaultCursor(owner.getFigure().getCursor());
+		setDisabledCursor(Cursors.NO);
+	}
+
+	/**
+	 * @param defaultCursor
+	 *            the defaultCursor to set
+	 */
+	public void setDefaultCursor(Cursor defaultCursor) {
+		this.defaultCursor = defaultCursor;
+	}
+
+	/**
+	 * @param disabledCursor
+	 *            the disabledCursor to set
+	 */
+	public void setDisabledCursor(Cursor disabledCursor) {
+		this.disabledCursor = disabledCursor;
+	}
+
+	@Override
+	public void activate() {
+		bus.register(this);
+
+		super.activate();
+
+		refreshCursor();
+	}
+
+	@Override
+	public void deactivate() {
+		bus.unregister(this);
+		this.command = null;
+
+		super.deactivate();
+		refreshCursor();
+	}
+
+	@Subscribe
+	public void handleCommandCreated(CommandCreatedEvent event) {
+		if (RequestConstants.REQ_CREATE_BENDPOINT.equals(event.getRequest().getType())) {
+			this.command = event.getCommand();
+			refreshCursor();
+		}
+	}
+
+	protected void refreshCursor() {
+		owner.getFigure().setCursor(command == null || command.canExecute() ? defaultCursor : disabledCursor);
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/util/CommandCreatedEvent.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/util/CommandCreatedEvent.java
@@ -1,0 +1,61 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util;
+
+import org.eclipse.gef.Request;
+import org.eclipse.gef.commands.Command;
+
+/**
+ * Event signalling the creation of a command (or not) in response to an request.
+ *
+ * @author Christian W. Damus
+ */
+public final class CommandCreatedEvent {
+
+	private final Request request;
+
+	private final Command command;
+
+	/**
+	 * Initializes me with the command that was created and the request that engendered it.
+	 * 
+	 * @param request
+	 *            the request (may not be {@code null})
+	 * @param command
+	 *            the command created for it (may be {@code null})
+	 */
+	public CommandCreatedEvent(Request request, Command command) {
+		super();
+
+		this.request = request;
+		this.command = command;
+	}
+
+	/**
+	 * Queries the request for which a {@link #getCommand() command} was or was not created.
+	 * 
+	 * @return the request
+	 */
+	public Request getRequest() {
+		return request;
+	}
+
+	/**
+	 * Queries the command created for the {@link #getRequest() request}.
+	 * 
+	 * @return the command, or {@code null} if no command was created
+	 */
+	public Command getCommand() {
+		return command;
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageMoveUITest.java
@@ -107,6 +107,33 @@ public class MessageMoveUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat(messageEP, runs(sendX, y, recvX, y));
 	}
 
+	@Test
+	public void attemptToMoveAsyncMessageAcrossAnother() {
+		final int slopeY = INITIAL_Y + 80;
+		final int otherY = moveDown ? INITIAL_Y + 80 + 15 : INITIAL_Y - 15;
+
+		if (!moveDown) { // Be sure to create messages in top-down order to avoid nudging
+			createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, otherY), at(recvX, otherY));
+		}
+
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, INITIAL_Y),
+				at(recvX, slopeY)); // always sloping down, of course
+		assumeThat(messageEP, runs(sendX, INITIAL_Y, recvX, slopeY));
+
+		if (moveDown) { // Be sure to create messages in top-down order to avoid nudging
+			createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, otherY), at(recvX, otherY));
+		}
+
+		int delta = moveDown ? 30 : -30;
+		int x = (sendX + recvX) / 2;
+		int grabY = (INITIAL_Y + slopeY) / 2;
+		int y = grabY + delta;
+
+		editor.moveSelection(at(x, grabY), at(x, y));
+
+		assertThat("Message should not have moved", messageEP, runs(sendX, INITIAL_Y, recvX, slopeY));
+	}
+
 	//
 	// Test framework
 	//


### PR DESCRIPTION
Ensure that the semantic re-ordering constraint on message ends is enforced on the moving of a message.  This includes display of the no-smoking cursor when such constraint would be violated.