### PR TITLE
Nudge also first element on insertion of execution #343

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
@@ -180,17 +180,43 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 
 		// Now we have commands to add the execution specification. But, first we must make
 		// room for it in the diagram. Nudge the element that will follow the new execution
-
-		MElement<?> distanceFrom = insertionPoint;
-		Optional<Command> makeSpace = getTarget().following(insertionPoint).map(el -> {
-			OptionalInt distance = el.verticalDistance(distanceFrom);
-			return distance.isPresent() ? el.nudge(height) : null;
-		});
+		Optional<Command> makeSpace = createNudgeCommand(insertionPoint, execParams.isInsertBefore());
 		if (makeSpace.isPresent()) {
 			result = makeSpace.get().chain(result);
 		}
 
 		return result;
+	}
+
+	/**
+	 * Creates the nudge command for the insertion of the execution.
+	 * <p>
+	 * If the insertion of the execution <code>isInsertBefore</code>, the <code>insertionPoint</code> also
+	 * needs to be nudged, otherwise we need to nudge everything after the insertion point.
+	 * </p>
+	 * 
+	 * @param insertionPoint
+	 *            the insertion point of the execution's insert command.
+	 * @param isInsertBefore
+	 *            whether or not, the insert command inserted before or after the insertion point.
+	 * @return the nudge command.
+	 */
+	protected Optional<Command> createNudgeCommand(MElement<? extends Element> insertionPoint,
+			boolean isInsertBefore) {
+		final MElement<? extends Element> nudgeStart;
+		if (isInsertBefore) {
+			nudgeStart = getTarget().preceding(insertionPoint).orElse(before);
+		} else {
+			nudgeStart = insertionPoint;
+		}
+
+		MElement<?> distanceFrom = insertionPoint;
+		Optional<Command> makeSpace = getTarget().following(nudgeStart).map(el -> {
+			OptionalInt distance = el.verticalDistance(distanceFrom);
+			return distance.isPresent() ? el.nudge(height) : null;
+		});
+
+		return makeSpace;
 	}
 
 	/**

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -19,6 +19,7 @@ import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTes
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTestB;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.BasicDeletionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.CreationMessageDeletionTest;
+import org.eclipse.papyrus.uml.interaction.model.tests.deletion.DeleteExecutionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.DeletionMessageDeletionTest;
 import org.eclipse.papyrus.uml.interaction.model.util.tests.LogicalModelPredicatesTest;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ //
 		DefaultLayoutHelperTest.class, //
 		CreateMessageTest.class, CreateMessageTestB.class, //
-		CreateExecutionTest.class, //
+		CreateExecutionTest.class, DeleteExecutionTest.class, //
 		CreationMessageDeletionTest.class, BasicDeletionTest.class, DeletionMessageDeletionTest.class, //
 		LogicalModelAdapterTest.class, //
 		LogicalModelPredicatesTest.class, //

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -14,6 +14,7 @@ package org.eclipse.papyrus.uml.interaction.model.tests;
 
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.DefaultLayoutHelperTest;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.LogicalModelAdapterTest;
+import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateExecutionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTestB;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.BasicDeletionTest;
@@ -33,6 +34,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ //
 		DefaultLayoutHelperTest.class, //
 		CreateMessageTest.class, CreateMessageTestB.class, //
+		CreateExecutionTest.class, //
 		CreationMessageDeletionTest.class, BasicDeletionTest.class, DeletionMessageDeletionTest.class, //
 		LogicalModelAdapterTest.class, //
 		LogicalModelPredicatesTest.class, //

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
@@ -17,6 +17,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 @ModelResource({"CreateExecutionTesting.uml", "CreateExecutionTesting.notation" })
+@SuppressWarnings("boxing")
 public class CreateExecutionTest {
 
 	private static final int EXECUTION_HEIGHT = 20;
@@ -49,17 +50,16 @@ public class CreateExecutionTest {
 		return interaction;
 	}
 
-	private void execute(Command remove) {
-		if (!remove.canExecute()) {
+	private void execute(Command command) {
+		if (!command.canExecute()) {
 			Assert.fail("Command not executable"); //$NON-NLS-1$
 		}
-		remove.execute();
+		command.execute();
 		/* force reinit after change */
 		interaction = null;
 	}
 
 	@Test
