### PR TITLE
Disallow creation of fragments via model explorer #186

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/.classpath
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/.project
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Simplifiedui
+Bundle-SymbolicName: org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Activator: org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui.Activator
+Require-Bundle: org.eclipse.ui,
+ org.eclipse.core.runtime,
+ org.eclipse.papyrus.infra.newchild;bundle-version="3.0.0",
+ org.eclipse.papyrus.infra.properties;bundle-version="3.0.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui
+Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/build.properties
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/build.properties
@@ -1,0 +1,6 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               newchild,\
+               plugin.xml

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/newchild/lightweight-seqd-newChild.creationmenumodel
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/newchild/lightweight-seqd-newChild.creationmenumodel
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ElementCreationMenuModel:Folder xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ElementCreationMenuModel="http://www.eclipse.org/papyrus/infra/newchild/elementcreationmenumodel" xmlns:elementtypesconfigurations="http://www.eclipse.org/papyrus/infra/elementtypesconfigurations/1.2" label="New Child">
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Lifeline">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Lifeline"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Property">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Property"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Comment">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Comment"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Constraint">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Constraint"/>
+  </menu>
+</ElementCreationMenuModel:Folder>
+ 

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/plugin.xml
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/plugin.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+	<extension
+	       point="org.eclipse.papyrus.infra.newchild">
+	    <menuCreationModel
+	          model="newchild/lightweight-seqd-newChild.creationmenumodel">
+	    </menuCreationModel>
+	 </extension>
+ <extension
+       point="org.eclipse.ui.startup">
+    <startup
+          class="org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui.StartUp">
+    </startup>
+ </extension>
+</plugin>

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/src/org/eclipse/papyrus/uml/diagram/sequence/contribution/simplifiedui/Activator.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/src/org/eclipse/papyrus/uml/diagram/sequence/contribution/simplifiedui/Activator.java
@@ -1,0 +1,50 @@
+package org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui;
+
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle
+ */
+public class Activator extends AbstractUIPlugin {
+
+	// The plug-in ID
+	public static final String PLUGIN_ID = "org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui"; //$NON-NLS-1$
+
+	// The shared instance
+	private static Activator plugin;
+	
+	/**
+	 * The constructor
+	 */
+	public Activator() {
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
+	 */
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+	 */
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/src/org/eclipse/papyrus/uml/diagram/sequence/contribution/simplifiedui/CreationMenuCleaner.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/src/org/eclipse/papyrus/uml/diagram/sequence/contribution/simplifiedui/CreationMenuCleaner.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016 EclipseSource Services GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Martin Fleck (EclipseSource) - Initial API and implementation
+ */
+package org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui;
+
+import org.eclipse.papyrus.infra.newchild.CreationMenuRegistry;
+import org.eclipse.papyrus.infra.newchild.elementcreationmenumodel.Folder;
+
+/**
+ * Cleans the creation menu.
+ */
+public final class CreationMenuCleaner {
+
+	private static final String UML_NEW_CHILD_MENU = "/resource/UML.creationmenumodel"; //$NON-NLS-1$
+
+	private static final String UML_NEW_RELATIONSHIP_MENU = "/resource/UMLEdges.creationmenumodel"; //$NON-NLS-1$
+
+	private static final String[] DEACTIVATED_CHILD_MENUS = new String[] { UML_NEW_CHILD_MENU,
+			UML_NEW_RELATIONSHIP_MENU };
+
+	private CreationMenuCleaner() {
+		// hidden constructor.
+	}
+
+	/**
+	 * Cleans the creation menu.
+	 */
+	public static void clean() {
+		CreationMenuRegistry instance = org.eclipse.papyrus.infra.newchild.CreationMenuRegistry.getInstance();
+		for (Folder folder : instance.getRootFolder()) {
+			for (String childMenuPath : DEACTIVATED_CHILD_MENUS) {
+				if (folder.eResource().getURI().toString().endsWith(childMenuPath)) {
+					instance.setCreationMenuVisibility(folder, false);
+				}
+			}
+		}
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/src/org/eclipse/papyrus/uml/diagram/sequence/contribution/simplifiedui/StartUp.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui/src/org/eclipse/papyrus/uml/diagram/sequence/contribution/simplifiedui/StartUp.java
@@ -1,0 +1,12 @@
+package org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui;
+
+import org.eclipse.ui.IStartup;
+
+public class StartUp implements IStartup {
+
+	@Override
+	public void earlyStartup() {
+		CreationMenuCleaner.clean();
+	}
+
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -20,6 +20,7 @@
 		<module>org.eclipse.papyrus.uml.diagram.sequence.assistants</module>
 		<module>org.eclipse.papyrus.uml.diagram.sequence.assistants.edit</module>
 		<module>org.eclipse.papyrus.uml.diagram.sequence.contribution</module>
+		<module>org.eclipse.papyrus.uml.diagram.sequence.contribution.simplifiedui</module>
 		<module>org.eclipse.papyrus.uml.diagram.sequence.runtime</module>
 		<module>org.eclipse.papyrus.uml.diagram.sequence.figure</module>
 	</modules>


### PR DESCRIPTION
This PR 

+ "customizes the New Child  menu in the property explorer as declared in #186 
+ adds a MenuCleaner to remove the "new Child"/"new Relationship" menus which are provided by PapyrusUML.

