### PR TITLE
Fix issue #354: Fragment ordering

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
@@ -27,6 +27,7 @@ import org.eclipse.papyrus.uml.interaction.internal.model.impl.MLifelineImpl;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredAddCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
@@ -150,8 +151,8 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 		// start and finish occurrences
 		List<MElement<? extends Element>> timeline = getTimeline(getTarget().getInteraction());
 		int absoluteExecY = referenceY.getAsInt() + offset;
-		Optional<MElement<? extends Element>> insertAt = getInsertionPoint(timeline, absoluteExecY)
-				.map(this::normalizeFragmentInsertionPoint);
+		Optional<MElement<? extends Element>> insertAt = getInsertionPoint(timeline, MExecution.class,
+				absoluteExecY).map(this::normalizeFragmentInsertionPoint);
 
 		SemanticHelper semantics = semanticHelper();
 		CreationParameters execParams = CreationParameters.in(getTarget().getInteraction().getElement(),

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertMessageCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertMessageCommand.java
@@ -44,6 +44,7 @@ import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredAddCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
@@ -292,8 +293,10 @@ public class InsertMessageCommand extends ModelCommand<MLifelineImpl> implements
 		List<MElement<? extends Element>> timeline = getTimeline(getTarget().getInteraction());
 		int absoluteSendY = sendReferenceY.getAsInt() + sendOffset;
 		int absoluteRecvY = recvReferenceY.getAsInt() + recvOffset;
-		Optional<MElement<? extends Element>> sendInsert = getInsertionPoint(timeline, absoluteSendY);
-		Optional<MElement<? extends Element>> recvInsert = getInsertionPoint(timeline, absoluteRecvY);
+		Optional<MElement<? extends Element>> sendInsert = getInsertionPoint(timeline, MMessageEnd.class,
+				absoluteSendY);
+		Optional<MElement<? extends Element>> recvInsert = getInsertionPoint(timeline, MMessageEnd.class,
+				absoluteRecvY);
 
 		SemanticHelper semantics = semanticHelper();
 		CreationParameters sendParams = endParams(

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageSnappingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageSnappingUITest.java
@@ -114,6 +114,12 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 		// The message receive event starts the execution
 		Message message = (Message) messageEP.getAdapter(EObject.class);
 		assertThat(exec.getStart(), withModifiers(is(message.getReceiveEvent())));
+
+		// The message send and receive both are semantically before the execution
+		assertThat("Message ends out of order", message.getSendEvent(),
+				editor.semanticallyPrecedes(message.getReceiveEvent()));
+		assertThat("Execution out of order", exec, editor.semanticallyFollows(message.getReceiveEvent()));
+		assertThat("Execution finish out of order", exec, editor.semanticallyPrecedes(exec.getFinish()));
 	}
 
 	@Test

--- a/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/rules/ModelFixture.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/rules/ModelFixture.java
@@ -12,6 +12,7 @@
 
 package org.eclipse.papyrus.uml.interaction.tests.rules;
 
+import static org.eclipse.uml2.uml.util.UMLUtil.getQualifiedText;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -24,6 +25,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -52,12 +54,15 @@ import org.eclipse.uml2.common.util.CacheAdapter;
 import org.eclipse.uml2.common.util.UML2Util;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Interaction;
+import org.eclipse.uml2.uml.InteractionFragment;
 import org.eclipse.uml2.uml.NamedElement;
 import org.eclipse.uml2.uml.Package;
 import org.eclipse.uml2.uml.UMLPackage;
 import org.eclipse.uml2.uml.edit.providers.UMLItemProviderAdapterFactory;
 import org.eclipse.uml2.uml.resources.util.UMLResourcesUtil;
 import org.eclipse.uml2.uml.util.UMLUtil;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.ClassRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -343,6 +348,59 @@ public class ModelFixture implements TestRule {
 
 		rset.getResourceFactoryRegistry().getExtensionToFactoryMap().put("notation",
 				new XMIResourceFactoryImpl());
+	}
+
+	public boolean semanticallyPrecedes(NamedElement fragment, NamedElement other) {
+		List<InteractionFragment> fragments = getInteraction().getFragments();
+		int indexOfOne = fragments.indexOf(fragment);
+		int indexOfOther = fragments.indexOf(other);
+		return (indexOfOne >= 0) && (indexOfOther >= 0) && (indexOfOther > indexOfOne);
+	}
+
+	public <T extends NamedElement> Matcher<T> semanticallyFollows(NamedElement other) {
+		return new TypeSafeDiagnosingMatcher<T>() {
+
+			@Override
+			protected boolean matchesSafely(T item, org.hamcrest.Description mismatchDescription) {
+				boolean result = semanticallyPrecedes(other, item);
+				if (!result) {
+					mismatchDescription.appendText(getQualifiedText(item));
+					mismatchDescription.appendText(" semantically precedes "); //$NON-NLS-1$
+					mismatchDescription.appendText(getQualifiedText(other));
+				}
+				return result;
+			}
+
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+				description.appendText("semantically follows "); //$NON-NLS-1$
+				description.appendText(getQualifiedText(other));
+			}
+
+		};
+	}
+
+	public <T extends NamedElement> Matcher<T> semanticallyPrecedes(NamedElement other) {
+		return new TypeSafeDiagnosingMatcher<T>() {
+
+			@Override
+			protected boolean matchesSafely(T item, org.hamcrest.Description mismatchDescription) {
+				boolean result = semanticallyPrecedes(item, other);
+				if (!result) {
+					mismatchDescription.appendText(getQualifiedText(item));
+					mismatchDescription.appendText(" semantically follows "); //$NON-NLS-1$
+					mismatchDescription.appendText(getQualifiedText(other));
+				}
+				return result;
+			}
+
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+				description.appendText("semantically precedes "); //$NON-NLS-1$
+				description.appendText(getQualifiedText(other));
+			}
+
+		};
 	}
 
 	//


### PR DESCRIPTION
The insertion order of fragments depends on the kind of fragment being inserted, because the preferred semantic (time) ordering of fragments depends on the types of fragments.  Account for this explicitly in the creation of messages and execution specifications.