-	@SuppressWarnings("boxing")
 	public void creationExecutionOnTopOfLifeline1() {
 		/* setup */
 		MLifeline lifeline1 = interaction().getLifelines().get(0);
@@ -81,7 +81,6 @@ public class CreateExecutionTest {
 	}
 
 	@Test
-	@SuppressWarnings("boxing")
 	public void creationExecutionOnTopOfLifeline2() {
 		/* setup */
 		MLifeline lifeline2 = interaction().getLifelines().get(1);
@@ -103,7 +102,6 @@ public class CreateExecutionTest {
 	}
 
 	@Test
-	@SuppressWarnings("boxing")
 	public void creationExecutionAfterMessage1OnLifeline1() {
 		/* setup */
 		MLifeline lifeline1 = interaction().getLifelines().get(0);
@@ -125,7 +123,6 @@ public class CreateExecutionTest {
 	}
 
 	@Test
-	@SuppressWarnings("boxing")
 	public void creationExecutionAfterMessage1OnLifeline2() {
 		/* setup */
 		MLifeline lifeline2 = interaction().getLifelines().get(1);

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
@@ -1,0 +1,148 @@
+package org.eclipse.papyrus.uml.interaction.model.tests.creation;
+
+import static org.eclipse.uml2.uml.UMLPackage.Literals.ACTION_EXECUTION_SPECIFICATION;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ModelResource({"CreateExecutionTesting.uml", "CreateExecutionTesting.notation" })
+public class CreateExecutionTest {
+
+	private static final int EXECUTION_HEIGHT = 20;
+
+	@Rule
+	public final ModelFixture.Edit model = new ModelFixture.Edit();
+
+	private MInteraction interaction;
+
+	private int message1Top;
+
+	private int message2Top;
+
+	private int message3Top;
+
+	private int message4Top;
+
+	@Before
+	public void before() {
+		message1Top = interaction().getMessages().get(0).getTop().getAsInt();
+		message2Top = interaction().getMessages().get(1).getTop().getAsInt();
+		message3Top = interaction().getMessages().get(2).getTop().getAsInt();
+		message4Top = interaction().getMessages().get(3).getTop().getAsInt();
+	}
+
+	private MInteraction interaction() {
+		if (interaction == null) {
+			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+		}
+		return interaction;
+	}
+
+	private void execute(Command remove) {
+		if (!remove.canExecute()) {
+			Assert.fail("Command not executable"); //$NON-NLS-1$
+		}
+		remove.execute();
+		/* force reinit after change */
+		interaction = null;
+	}
+
+	@Test
+	@SuppressWarnings("boxing")
+	public void creationExecutionOnTopOfLifeline1() {
+		/* setup */
+		MLifeline lifeline1 = interaction().getLifelines().get(0);
+		CreationCommand<ExecutionSpecification> command = lifeline1.insertExecutionAfter(lifeline1, 10,
+				EXECUTION_HEIGHT, ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: All messages moved down */
+		assertThat(interaction().getMessages().get(0).getTop().getAsInt(),
+				is(message1Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(1).getTop().getAsInt(),
+				is(message2Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(2).getTop().getAsInt(),
+				is(message3Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(3).getTop().getAsInt(),
+				is(message4Top + EXECUTION_HEIGHT));
+	}
+
+	@Test
+	@SuppressWarnings("boxing")
+	public void creationExecutionOnTopOfLifeline2() {
+		/* setup */
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+		CreationCommand<ExecutionSpecification> command = lifeline2.insertExecutionAfter(lifeline2, 0,
+				EXECUTION_HEIGHT, ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: All messages moved down */
+		assertThat(interaction().getMessages().get(0).getTop().getAsInt(),
+				is(message1Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(1).getTop().getAsInt(),
+				is(message2Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(2).getTop().getAsInt(),
+				is(message3Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(3).getTop().getAsInt(),
+				is(message4Top + EXECUTION_HEIGHT));
+	}
+
+	@Test
+	@SuppressWarnings("boxing")
+	public void creationExecutionAfterMessage1OnLifeline1() {
+		/* setup */
+		MLifeline lifeline1 = interaction().getLifelines().get(0);
+		CreationCommand<ExecutionSpecification> command = lifeline1.insertExecutionAfter(
+				interaction().getMessages().get(0), 0, EXECUTION_HEIGHT, ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: message 1 didn't move, message 2, 3 and 4 moved down */
+		assertThat(interaction().getMessages().get(0).getTop().getAsInt(), is(message1Top));
+
+		assertThat(interaction().getMessages().get(1).getTop().getAsInt(),
+				is(message2Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(2).getTop().getAsInt(),
+				is(message3Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(3).getTop().getAsInt(),
+				is(message4Top + EXECUTION_HEIGHT));
+	}
+
+	@Test
+	@SuppressWarnings("boxing")
+	public void creationExecutionAfterMessage1OnLifeline2() {
+		/* setup */
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+		CreationCommand<ExecutionSpecification> command = lifeline2.insertExecutionAfter(
+				interaction().getMessages().get(0), 0, EXECUTION_HEIGHT, ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: message 1 didn't move, message 2, 3 and 4 moved down */
+		assertThat(interaction().getMessages().get(0).getTop().getAsInt(), is(message1Top));
+
+		assertThat(interaction().getMessages().get(1).getTop().getAsInt(),
+				is(message2Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(2).getTop().getAsInt(),
+				is(message3Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(3).getTop().getAsInt(),
+				is(message4Top + EXECUTION_HEIGHT));
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
@@ -1,3 +1,14 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Philip Langer and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Philip Langer - Initial API and implementation
+ *****************************************************************************/
 package org.eclipse.papyrus.uml.interaction.model.tests.creation;
 
 import static org.eclipse.uml2.uml.UMLPackage.Literals.ACTION_EXECUTION_SPECIFICATION;

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTesting.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTesting.notation
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kCqjwLA8EeiVu8M2BzYNdA" type="LightweightSequenceDiagram" name="Lightweight Sequence Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_kCqjwbA8EeiVu8M2BzYNdA" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_kCqjwrA8EeiVu8M2BzYNdA" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_kCqjw7A8EeiVu8M2BzYNdA" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_k3YlQLA8EeiVu8M2BzYNdA" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQbA8EeiVu8M2BzYNdA" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQrA8EeiVu8M2BzYNdA" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQ7A8EeiVu8M2BzYNdA" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_k3YlRLA8EeiVu8M2BzYNdA" width="150" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="CreateExecutionTesting.uml#_kxgmwLA8EeiVu8M2BzYNdA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k3YlRbA8EeiVu8M2BzYNdA" x="29" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_lH4fYLA8EeiVu8M2BzYNdA" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_lH4fYbA8EeiVu8M2BzYNdA" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_lH4fYrA8EeiVu8M2BzYNdA" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_lH4fY7A8EeiVu8M2BzYNdA" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_lH4fZLA8EeiVu8M2BzYNdA" width="150" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="CreateExecutionTesting.uml#_k9yvQLA8EeiVu8M2BzYNdA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lH4fZbA8EeiVu8M2BzYNdA" x="164" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kCqjxLA8EeiVu8M2BzYNdA" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_kCqjxbA8EeiVu8M2BzYNdA" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_kCqjxrA8EeiVu8M2BzYNdA"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_kCqjx7A8EeiVu8M2BzYNdA" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="CreateExecutionTesting.uml#_kCRiMLA8EeiVu8M2BzYNdA"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="CreateExecutionTesting.uml#_kCRiMLA8EeiVu8M2BzYNdA"/>
+  <edges xmi:type="notation:Connector" xmi:id="_mX-1ULA8EeiVu8M2BzYNdA" type="Edge_Message" source="_k3YlQ7A8EeiVu8M2BzYNdA" target="_lH4fY7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="CreateExecutionTesting.uml#_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX-1UbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX-1UrA8EeiVu8M2BzYNdA" id="98"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX-1U7A8EeiVu8M2BzYNdA" id="98"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_mzDnwLA8EeiVu8M2BzYNdA" type="Edge_Message" source="_lH4fY7A8EeiVu8M2BzYNdA" target="_k3YlQ7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="CreateExecutionTesting.uml#_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mzDnwbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mzDnwrA8EeiVu8M2BzYNdA" id="133"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mzDnw7A8EeiVu8M2BzYNdA" id="133"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_nM8HY7A8EeiVu8M2BzYNdA" type="Edge_Message" source="_k3YlQ7A8EeiVu8M2BzYNdA" target="_lH4fY7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="CreateExecutionTesting.uml#_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nM8HZLA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nM8HZbA8EeiVu8M2BzYNdA" id="191"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nM8HZrA8EeiVu8M2BzYNdA" id="191"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_nr-MwLA8EeiVu8M2BzYNdA" type="Edge_Message" source="_lH4fY7A8EeiVu8M2BzYNdA" target="_k3YlQ7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="CreateExecutionTesting.uml#_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nr-MwbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nr-MwrA8EeiVu8M2BzYNdA" id="220"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nr-Mw7A8EeiVu8M2BzYNdA" id="220"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTesting.uml
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTesting.uml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kBamkLA8EeiVu8M2BzYNdA" name="CreateExecutionTesting">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_kKeb8LA8EeiVu8M2BzYNdA">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_kCRiMLA8EeiVu8M2BzYNdA" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_kxgmwLA8EeiVu8M2BzYNdA" name="Lifeline1" coveredBy="_mX8ZELA8EeiVu8M2BzYNdA _mzBykLA8EeiVu8M2BzYNdA _nM8HYLA8EeiVu8M2BzYNdA _nr8XkLA8EeiVu8M2BzYNdA"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_k9yvQLA8EeiVu8M2BzYNdA" name="Lifeline2" coveredBy="_mX9AILA8EeiVu8M2BzYNdA _mzBLgLA8EeiVu8M2BzYNdA _nM8HYbA8EeiVu8M2BzYNdA _nr7wgLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mX8ZELA8EeiVu8M2BzYNdA" name="msg1_send" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mX9AILA8EeiVu8M2BzYNdA" name="msg1_receive" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mzBLgLA8EeiVu8M2BzYNdA" name="msg2_send" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mzBykLA8EeiVu8M2BzYNdA" name="msg2_receive" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nM8HYLA8EeiVu8M2BzYNdA" name="msg3_send" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nM8HYbA8EeiVu8M2BzYNdA" name="msg3_receive" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nr7wgLA8EeiVu8M2BzYNdA" name="msg4_send" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nr8XkLA8EeiVu8M2BzYNdA" name="msg4_receive" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_mX9nMLA8EeiVu8M2BzYNdA" name="msg1" receiveEvent="_mX9AILA8EeiVu8M2BzYNdA" sendEvent="_mX8ZELA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_mzCZoLA8EeiVu8M2BzYNdA" name="ms2" receiveEvent="_mzBykLA8EeiVu8M2BzYNdA" sendEvent="_mzBLgLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_nM8HYrA8EeiVu8M2BzYNdA" name="msg3" receiveEvent="_nM8HYbA8EeiVu8M2BzYNdA" sendEvent="_nM8HYLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_nr8-oLA8EeiVu8M2BzYNdA" name="msg4" receiveEvent="_nr8XkLA8EeiVu8M2BzYNdA" sendEvent="_nr7wgLA8EeiVu8M2BzYNdA"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTest.java
@@ -1,0 +1,221 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Philip Langer and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Philip Langer - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.tests.deletion;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MMessage;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ModelResource({"DeleteExecutionTesting.uml", "DeleteExecutionTesting.notation" })
+@SuppressWarnings("boxing")
+public class DeleteExecutionTest {
+
+	@Rule
+	public final ModelFixture.Edit model = new ModelFixture.Edit();
+
+	private MInteraction interaction;
+
+	private int execution1OfLifeline1Top;
+
+	private int execution2OfLifeline1Top;
+
+	private int totalHeightExecution1Lifeline1;
+
+	private int totalHeightExecution2Lifeline1;
+
+	private int execution1OfLifeline2Top;
+
+	private int execution2OfLifeline2Top;
+
+	private int totalHeightExecution1Lifeline2;
+
+	private int totalHeightExecution2Lifeline2;
+
+	private int message1Top;
+
+	private int message2Top;
+
+	private int message3Top;
+
+	private int message4Top;
+
+	@Before
+	public void before() {
+		message1Top = messageAt(0).getTop().getAsInt();
+		message2Top = messageAt(1).getTop().getAsInt();
+		message3Top = messageAt(2).getTop().getAsInt();
+		message4Top = messageAt(3).getTop().getAsInt();
+
+		MLifeline lifeline1 = lifelineAt(0);
+		MExecution execution1OfLifeline1 = lifeline1.getExecutions().get(0);
+		MExecution execution2OfLifeline1 = lifeline1.getExecutions().get(1);
+		execution1OfLifeline1Top = execution1OfLifeline1.getTop().getAsInt();
+		execution2OfLifeline1Top = execution2OfLifeline1.getTop().getAsInt();
+		// see DeleteExecutionTesting.notation:12 -- height = 40; y = 20
+		totalHeightExecution1Lifeline1 = 40 + 20;
+		// see DeleteExecutionTesting.notation:16 -- height = 40; y = 78
+		totalHeightExecution2Lifeline1 = 40 + 78 - totalHeightExecution1Lifeline1;
+
+		MLifeline lifeline2 = lifelineAt(1);
+		MExecution execution1OfLifeline2 = lifeline2.getExecutions().get(0);
+		MExecution execution2OfLifeline2 = lifeline2.getExecutions().get(1);
+		execution1OfLifeline2Top = execution1OfLifeline2.getTop().getAsInt();
+		execution2OfLifeline2Top = execution2OfLifeline2.getTop().getAsInt();
+		// see DeleteExecutionTesting.notation:29 -- height = 30; y = 122
+		totalHeightExecution1Lifeline2 = 30 + 122;
+		// see DeleteExecutionTesting.notation:33 -- height = 36; y = 167
+		totalHeightExecution2Lifeline2 = 36 + 167 - totalHeightExecution1Lifeline2;
+	}
+
+	private MInteraction interaction() {
+		if (interaction == null) {
+			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+		}
+		return interaction;
+	}
+
+	private void execute(Command command) {
+		if (!command.canExecute()) {
+			Assert.fail("Command not executable"); //$NON-NLS-1$
+		}
+		command.execute();
+		/* force reinit after change */
+		interaction = null;
+	}
+
+	@Test
+	public void deletionOfFirstExecutionOfLifeline1() {
+		/* setup */
+		Command command = executionAt(0, 0).remove();
+
+		/* act */
+		execute(command);
+
+		/*
+		 * assert: Only one execution left on lifeline1 and all other executions and all messages moved up
+		 */
+		assertThat(lifelineAt(0).getExecutions().size(), is(1));
+		assertThat(executionAt(0, 0).getTop().getAsInt(),
+				is(execution2OfLifeline1Top - totalHeightExecution1Lifeline1));
+
+		assertThat(lifelineAt(1).getExecutions().size(), is(2));
+		assertThat(executionAt(1, 0).getTop().getAsInt(),
+				is(execution1OfLifeline2Top - totalHeightExecution1Lifeline1));
+		assertThat(executionAt(1, 1).getTop().getAsInt(),
+				is(execution2OfLifeline2Top - totalHeightExecution1Lifeline1));
+
+		assertThat(messageAt(0).getTop().getAsInt(), is(message1Top - totalHeightExecution1Lifeline1));
+		assertThat(messageAt(1).getTop().getAsInt(), is(message2Top - totalHeightExecution1Lifeline1));
+		assertThat(messageAt(2).getTop().getAsInt(), is(message3Top - totalHeightExecution1Lifeline1));
+		assertThat(messageAt(3).getTop().getAsInt(), is(message4Top - totalHeightExecution1Lifeline1));
+	}
+
+	@Test
+	public void deletionOfSecondExecutionOfLifeline1() {
+		/* setup */
+		Command command = executionAt(0, 1).remove();
+
+		/* act */
+		execute(command);
+
+		/* assert only one execution left on lifeline1 */
+		assertThat(lifelineAt(0).getExecutions().size(), is(1));
+		assertThat(executionAt(0, 0).getTop().getAsInt(), is(execution1OfLifeline1Top));
+
+		/* assert first execution hasn't been moved */
+		assertThat(lifelineAt(1).getExecutions().size(), is(2));
+		assertThat(executionAt(1, 0).getTop().getAsInt(),
+				is(execution1OfLifeline2Top - totalHeightExecution2Lifeline1));
+		assertThat(executionAt(1, 1).getTop().getAsInt(),
+				is(execution2OfLifeline2Top - totalHeightExecution2Lifeline1));
+
+		/* assert all other executions and all messages moved up */
+		assertThat(messageAt(0).getTop().getAsInt(), is(message1Top - totalHeightExecution2Lifeline1));
+		assertThat(messageAt(1).getTop().getAsInt(), is(message2Top - totalHeightExecution2Lifeline1));
+		assertThat(messageAt(2).getTop().getAsInt(), is(message3Top - totalHeightExecution2Lifeline1));
+		assertThat(messageAt(3).getTop().getAsInt(), is(message4Top - totalHeightExecution2Lifeline1));
+	}
+
+	@Test
+	public void deletionOfFirstExecutionOfLifeline2() {
+		/* setup */
+		Command command = executionAt(1, 0).remove();
+
+		/* act */
+		execute(command);
+
+		/* assert only one execution left on lifeline2 and both executions on lifeline1 */
+		assertThat(lifelineAt(1).getExecutions().size(), is(1));
+		assertThat(lifelineAt(0).getExecutions().size(), is(2));
+
+		/* assert executions on lifeline1 haven't been moved */
+		assertThat(executionAt(0, 0).getTop().getAsInt(), is(execution1OfLifeline1Top));
+		assertThat(executionAt(0, 1).getTop().getAsInt(), is(execution2OfLifeline1Top));
+
+		/* assert the remaining execution on lifeline2 moved up and all messages moved up */
+		int pullUpDelta = totalHeightExecution1Lifeline2 - totalHeightExecution1Lifeline1
+				- totalHeightExecution2Lifeline1;
+		assertThat(executionAt(1, 0).getTop().getAsInt(), is(execution2OfLifeline2Top - pullUpDelta));
+		assertThat(messageAt(0).getTop().getAsInt(), is(message1Top - pullUpDelta));
+		assertThat(messageAt(1).getTop().getAsInt(), is(message2Top - pullUpDelta));
+		assertThat(messageAt(2).getTop().getAsInt(), is(message3Top - pullUpDelta));
+		assertThat(messageAt(3).getTop().getAsInt(), is(message4Top - pullUpDelta));
+	}
+
+	@Test
+	public void deletionOfSecondExecutionOfLifeline2() {
+		/* setup */
+		Command command = executionAt(1, 1).remove();
+
+		/* act */
+		execute(command);
+
+		/* assert only one execution left on lifeline2 and both executions on lifeline1 */
+		assertThat(lifelineAt(1).getExecutions().size(), is(1));
+		assertThat(lifelineAt(0).getExecutions().size(), is(2));
+
+		/* assert executions on lifeline1 and remaining on lifeline2 haven't been moved */
+		assertThat(executionAt(0, 0).getTop().getAsInt(), is(execution1OfLifeline1Top));
+		assertThat(executionAt(0, 1).getTop().getAsInt(), is(execution2OfLifeline1Top));
+		assertThat(executionAt(1, 0).getTop().getAsInt(), is(execution1OfLifeline2Top));
+
+		/* assert all messages moved up */
+		assertThat(messageAt(0).getTop().getAsInt(), is(message1Top - totalHeightExecution2Lifeline2));
+		assertThat(messageAt(1).getTop().getAsInt(), is(message2Top - totalHeightExecution2Lifeline2));
+		assertThat(messageAt(2).getTop().getAsInt(), is(message3Top - totalHeightExecution2Lifeline2));
+		assertThat(messageAt(3).getTop().getAsInt(), is(message4Top - totalHeightExecution2Lifeline2));
+	}
+
+	private MExecution executionAt(int lifelineIndex, int executionIndex) {
+		return lifelineAt(lifelineIndex).getExecutions().get(executionIndex);
+	}
+
+	protected MLifeline lifelineAt(int lifelineIndex) {
+		return interaction().getLifelines().get(lifelineIndex);
+	}
+
+	private MMessage messageAt(int messageIndex) {
+		return interaction().getMessages().get(messageIndex);
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTesting.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTesting.notation
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kCqjwLA8EeiVu8M2BzYNdA" type="LightweightSequenceDiagram" name="Lightweight Sequence Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_kCqjwbA8EeiVu8M2BzYNdA" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_kCqjwrA8EeiVu8M2BzYNdA" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_kCqjw7A8EeiVu8M2BzYNdA" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_k3YlQLA8EeiVu8M2BzYNdA" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQbA8EeiVu8M2BzYNdA" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQrA8EeiVu8M2BzYNdA" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQ7A8EeiVu8M2BzYNdA" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_Jx7QQLD_Eeif-f3-rx6-Ug" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="DeleteExecutionTesting.uml#_Jvm8ELD_Eeif-f3-rx6-Ug"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jx7QQbD_Eeif-f3-rx6-Ug" x="70" y="20" width="10" height="40"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_N6yjELD_Eeif-f3-rx6-Ug" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="DeleteExecutionTesting.uml#_N1qygLD_Eeif-f3-rx6-Ug"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N6yjEbD_Eeif-f3-rx6-Ug" x="70" y="78" width="10" height="40"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_k3YlRLA8EeiVu8M2BzYNdA" width="150" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="DeleteExecutionTesting.uml#_kxgmwLA8EeiVu8M2BzYNdA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k3YlRbA8EeiVu8M2BzYNdA" x="29" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_lH4fYLA8EeiVu8M2BzYNdA" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_lH4fYbA8EeiVu8M2BzYNdA" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_lH4fYrA8EeiVu8M2BzYNdA" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_lH4fY7A8EeiVu8M2BzYNdA" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_TqyGYLDsEeip79oPPjBVbA" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="DeleteExecutionTesting.uml#_ToF-wLDsEeip79oPPjBVbA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TqyGYbDsEeip79oPPjBVbA" x="70" y="122" width="10" height="30"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_bS7eULD-Eeip79oPPjBVbA" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="DeleteExecutionTesting.uml#_bL1X0LD-Eeip79oPPjBVbA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bS7eUbD-Eeip79oPPjBVbA" x="70" y="167" width="10" height="36"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_lH4fZLA8EeiVu8M2BzYNdA" width="150" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="DeleteExecutionTesting.uml#_k9yvQLA8EeiVu8M2BzYNdA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lH4fZbA8EeiVu8M2BzYNdA" x="164" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kCqjxLA8EeiVu8M2BzYNdA" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_kCqjxbA8EeiVu8M2BzYNdA" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_kCqjxrA8EeiVu8M2BzYNdA"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_kCqjx7A8EeiVu8M2BzYNdA" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="DeleteExecutionTesting.uml#_kCRiMLA8EeiVu8M2BzYNdA"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="DeleteExecutionTesting.uml#_kCRiMLA8EeiVu8M2BzYNdA"/>
+  <edges xmi:type="notation:Connector" xmi:id="_mX-1ULA8EeiVu8M2BzYNdA" type="Edge_Message" source="_k3YlQ7A8EeiVu8M2BzYNdA" target="_lH4fY7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="DeleteExecutionTesting.uml#_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX-1UbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX-1UrA8EeiVu8M2BzYNdA" id="229"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX-1U7A8EeiVu8M2BzYNdA" id="229"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_mzDnwLA8EeiVu8M2BzYNdA" type="Edge_Message" source="_lH4fY7A8EeiVu8M2BzYNdA" target="_k3YlQ7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="DeleteExecutionTesting.uml#_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mzDnwbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mzDnwrA8EeiVu8M2BzYNdA" id="258"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mzDnw7A8EeiVu8M2BzYNdA" id="258"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_nM8HY7A8EeiVu8M2BzYNdA" type="Edge_Message" source="_k3YlQ7A8EeiVu8M2BzYNdA" target="_lH4fY7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="DeleteExecutionTesting.uml#_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nM8HZLA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nM8HZbA8EeiVu8M2BzYNdA" id="305"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nM8HZrA8EeiVu8M2BzYNdA" id="305"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_nr-MwLA8EeiVu8M2BzYNdA" type="Edge_Message" source="_lH4fY7A8EeiVu8M2BzYNdA" target="_k3YlQ7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="DeleteExecutionTesting.uml#_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nr-MwbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nr-MwrA8EeiVu8M2BzYNdA" id="335"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nr-Mw7A8EeiVu8M2BzYNdA" id="335"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTesting.uml
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTesting.uml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kBamkLA8EeiVu8M2BzYNdA" name="CreateExecutionTesting">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_kKeb8LA8EeiVu8M2BzYNdA">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_kCRiMLA8EeiVu8M2BzYNdA" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_kxgmwLA8EeiVu8M2BzYNdA" name="Lifeline1" coveredBy="_mX8ZELA8EeiVu8M2BzYNdA _mzBykLA8EeiVu8M2BzYNdA _nM8HYLA8EeiVu8M2BzYNdA _nr8XkLA8EeiVu8M2BzYNdA _JvnjILD_Eeif-f3-rx6-Ug _Jvm8ELD_Eeif-f3-rx6-Ug _JvnjIbD_Eeif-f3-rx6-Ug _N1qygbD_Eeif-f3-rx6-Ug _N1qygLD_Eeif-f3-rx6-Ug _N1rZkLD_Eeif-f3-rx6-Ug"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_k9yvQLA8EeiVu8M2BzYNdA" name="Lifeline2" coveredBy="_mX9AILA8EeiVu8M2BzYNdA _mzBLgLA8EeiVu8M2BzYNdA _nM8HYbA8EeiVu8M2BzYNdA _nr7wgLA8EeiVu8M2BzYNdA _ToGl0LDsEeip79oPPjBVbA _ToF-wLDsEeip79oPPjBVbA _ToHz8LDsEeip79oPPjBVbA _bL1X0bD-Eeip79oPPjBVbA _bL1X0LD-Eeip79oPPjBVbA _bL1X0rD-Eeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_JvnjILD_Eeif-f3-rx6-Ug" covered="_kxgmwLA8EeiVu8M2BzYNdA" execution="_Jvm8ELD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_Jvm8ELD_Eeif-f3-rx6-Ug" name="Execution3" covered="_kxgmwLA8EeiVu8M2BzYNdA" finish="_JvnjIbD_Eeif-f3-rx6-Ug" start="_JvnjILD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_JvnjIbD_Eeif-f3-rx6-Ug" covered="_kxgmwLA8EeiVu8M2BzYNdA" execution="_Jvm8ELD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_N1qygbD_Eeif-f3-rx6-Ug" covered="_kxgmwLA8EeiVu8M2BzYNdA" execution="_N1qygLD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_N1qygLD_Eeif-f3-rx6-Ug" name="Execution4" covered="_kxgmwLA8EeiVu8M2BzYNdA" finish="_N1rZkLD_Eeif-f3-rx6-Ug" start="_N1qygbD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_N1rZkLD_Eeif-f3-rx6-Ug" covered="_kxgmwLA8EeiVu8M2BzYNdA" execution="_N1qygLD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mX8ZELA8EeiVu8M2BzYNdA" name="msg1_send" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_ToGl0LDsEeip79oPPjBVbA" covered="_k9yvQLA8EeiVu8M2BzYNdA" execution="_ToF-wLDsEeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_ToF-wLDsEeip79oPPjBVbA" name="Execution1" covered="_k9yvQLA8EeiVu8M2BzYNdA" finish="_ToHz8LDsEeip79oPPjBVbA" start="_ToGl0LDsEeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_ToHz8LDsEeip79oPPjBVbA" covered="_k9yvQLA8EeiVu8M2BzYNdA" execution="_ToF-wLDsEeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_bL1X0bD-Eeip79oPPjBVbA" covered="_k9yvQLA8EeiVu8M2BzYNdA" execution="_bL1X0LD-Eeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_bL1X0LD-Eeip79oPPjBVbA" name="Execution2" covered="_k9yvQLA8EeiVu8M2BzYNdA" finish="_bL1X0rD-Eeip79oPPjBVbA" start="_bL1X0bD-Eeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_bL1X0rD-Eeip79oPPjBVbA" covered="_k9yvQLA8EeiVu8M2BzYNdA" execution="_bL1X0LD-Eeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mX9AILA8EeiVu8M2BzYNdA" name="msg1_receive" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mzBLgLA8EeiVu8M2BzYNdA" name="msg2_send" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mzBykLA8EeiVu8M2BzYNdA" name="msg2_receive" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nM8HYLA8EeiVu8M2BzYNdA" name="msg3_send" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nM8HYbA8EeiVu8M2BzYNdA" name="msg3_receive" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nr7wgLA8EeiVu8M2BzYNdA" name="msg4_send" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nr8XkLA8EeiVu8M2BzYNdA" name="msg4_receive" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_mX9nMLA8EeiVu8M2BzYNdA" name="msg1" receiveEvent="_mX9AILA8EeiVu8M2BzYNdA" sendEvent="_mX8ZELA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_mzCZoLA8EeiVu8M2BzYNdA" name="ms2" receiveEvent="_mzBykLA8EeiVu8M2BzYNdA" sendEvent="_mzBLgLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_nM8HYrA8EeiVu8M2BzYNdA" name="msg3" receiveEvent="_nM8HYbA8EeiVu8M2BzYNdA" sendEvent="_nM8HYLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_nr8-oLA8EeiVu8M2BzYNdA" name="msg4" receiveEvent="_nr8XkLA8EeiVu8M2BzYNdA" sendEvent="_nr7wgLA8EeiVu8M2BzYNdA"/>
+  </packagedElement>
+</uml:Model>


### PR DESCRIPTION
This change addresses comment #343#issuecomment-418037298 (third
comment) of #343. When inserting an execution specification as first
element (execParams.isInsertBefore) of a lifeline, the isInsertBefore
flag has not been respected when invoking the nudge command.

Signed-off-by: Philip Langer <planger@eclipsesource.com>