### PR TITLE
Proposal for nudging behavior of insert/delete commands

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
@@ -12,8 +12,6 @@
 
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
-import static java.lang.Math.max;
-
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Function;
@@ -182,11 +180,11 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 
 		// Now we have commands to add the execution specification. But, first we must make
 		// room for it in the diagram. Nudge the element that will follow the new execution
-		int spaceRequired = 2 * offset + height;
+
 		MElement<?> distanceFrom = insertionPoint;
 		Optional<Command> makeSpace = getTarget().following(insertionPoint).map(el -> {
 			OptionalInt distance = el.verticalDistance(distanceFrom);
-			return distance.isPresent() ? el.nudge(max(0, spaceRequired - distance.getAsInt())) : null;
+			return distance.isPresent() ? el.nudge(height) : null;
 		});
 		if (makeSpace.isPresent()) {
 			result = makeSpace.get().chain(result);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeOnRemovalCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeOnRemovalCommand.java
@@ -145,7 +145,7 @@ public class NudgeOnRemovalCommand extends ModelCommand<MInteractionImpl> {
 			Set<Integer> topsBelowDeletion = topToElements.keySet().stream()//
 					.filter(top -> top >= bottomFinal)//
 					.collect(Collectors.toSet());
-			Optional<Integer> min = topsBelowDeletion.stream().min(Integer::compare);
+			Optional<Integer> firstTopBelowDeletion = topsBelowDeletion.stream().min(Integer::compare);
 
 			/* if there is an undeleted element ending in deletion range use this as benchmark */
 			Optional<Integer> benchmark = bottomToElements.keySet().stream()//
@@ -155,11 +155,16 @@ public class NudgeOnRemovalCommand extends ModelCommand<MInteractionImpl> {
 			int delta;
 			if (benchmark.isPresent()) {
 				/* keep previous distance to deleted range and move below benchmark */
-				delta = (benchmark.get()) - min.orElse(benchmark.get())
-						+ (min.orElse(bottomFinal) - bottomFinal);
+				delta = (benchmark.get()) - firstTopBelowDeletion.orElse(benchmark.get())
+						+ (firstTopBelowDeletion.orElse(bottomFinal) - bottomFinal);
 			} else {
-				/* move to top of deleted range */
-				delta = topFinal - min.orElse(topFinal) + additionalVerticalOffSet();
+				Optional<Integer> firstBottomAboveDeletion = bottomToElements.keySet().stream()
+						.filter(bot -> bot <= topFinal).reduce(Integer::max);
+				/*
+				 * keep previous distance between delete range and next element and move below deleted range
+				 */
+				delta = firstBottomAboveDeletion.orElse(bottomFinal) - bottomFinal
+						+ additionalVerticalOffSet();
 			}
 
 			topsBelowDeletion.stream()//

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/BasicDeletionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/BasicDeletionTest.java
@@ -78,8 +78,11 @@ public class BasicDeletionTest {
 	public void message_notTriggeringExecution() {
 		/* setup */
 		MMessage message = interaction().getMessages().get(1);
-		int deletedTop = message.getTop().getAsInt();
+		MExecution executionBeforeMessage = interaction.getLifelines().get(1).getExecutions().get(0);
+		MExecution executionAfterMessage = interaction.getLifelines().get(1).getExecutions().get(1);
 
+		final int spaceToPreserve = executionAfterMessage.getTop().getAsInt()
+				- message.getBottom().getAsInt();
 		/* act */
 		executeAndAssertRemoval((RemovalCommand<Element>)message.remove(), //
 				message, message.getSend().get(), message.getReceive().get());
@@ -94,8 +97,11 @@ public class BasicDeletionTest {
 		assertEquals(3, interaction().getLifelines().get(1).getExecutionOccurrences().size());
 		assertEquals(2, interaction().getLifelines().get(2).getExecutionOccurrences().size());
 
-		/* execution moved up to where message was */
-		assertTop(deletedTop, interaction().getLifelines().get(1).getExecutions().get(1));
+		/* the space after the deleted message and the next element has been preserved */
+
+		assertEquals(spaceToPreserve,
+				executionAfterMessage.getTop().getAsInt() - executionBeforeMessage.getBottom().getAsInt());
+
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
This PR is a proposal for updating the  behavior of insert/delete commands in the following manner
## Deletion preserves space from deleted element to first element after deletion
* Currently deletion preserves the space from first element after deletion to deleted element.
  Elements after the deleted element are moved up b + c (i.e. space a is preserved)
    This contradicts with the assumption that the space before an element belongs to the element (and not the one after it). This assumption has been specified by Antonio.
-> We propose moving up a+b (i.e. preserving space c)
![delete](https://user-images.githubusercontent.com/2311075/43201054-b8a833ca-9017-11e8-8935-ff37f52fead2.png)


a...space before deleted element
b...height of deleted element
c...space after deleted element to next element

## Insertion should only push down the height of the inserted element 
  * Currently we push everything down so that we at least have a  space after the inserted element.
    Following the assumption of Antonio (Space before element belongs to element), we should -- if at all -- push everything down the entire space that existed before (a+c). This would preserve the space of the element after the element that has been inserted.
    However, we feel that this behavior is weird when there is already a lot of room between two elements. Therefore, we figured it might feel more natural if it ALWAYS (simple rule is good rule) just push down the height (b) of the element being inserted. As a result the space before the inserted point (a) would belong to the inserted element and the space after the insertion point (c) would belong to the element after the inserted element
![insert](https://user-images.githubusercontent.com/2311075/43201984-635fe220-901a-11e8-8e06-e1ab23c3ff5d.png)

a...space before insertion point
b...height of inserted element
c...space after insertion point


