### PR TITLE
Issue #76: Adjust Y calculations in logical model

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/Activator.java
@@ -16,6 +16,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gmf.runtime.diagram.core.preferences.PreferencesHint;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.papyrus.infra.core.log.LogHelper;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.layout.DiagramFontHelper;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
 import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints;
@@ -51,6 +52,8 @@ public class Activator extends AbstractUIPlugin {
 		instance = this;
 		PreferencesHint.registerPreferenceStore(DIAGRAM_PREFERENCES_HINT, getPreferenceStore());
 		log = new LogHelper(instance);
+
+		LogicalModelPlugin.getInstance().setFontHelperFactory(DiagramFontHelper::new);
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/layout/DiagramFontHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/layout/DiagramFontHelper.java
@@ -1,0 +1,92 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.layout;
+
+import java.util.OptionalInt;
+
+import org.eclipse.draw2d.FigureUtilities;
+import org.eclipse.draw2d.geometry.Dimension;
+import org.eclipse.gmf.runtime.diagram.core.util.ViewUtil;
+import org.eclipse.gmf.runtime.diagram.ui.preferences.IPreferenceConstants;
+import org.eclipse.gmf.runtime.notation.FontStyle;
+import org.eclipse.gmf.runtime.notation.NotationPackage;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.jface.preference.PreferenceConverter;
+import org.eclipse.jface.resource.FontDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.Activator;
+import org.eclipse.papyrus.uml.interaction.model.spi.FontHelper;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontData;
+
+/**
+ * An implementation of the {@link FontHelper} protocol that understands the configuration of fonts in the
+ * diagrams and has access to font metrics via SWT.
+ *
+ * @author Christian W. Damus
+ */
+public class DiagramFontHelper implements FontHelper {
+
+	private final Dimension scratch = new Dimension();
+
+	/**
+	 * Initializes me.
+	 */
+	public DiagramFontHelper() {
+		super();
+	}
+
+	@Override
+	public String getFontName(View view) {
+		return (String)ViewUtil.getPropertyValue(view, NotationPackage.Literals.FONT_STYLE__FONT_NAME,
+				NotationPackage.Literals.FONT_STYLE);
+	}
+
+	@Override
+	public OptionalInt getFontHeight(View view) {
+		Font font = getFont(view);
+
+		return font == null ? OptionalInt.empty() : OptionalInt.of(getHeight(view, font));
+	}
+
+	protected Font getFont(View view) {
+		Font result = null;
+
+		FontData fontData = null;
+		FontStyle style = (FontStyle)view.getStyle(NotationPackage.eINSTANCE.getFontStyle());
+		if (style != null) {
+			fontData = new FontData(style.getFontName(), style.getFontHeight(),
+					(style.isBold() ? SWT.BOLD : SWT.NORMAL) | (style.isItalic() ? SWT.ITALIC : SWT.NORMAL));
+		} else {
+			// initialize font to defaults
+			fontData = PreferenceConverter.getFontData(Activator.getDefault().getPreferenceStore(),
+					IPreferenceConstants.PREF_DEFAULT_FONT);
+		}
+
+		if (fontData != null) {
+			FontDescriptor desc = FontDescriptor.createFrom(fontData);
+			result = (Font)JFaceResources.getResources().get(desc);
+		}
+
+		return result;
+	}
+
+	protected int getHeight(View view, Font font) {
+		// Very approximate
+		String text = String.valueOf(view.getElement());
+
+		FigureUtilities.getTextExtents(text, font, scratch);
+		return scratch.height();
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/impl/LogicalModelPlugin.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/impl/LogicalModelPlugin.java
@@ -15,15 +15,18 @@ package org.eclipse.papyrus.uml.interaction.internal.model.impl;
 import com.google.common.collect.MapMaker;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.eclipse.emf.common.EMFPlugin;
 import org.eclipse.emf.common.util.ResourceLocator;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultDiagramHelper;
+import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultFontHelper;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutConstraints;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutHelper;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultSemanticHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.FontHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
 import org.osgi.framework.BundleContext;
@@ -47,6 +50,8 @@ public class LogicalModelPlugin extends EMFPlugin {
 
 	private final Map<EditingDomain, SemanticHelper> semanticHelpers = new MapMaker().weakKeys().weakValues()
 			.makeMap();
+
+	private Supplier<FontHelper> fontHelperFactory = DefaultFontHelper::new;
 
 	/**
 	 * Initializes me.
@@ -78,7 +83,7 @@ public class LogicalModelPlugin extends EMFPlugin {
 	 */
 	public LayoutHelper getLayoutHelper(EditingDomain editingDomain) {
 		return layoutHelpers.computeIfAbsent(editingDomain, //
-				domain -> new DefaultLayoutHelper(domain, DefaultLayoutConstraints::new));
+				domain -> new DefaultLayoutHelper(domain, DefaultLayoutConstraints::new, fontHelperFactory));
 	}
 
 	/**
@@ -90,6 +95,17 @@ public class LogicalModelPlugin extends EMFPlugin {
 	 */
 	public SemanticHelper getSemanticHelper(EditingDomain editingDomain) {
 		return semanticHelpers.computeIfAbsent(editingDomain, DefaultSemanticHelper::new);
+	}
+
+	/**
+	 * Inject a factory to create (hopeully UI/SWT-aware) font helpers.
+	 * 
+	 * @param fontHelperFactory
+	 *            the font-helper factory to set, or {@code null} for the default implementation that is now
+	 *            aware of SWT font metrics
+	 */
+	public void setFontHelperFactory(Supplier<FontHelper> fontHelperFactory) {
+		this.fontHelperFactory = (fontHelperFactory == null) ? DefaultFontHelper::new : fontHelperFactory;
 	}
 
 	public static LogicalModelPlugin getInstance() {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultFontHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultFontHelper.java
@@ -1,0 +1,45 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.spi.impl;
+
+import java.util.OptionalInt;
+
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.interaction.model.spi.FontHelper;
+
+/**
+ * A default implementation of the {@link FontHelper} protocol that doesn't understand anything about font
+ * metrics because it has no access to the SWT or other graphics toolkit APIs.
+ *
+ * @author Christian W. Damus
+ */
+public class DefaultFontHelper implements FontHelper {
+
+	/**
+	 * Initializes me.
+	 */
+	public DefaultFontHelper() {
+		super();
+	}
+
+	@Override
+	public String getFontName(View view) {
+		return null;
+	}
+
+	@Override
+	public OptionalInt getFontHeight(View view) {
+		return OptionalInt.of(11);
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
@@ -13,6 +13,7 @@
 package org.eclipse.papyrus.uml.interaction.internal.model.spi.impl;
 
 import static java.lang.Math.abs;
+import static org.eclipse.gmf.runtime.diagram.core.util.ViewUtil.getContainerView;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.applyModifier;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.ANCHOR;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.ARROW;
@@ -24,9 +25,14 @@ import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Re
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.gmf.runtime.diagram.core.util.ViewUtil;
 import org.eclipse.gmf.runtime.notation.Compartment;
+import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints;
+import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
 
 /**
@@ -48,6 +54,10 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 
 	private final Map<String, Integer> standardPaddings;
 
+	private final Map<String, Integer> standardTopInsets;
+
+	private final Map<String, Integer> standardBottomInsets;
+
 	/**
 	 * Initializes me.
 	 */
@@ -59,6 +69,8 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 		standardHeights = loadHeights();
 		standardWidths = loadWidths();
 		standardPaddings = loadPaddings();
+		standardTopInsets = loadTopInsets();
+		standardBottomInsets = loadBottomInsets();
 	}
 
 	@Override
@@ -73,7 +85,22 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 
 	@Override
 	public int getYOffset(Compartment shapeCompartment) {
-		return getYOffset(shapeCompartment.getType());
+		int result = getYOffset(shapeCompartment.getType());
+
+		if (ViewTypes.INTERACTION_CONTENTS.equals(shapeCompartment.getType())) {
+			// Add the height of the name label above it
+			LayoutHelper layout = LogicalModelPlugin.getInstance()
+					.getLayoutHelper(AdapterFactoryEditingDomain.getEditingDomainFor(shapeCompartment));
+			if (layout != null) {
+				Node nameLabel = (Node)ViewUtil.getChildBySemanticHint(getContainerView(shapeCompartment),
+						ViewTypes.INTERACTION_NAME);
+				if (nameLabel != null) {
+					result = result + layout.getHeight(nameLabel);
+				}
+			}
+		}
+
+		return result;
 	}
 
 	@Override
@@ -158,11 +185,21 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 		return 15;
 	}
 
+	@Override
+	public int getTopInset(String viewType) {
+		return standardTopInsets.getOrDefault(viewType, ZERO).intValue();
+	}
+
+	@Override
+	public int getBottomInset(String viewType) {
+		return standardBottomInsets.getOrDefault(viewType, ZERO).intValue();
+	}
+
 	@SuppressWarnings("boxing")
 	private static Map<String, Integer> loadXOffsets() {
 		Map<String, Integer> result = new HashMap<>();
 
-		// Inset of the viewpoint figure
+		// Inset of the viewport figure
 		result.put(ViewTypes.INTERACTION_CONTENTS, 5);
 
 		return result;
@@ -172,9 +209,29 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 	private static Map<String, Integer> loadYOffsets() {
 		Map<String, Integer> result = new HashMap<>();
 
-		// The size of the interaction frame's pentagon label
-		result.put(ViewTypes.INTERACTION_CONTENTS, 30);
+		// Inset of the viewport figure
+		result.put(ViewTypes.INTERACTION_CONTENTS, 5);
 		result.put(ViewTypes.LIFELINE_HEADER, 25);
+		return result;
+	}
+
+	@SuppressWarnings("boxing")
+	private static Map<String, Integer> loadTopInsets() {
+		Map<String, Integer> result = new HashMap<>();
+
+		// Inset of the label figure
+		result.put(ViewTypes.INTERACTION_NAME, 5);
+
+		return result;
+	}
+
+	@SuppressWarnings("boxing")
+	private static Map<String, Integer> loadBottomInsets() {
+		Map<String, Integer> result = new HashMap<>();
+
+		// Inset of the label figure
+		result.put(ViewTypes.INTERACTION_NAME, 6);
+
 		return result;
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/FontHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/FontHelper.java
@@ -1,0 +1,50 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model.spi;
+
+import java.util.OptionalInt;
+
+import org.eclipse.gmf.runtime.notation.View;
+
+/**
+ * Protocol for a pluggable utility that provides font names and metrics of those fonts for the views in a
+ * diagram.
+ *
+ * @author Christian W. Damus
+ */
+public interface FontHelper {
+
+	/**
+	 * Queries the name of the font configured for a {@code view}. The result should never be {@code null} in
+	 * an installation with UI (SWT) awareness, because the frameworks provide for a default font. But in a
+	 * non-UI context it may be {@code null}.
+	 * 
+	 * @param view
+	 *            a view in the diagram
+	 * @return its font name, if any can be determined
+	 */
+	String getFontName(View view);
+
+	/**
+	 * Queries the height of the font configured for a {@code view}, in diagram measurement units. Note that
+	 * this may depend on the particular font metrics and the text of the {@code view}. The result should
+	 * always be {@link OptionalInt#isPresent() present} in an installation with UI (SWT) awareness, because
+	 * the frameworks provide for a default font height. But in a non-UI context it may be absent.
+	 * 
+	 * @param view
+	 *            a view in the diagram
+	 * @return its font height
+	 */
+	OptionalInt getFontHeight(View view);
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutConstraints.java
@@ -210,6 +210,46 @@ public interface LayoutConstraints {
 	int getMagnetStrength(View view);
 
 	/**
+	 * Query the top inset of the given {@code view}.
+	 * 
+	 * @param view
+	 *            a view in the diagram
+	 * @return the top inset for that {@code view}
+	 */
+	default int getTopInset(View view) {
+		return getTopInset(view.getType());
+	}
+
+	/**
+	 * Query the standard top inset of the given view type.
+	 * 
+	 * @param viewType
+	 *            a view type
+	 * @return the standard top inset for that view type
+	 */
+	int getTopInset(String viewType);
+
+	/**
+	 * Query the bottom inset of the given {@code view}.
+	 * 
+	 * @param view
+	 *            a view in the diagram
+	 * @return the bottom inset for that {@code view}
+	 */
+	default int getBottomInset(View view) {
+		return getBottomInset(view.getType());
+	}
+
+	/**
+	 * Query the standard bottom inset of the given view type.
+	 * 
+	 * @param viewType
+	 *            a view type
+	 * @return the standard bottom inset for that view type
+	 */
+	int getBottomInset(String viewType);
+
+	/**
 	 * Applies a {@link Modifiers modifier} to the given <code>viewType</code> and returns the resulting key.
 	 * 
 	 * @param modifier

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/LayoutHelper.java
@@ -49,7 +49,7 @@ public interface LayoutHelper {
 	 *            a shape in the sequence diagram
 	 * @return its top position
 	 */
-	int getTop(Shape shape);
+	int getTop(Node shape);
 
 	/**
 	 * Queries the bottom (y-coördinate) of the diagram visual element associated with a vertex in the graph.
@@ -67,7 +67,7 @@ public interface LayoutHelper {
 	 *            a shape in the sequence diagram
 	 * @return its bottom position
 	 */
-	int getBottom(Shape shape);
+	int getBottom(Node shape);
 
 	/**
 	 * Queries the height of a {@code shape}.
@@ -76,7 +76,7 @@ public interface LayoutHelper {
 	 *            a shape in the diagram
 	 * @return its height
 	 */
-	int getHeight(Shape shape);
+	int getHeight(Node shape);
 
 	/**
 	 * Queries the vertical position (y-coördinate) of an {@code anchor} in the sequence diagram.
@@ -105,7 +105,7 @@ public interface LayoutHelper {
 	 *            a shape in the sequence diagram
 	 * @return its left position
 	 */
-	int getLeft(Shape shape);
+	int getLeft(Node shape);
 
 	/**
 	 * Queries the right (x-coördinate) of the diagram visual element associated with a vertex in the graph.
@@ -123,7 +123,7 @@ public interface LayoutHelper {
 	 *            a shape in the sequence diagram
 	 * @return its right position
 	 */
-	int getRight(Shape shape);
+	int getRight(Node shape);
 
 	/**
 	 * Obtains a command that sets the top (y-coördinate) of the diagram visual element associated with a
@@ -146,7 +146,7 @@ public interface LayoutHelper {
 	 *            the new top position to set
 	 * @return the command, which may not be executable but will not be {@code null}
 	 */
-	Command setTop(Shape shape, int yPosition);
+	Command setTop(Node shape, int yPosition);
 
 	/**
 	 * Obtains a command that sets the bottom (y-coördinate) of the diagram visual element associated with a
@@ -169,7 +169,7 @@ public interface LayoutHelper {
 	 *            the new bottom position to set
 	 * @return the command, which may not be executable but will not be {@code null}
 	 */
-	Command setBottom(Shape shape, int yPosition);
+	Command setBottom(Node shape, int yPosition);
 
 	/**
 	 * Obtains a command that sets the vertical position (y-coördinate) of an {@code anchor} in the sequence
@@ -206,7 +206,7 @@ public interface LayoutHelper {
 	 *            the new left position to set
 	 * @return the command, which may not be executable but will not be {@code null}
 	 */
-	Command setLeft(Shape shape, int xPosition);
+	Command setLeft(Node shape, int xPosition);
 
 	/**
 	 * Returns the bounds for a new representation, given the proposed bounds.
@@ -246,7 +246,7 @@ public interface LayoutHelper {
 	 *            an X position in relative coördinate space of the {@code parent}
 	 * @return the corresponding position in absolute coördinate space
 	 */
-	int toAbsoluteX(Shape shape, View parent, int x);
+	int toAbsoluteX(Node shape, View parent, int x);
 
 	/**
 	 * Obtain an {@code x} coördinate in absolute space from one that is relative to the parent of a
@@ -258,7 +258,7 @@ public interface LayoutHelper {
 	 *            an X position in relative coördinate space of the {@code shape}'s parent
 	 * @return the corresponding position in absolute coördinate space, or the relative {@code x} if none
 	 */
-	default int toAbsoluteX(Shape shape, int x) {
+	default int toAbsoluteX(Node shape, int x) {
 		EObject container = shape.eContainer();
 		return (container instanceof View) ? toAbsoluteX(shape, (View)container, x) : x;
 	}
@@ -275,7 +275,7 @@ public interface LayoutHelper {
 	 *            an X position in absolute coördinate space
 	 * @return the corresponding position in the {@code parent}'s space
 	 */
-	int toRelativeX(Shape shape, View parent, int x);
+	int toRelativeX(Node shape, View parent, int x);
 
 	/**
 	 * Obtain an {@code x} coördinate in the space of the parent of a {@code shape}, if it has one, from one
@@ -289,7 +289,7 @@ public interface LayoutHelper {
 	 *         none
 	 * @see #toRelativeX(Shape, View, int)
 	 */
-	default int toRelativeX(Shape shape, int x) {
+	default int toRelativeX(Node shape, int x) {
 		EObject container = shape.eContainer();
 		return (container instanceof View) ? toRelativeX(shape, (View)container, x) : x;
 	}
@@ -306,7 +306,7 @@ public interface LayoutHelper {
 	 *            a Y position in relative coördinate space of the {@code parent}
 	 * @return the corresponding position in absolute coördinate space
 	 */
-	int toAbsoluteY(Shape shape, View parent, int y);
+	int toAbsoluteY(Node shape, View parent, int y);
 
 	/**
 	 * Obtain a {@code y} coördinate in absolute space from one that is relative to the parent of a
@@ -318,7 +318,7 @@ public interface LayoutHelper {
 	 *            a Y position in relative coördinate space of the {@code shape}'s parent
 	 * @return the corresponding position in absolute coördinate space, or the relative {@code x} if none
 	 */
-	default int toAbsoluteY(Shape shape, int y) {
+	default int toAbsoluteY(Node shape, int y) {
 		EObject container = shape.eContainer();
 		return (container instanceof View) ? toAbsoluteY(shape, (View)container, y) : y;
 	}
@@ -335,7 +335,7 @@ public interface LayoutHelper {
 	 *            a Y position in absolute coördinate space
 	 * @return the corresponding position in the {@code parent}'s space
 	 */
-	int toRelativeY(Shape shape, View parent, int y);
+	int toRelativeY(Node shape, View parent, int y);
 
 	/**
 	 * Obtain a {@code y} coördinate in the space of the parent of a {@code shape}, if it has one, from one
@@ -349,7 +349,7 @@ public interface LayoutHelper {
 	 *         none
 	 * @see #toRelativeY(Shape, View, int)
 	 */
-	default int toRelativeY(Shape shape, int y) {
+	default int toRelativeY(Node shape, int y) {
 		EObject container = shape.eContainer();
 		return (container instanceof View) ? toRelativeY(shape, (View)container, y) : y;
 	}
@@ -361,4 +361,10 @@ public interface LayoutHelper {
 	 */
 	LayoutConstraints getConstraints();
 
+	/**
+	 * Obtain the font helper for label calculations.
+	 * 
+	 * @return the pluggable font helper
+	 */
+	FontHelper getFontHelper();
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.gef,
  org.eclipse.gmf.runtime.emf.type.core,
  org.eclipse.papyrus.infra.gmfdiag.common,
- org.eclipse.papyrus.uml.diagram.sequence.figure;bundle-version="[1.0.0,2.0.0)"
+ org.eclipse.papyrus.uml.diagram.sequence.figure;bundle-version="[1.0.0,2.0.0)",
+ org.eclipse.papyrus.uml.interaction.model;bundle-version="[1.0.0,2.0.0)"
 Bundle-Description: Tests of the core run-time APIs of the sequence diagram.
 Export-Package: org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers;version="1.0.0"

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/DefaultLayoutHelperIntegrationUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/DefaultLayoutHelperIntegrationUITest.java
@@ -1,0 +1,257 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.Supplier;
+
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gmf.runtime.notation.Edge;
+import org.eclipse.gmf.runtime.notation.IdentityAnchor;
+import org.eclipse.gmf.runtime.notation.NotationPackage;
+import org.eclipse.gmf.runtime.notation.Shape;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.gmf.runtime.notation.util.NotationSwitch;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests.DefaultLayoutHelperIntegrationUITest.PerEditPartTests;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.uml2.uml.Element;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runner.Runner;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Suite;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
+import org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters;
+import org.junit.runners.parameterized.TestWithParameters;
+
+/**
+ * An integration test for the {@code DefaultLayoutHelper}, that it correctly
+ * computes the locations of visuals in the diagram.
+ */
+@RunWith(PerEditPartTests.class)
+public class DefaultLayoutHelperIntegrationUITest {
+
+	@ClassRule
+	public static final EditorFixture EDITOR = new EditorFixture(DefaultLayoutHelperIntegrationUITest.class,
+			"kitchen-sink.di");
+
+	@Parameter
+	public Supplier<MElement<? extends Element>> elementSupplier;
+
+	private MElement<? extends Element> element;
+
+	/**
+	 * Initializes me.
+	 */
+	public DefaultLayoutHelperIntegrationUITest() {
+		super();
+	}
+
+	@Test
+	public void modelComputesCorrectY() {
+		// Get what the layout helper thinks the top and bottom of the element are
+		OptionalInt _top = element.getTop();
+		OptionalInt _bottom = element.getBottom();
+
+		if (!_top.isPresent() || !_bottom.isPresent()) {
+			if (!_top.isPresent()) {
+				fail("No top");
+			}
+			if (!_bottom.isPresent()) {
+				fail("No bottom");
+			}
+		}
+
+		int top = _top.getAsInt();
+		int bottom = _bottom.getAsInt();
+		int height = bottom - top;
+
+		// Get the notation view
+		Optional<? extends EObject> view = element.getDiagramView();
+		if (!view.isPresent()) {
+			// These aren't supposed to have views
+			if (!(element instanceof MExecutionOccurrence)) {
+				fail("No diagram view");
+			}
+			Assume.assumeFalse("Execution occurrences have no views", true);
+		}
+
+		// Compare the view's extent as GEF knows it
+		String failure = (String) new NotationSwitch() {
+			@Override
+			public Object caseShape(Shape shape) {
+				return verify(GEFMatchers.Figures.isBounded(anything(), is(top), anything(), is(height)),
+						getFigure(shape));
+			}
+
+			@Override
+			public Object caseEdge(Edge edge) {
+				return verify(GEFMatchers.Figures.runs(isPoint(anything(), is(top)),
+						isPoint(anything(), is(bottom))), getFigure(edge));
+			}
+
+			@Override
+			public Object caseIdentityAnchor(IdentityAnchor anchor) {
+				if (top != bottom) {
+					return String.format("Different top and bottom: %d ≠ %d", top, bottom);
+				}
+
+				Edge edge = (Edge) anchor.eContainer();
+				switch (anchor.eContainmentFeature().getFeatureID()) {
+				case NotationPackage.EDGE__SOURCE_ANCHOR:
+					return verify(GEFMatchers.Figures.runs(isPoint(anything(), is(top)), anything()),
+							getFigure(edge));
+				case NotationPackage.EDGE__TARGET_ANCHOR:
+					return verify(GEFMatchers.Figures.runs(anything(), isPoint(anything(), is(bottom))),
+							getFigure(edge));
+				}
+
+				return null;
+			}
+		}.doSwitch(view.get());
+
+		if (failure != null) {
+			fail(failure);
+		}
+	}
+
+	//
+	// Test framework
+	//
+
+	static MInteraction getInteraction() {
+		return MInteraction.getInstance(EDITOR.getInteraction(), EDITOR.getSequenceDiagram().orElse(null));
+	}
+
+	@Before
+	public void resolveElement() {
+		element = elementSupplier.get();
+	}
+
+	@After
+	public void cleanUp() {
+		element = null;
+		elementSupplier = null;
+	}
+
+	static <T> String verify(Matcher<? super T> matcher, T subject) {
+		String result = null;
+
+		if (!matcher.matches(subject)) {
+			StringDescription mismatch = new StringDescription();
+			matcher.describeMismatch(subject, mismatch);
+			mismatch.appendText(" (");
+			mismatch.appendDescriptionOf(matcher);
+			mismatch.appendText(")");
+			result = mismatch.toString();
+		}
+
+		return result;
+	}
+
+	static IFigure getFigure(View view) {
+		EditPart ep = (EditPart) EDITOR.getDiagramEditPart().getViewer().getEditPartRegistry().get(view);
+		return (ep instanceof GraphicalEditPart) ? ((GraphicalEditPart) ep).getFigure() : null;
+	}
+
+	//
+	// Nested types
+	//
+
+	public static class PerEditPartTests extends Suite {
+
+		private List<Runner> children = new ArrayList<>();
+
+		public PerEditPartTests(Class<?> klass) throws InitializationError {
+			super(klass, Collections.emptyList());
+
+			ModelFixture model = new ModelFixture("kitchen-sink.uml");
+			Description desc = Description.createSuiteDescription(klass);
+			Statement parametersGathering = new Statement() {
+
+				@Override
+				public void evaluate() throws Throwable {
+					try {
+						MInteraction interaction = MInteraction.getInstance(model.getInteraction());
+						createChildrenWithParameters(interaction);
+					} catch (InitializationError e) {
+						throw e.getCause();
+					}
+				}
+			};
+
+			try {
+				model.apply(parametersGathering, desc).evaluate();
+			} catch (Throwable e) {
+				throw new InitializationError(e);
+			}
+		}
+
+		@Override
+		protected List<Runner> getChildren() {
+			return children;
+		}
+
+		protected void createChildrenWithParameters(MInteraction interaction) throws InitializationError {
+			TestClass testClass = getTestClass();
+
+			// Don't assert the root interaction object because the diagram has no bounds
+			for (Iterator<EObject> iter = ((EObject) interaction).eAllContents(); iter.hasNext();) {
+				@SuppressWarnings("unchecked")
+				MElement<? extends Element> next = (MElement<? extends Element>) iter.next();
+				String uriFragment = EcoreUtil.getURI(next.getElement()).fragment();
+
+				Supplier<MElement<?>> translocator = () -> {
+					Element uml = (Element) EDITOR.getModel().eResource().getEObject(uriFragment);
+					return getInteraction().getElement(uml).get();
+				};
+
+				String name = next.toString();
+				TestWithParameters test = new TestWithParameters("[" + name + "]", testClass,
+						singletonList(translocator));
+
+				children.add(new BlockJUnit4ClassRunnerWithParameters(test));
+			}
+		}
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageMoveUITest.java
@@ -46,7 +46,7 @@ public class MessageMoveUITest extends AbstractGraphicalEditPolicyUITest {
 	// Horizontal position of the second lifeline's body
 	private static final int LIFELINE_2_BODY_X = 281;
 
-	private static final int INITIAL_Y = 170;
+	private static final int INITIAL_Y = 200;
 
 	private final int sendX;
 
@@ -110,9 +110,11 @@ public class MessageMoveUITest extends AbstractGraphicalEditPolicyUITest {
 	@Test
 	public void attemptToMoveAsyncMessageAcrossAnother() {
 		final int slopeY = INITIAL_Y + 80;
-		final int otherY = moveDown ? INITIAL_Y + 80 + 15 : INITIAL_Y - 15;
+		final int otherY = moveDown ? INITIAL_Y + 80 + 30 : INITIAL_Y - 30;
 
-		if (!moveDown) { // Be sure to create messages in top-down order to avoid nudging
+		// Be sure to create messages in top-down order to avoid nudging and
+		// far enough apart to avoid padding
+		if (!moveDown) {
 			createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, otherY), at(recvX, otherY));
 		}
 
@@ -120,11 +122,13 @@ public class MessageMoveUITest extends AbstractGraphicalEditPolicyUITest {
 				at(recvX, slopeY)); // always sloping down, of course
 		assumeThat(messageEP, runs(sendX, INITIAL_Y, recvX, slopeY));
 
-		if (moveDown) { // Be sure to create messages in top-down order to avoid nudging
+		// Be sure to create messages in top-down order to avoid nudging and
+		// far enough apart to avoid padding
+		if (moveDown) {
 			createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, otherY), at(recvX, otherY));
 		}
 
-		int delta = moveDown ? 30 : -30;
+		int delta = moveDown ? 60 : -60;
 		int x = (sendX + recvX) / 2;
 		int grabY = (INITIAL_Y + slopeY) / 2;
 		int y = grabY + delta;

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageReconnectionConstraintsUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageReconnectionConstraintsUITest.java
@@ -27,37 +27,42 @@ public class MessageReconnectionConstraintsUITest extends AbstractGraphicalEditP
 	// Horizontal position of the second lifeline's body
 	private static final int LIFELINE_2_BODY_X = 281;
 
-	private static final int INITIAL_Y = 120;
-	
+	// Attempting to create these at the same Y position results in padding that
+	// breaks our assumptions
+	private static final int MSG1_Y = 120;
+	private static final int MSG2_Y = 150;
+
 	@Test
 	public void reconnectTargetToMessageNotAllowed() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(LIFELINE_1_BODY_X, INITIAL_Y),
-				at(LIFELINE_2_BODY_X, INITIAL_Y)); // always sloping down, of course
-		assumeThat(messageEP, runs(LIFELINE_1_BODY_X, INITIAL_Y, LIFELINE_2_BODY_X, INITIAL_Y));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge,
+				at(LIFELINE_1_BODY_X, MSG1_Y), at(LIFELINE_2_BODY_X, MSG1_Y));
+		assumeThat(messageEP, runs(LIFELINE_1_BODY_X, MSG1_Y, LIFELINE_2_BODY_X, MSG1_Y));
 
-		EditPart messageEP2 = createConnection(SequenceElementTypes.Async_Message_Edge, at(LIFELINE_1_BODY_X, INITIAL_Y+50),
-				at(LIFELINE_2_BODY_X, INITIAL_Y)); // always sloping down, of course
-		assumeThat(messageEP2, runs(LIFELINE_1_BODY_X, INITIAL_Y, LIFELINE_2_BODY_X, INITIAL_Y+50));
+		EditPart messageEP2 = createConnection(SequenceElementTypes.Async_Message_Edge,
+				at(LIFELINE_1_BODY_X, MSG2_Y), at(LIFELINE_2_BODY_X, MSG2_Y + 50)); // always sloping down,
+																					// of course
+		assumeThat(messageEP2, runs(LIFELINE_1_BODY_X, MSG2_Y, LIFELINE_2_BODY_X, MSG2_Y + 50));
 
-		int middleX = (LIFELINE_2_BODY_X - LIFELINE_1_BODY_X) / 2; 
-		editor.moveSelection(at(LIFELINE_2_BODY_X, INITIAL_Y+50), at(middleX, INITIAL_Y));
+		int middleX = (LIFELINE_2_BODY_X + LIFELINE_1_BODY_X) / 2;
+		editor.moveSelection(at(LIFELINE_2_BODY_X, MSG2_Y + 50), at(middleX, MSG1_Y));
 
-		assertThat(messageEP, not(runs(LIFELINE_1_BODY_X, INITIAL_Y+50, middleX, INITIAL_Y)));
+		assertThat(messageEP, not(runs(LIFELINE_1_BODY_X, MSG2_Y + 50, middleX, MSG1_Y)));
 	}
 
 	@Test
 	public void reconnectSourceToMessageNotAllowed() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(LIFELINE_1_BODY_X, INITIAL_Y),
-				at(LIFELINE_2_BODY_X, INITIAL_Y)); // always sloping down, of course
-		assumeThat(messageEP, runs(LIFELINE_1_BODY_X, INITIAL_Y, LIFELINE_2_BODY_X, INITIAL_Y));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge,
+				at(LIFELINE_1_BODY_X, MSG1_Y), at(LIFELINE_2_BODY_X, MSG1_Y));
+		assumeThat(messageEP, runs(LIFELINE_1_BODY_X, MSG1_Y, LIFELINE_2_BODY_X, MSG1_Y));
 
-		EditPart messageEP2 = createConnection(SequenceElementTypes.Async_Message_Edge, at(LIFELINE_1_BODY_X, INITIAL_Y+50),
-				at(LIFELINE_2_BODY_X, INITIAL_Y)); // always sloping down, of course
-		assumeThat(messageEP2, runs(LIFELINE_1_BODY_X, INITIAL_Y, LIFELINE_2_BODY_X, INITIAL_Y+50));
+		EditPart messageEP2 = createConnection(SequenceElementTypes.Async_Message_Edge,
+				at(LIFELINE_1_BODY_X, MSG2_Y), at(LIFELINE_2_BODY_X, MSG2_Y + 50)); // always sloping down,
+																					// of course
+		assumeThat(messageEP2, runs(LIFELINE_1_BODY_X, MSG2_Y, LIFELINE_2_BODY_X, MSG2_Y + 50));
 
-		int middleX = (LIFELINE_2_BODY_X - LIFELINE_1_BODY_X) / 2; 
-		editor.moveSelection(at(LIFELINE_1_BODY_X, INITIAL_Y+50), at(middleX, INITIAL_Y));
+		int middleX = (LIFELINE_2_BODY_X + LIFELINE_1_BODY_X) / 2;
+		editor.moveSelection(at(LIFELINE_1_BODY_X, MSG2_Y), at(middleX, MSG1_Y));
 
-		assertThat(messageEP, not(runs(middleX, INITIAL_Y, LIFELINE_2_BODY_X, INITIAL_Y+50)));
+		assertThat(messageEP, not(runs(middleX, MSG1_Y, LIFELINE_2_BODY_X, MSG2_Y + 50)));
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/kitchen-sink.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/kitchen-sink.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/kitchen-sink.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/kitchen-sink.notation
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_nieKUMGGEeiBUataQqP5Qw" type="LightweightSequenceDiagram" name="scenario" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_nieKUcGGEeiBUataQqP5Qw" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_nieKUsGGEeiBUataQqP5Qw" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_nieKU8GGEeiBUataQqP5Qw" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_phL5wMGGEeiBUataQqP5Qw" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_phL5wcGGEeiBUataQqP5Qw" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_phL5wsGGEeiBUataQqP5Qw" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_phL5w8GGEeiBUataQqP5Qw" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_BRwzAMGHEeiBUataQqP5Qw" type="Shape_Execution_Specification">
+            <element xmi:type="uml:BehaviorExecutionSpecification" href="kitchen-sink.uml#_BPmP0MGHEeiBUataQqP5Qw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BRwzAcGHEeiBUataQqP5Qw" x="-4" y="138" width="10" height="80"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_phL5xMGGEeiBUataQqP5Qw" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="kitchen-sink.uml#_pcNTIMGGEeiBUataQqP5Qw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_phL5xcGGEeiBUataQqP5Qw" x="61" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_qA2RQMGGEeiBUataQqP5Qw" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_qA2RQcGGEeiBUataQqP5Qw" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_qA2RQsGGEeiBUataQqP5Qw" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_qA2RQ8GGEeiBUataQqP5Qw" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_wjrFEMGGEeiBUataQqP5Qw" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="kitchen-sink.uml#_walagMGGEeiBUataQqP5Qw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wjrFEcGGEeiBUataQqP5Qw" x="-4" y="60" width="10" height="40"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_qA2RRMGGEeiBUataQqP5Qw" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="kitchen-sink.uml#_p-qf8MGGEeiBUataQqP5Qw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qA2RRcGGEeiBUataQqP5Qw" x="198" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_NLtcgMGHEeiBUataQqP5Qw" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_NLtcgcGHEeiBUataQqP5Qw" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_NLtcgsGHEeiBUataQqP5Qw" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_NLtcg8GHEeiBUataQqP5Qw" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_Vulcg8GHEeiBUataQqP5Qw" type="Shape_Destruction_Specification">
+            <element xmi:type="uml:DestructionOccurrenceSpecification" href="kitchen-sink.uml#_VulcgcGHEeiBUataQqP5Qw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VulchMGHEeiBUataQqP5Qw" x="-9" y="41" width="20" height="20"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_NLtchMGHEeiBUataQqP5Qw" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="kitchen-sink.uml#_NK150MGHEeiBUataQqP5Qw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NLtchcGHEeiBUataQqP5Qw" x="340" y="268" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nieKVMGGEeiBUataQqP5Qw" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_nieKVcGGEeiBUataQqP5Qw" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_nieKVsGGEeiBUataQqP5Qw"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_nieKV8GGEeiBUataQqP5Qw" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="kitchen-sink.uml#_mWGd0MGGEeiBUataQqP5Qw"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="kitchen-sink.uml#_mWGd0MGGEeiBUataQqP5Qw"/>
+  <edges xmi:type="notation:Connector" xmi:id="_1rVicMGGEeiBUataQqP5Qw" type="Edge_Message" source="_phL5w8GGEeiBUataQqP5Qw" target="_wjrFEMGGEeiBUataQqP5Qw">
+    <element xmi:type="uml:Message" href="kitchen-sink.uml#_1rU7YsGGEeiBUataQqP5Qw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_1rViccGGEeiBUataQqP5Qw"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1rVicsGGEeiBUataQqP5Qw" id="60"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_1rVic8GGEeiBUataQqP5Qw" id="start"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_8U4CQMGGEeiBUataQqP5Qw" type="Edge_Message" source="_wjrFEMGGEeiBUataQqP5Qw" target="_phL5w8GGEeiBUataQqP5Qw">
+    <element xmi:type="uml:Message" href="kitchen-sink.uml#_8U3bMsGGEeiBUataQqP5Qw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8U4CQcGGEeiBUataQqP5Qw"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8U4CQsGGEeiBUataQqP5Qw" id="end"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8U4CQ8GGEeiBUataQqP5Qw" id="100"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_Hy6y48GHEeiBUataQqP5Qw" type="Edge_Message" source="_BRwzAMGHEeiBUataQqP5Qw" target="_qA2RQ8GGEeiBUataQqP5Qw">
+    <element xmi:type="uml:Message" href="kitchen-sink.uml#_Hy6y4sGHEeiBUataQqP5Qw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Hy6y5MGHEeiBUataQqP5Qw"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hy6y5cGHEeiBUataQqP5Qw" id="right;35"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hy6y5sGHEeiBUataQqP5Qw" id="204"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_Uhk208GHEeiBUataQqP5Qw" type="Edge_Message" source="_qA2RQ8GGEeiBUataQqP5Qw" target="_NLtcgMGHEeiBUataQqP5Qw">
+    <element xmi:type="uml:Message" href="kitchen-sink.uml#_Uhk20sGHEeiBUataQqP5Qw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Uhk21MGHEeiBUataQqP5Qw"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhk21cGHEeiBUataQqP5Qw" id="229"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhk21sGHEeiBUataQqP5Qw" id="left;14"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_VulchcGHEeiBUataQqP5Qw" type="Edge_Message" source="_qA2RQ8GGEeiBUataQqP5Qw" target="_Vulcg8GHEeiBUataQqP5Qw">
+    <element xmi:type="uml:Message" href="kitchen-sink.uml#_VulcgsGHEeiBUataQqP5Qw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_VulchsGHEeiBUataQqP5Qw"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Vulch8GHEeiBUataQqP5Qw" id="294"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_VulciMGHEeiBUataQqP5Qw" id="(0.9,0.5)"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/kitchen-sink.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/kitchen-sink.uml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kwE7MMGGEeiBUataQqP5Qw" name="kitchen-sink">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_k5DRAMGGEeiBUataQqP5Qw">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_mWGd0MGGEeiBUataQqP5Qw" name="Scenario">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_pcNTIMGGEeiBUataQqP5Qw" name="L1" coveredBy="_1rU7YMGGEeiBUataQqP5Qw _8U3bMcGGEeiBUataQqP5Qw _BPmP0cGHEeiBUataQqP5Qw _BPmP0MGHEeiBUataQqP5Qw _BPmP0sGHEeiBUataQqP5Qw _Hy6y4MGHEeiBUataQqP5Qw"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_p-qf8MGGEeiBUataQqP5Qw" name="L2" coveredBy="_walagMGGEeiBUataQqP5Qw _1rU7YcGGEeiBUataQqP5Qw _8U3bMMGGEeiBUataQqP5Qw _Hy6y4cGHEeiBUataQqP5Qw _Uhk20MGHEeiBUataQqP5Qw _VulcgMGHEeiBUataQqP5Qw"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_NK150MGHEeiBUataQqP5Qw" name="L3" coveredBy="_Uhk20cGHEeiBUataQqP5Qw _VulcgcGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_1rU7YMGGEeiBUataQqP5Qw" name="s1" covered="_pcNTIMGGEeiBUataQqP5Qw" message="_1rU7YsGGEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_1rU7YcGGEeiBUataQqP5Qw" name="r1" covered="_p-qf8MGGEeiBUataQqP5Qw" message="_1rU7YsGGEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_walagMGGEeiBUataQqP5Qw" name="exec1" covered="_p-qf8MGGEeiBUataQqP5Qw" finish="_8U3bMMGGEeiBUataQqP5Qw" start="_1rU7YcGGEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_8U3bMMGGEeiBUataQqP5Qw" name="s2" covered="_p-qf8MGGEeiBUataQqP5Qw" message="_8U3bMsGGEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_8U3bMcGGEeiBUataQqP5Qw" name="r2" covered="_pcNTIMGGEeiBUataQqP5Qw" message="_8U3bMsGGEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_BPmP0cGHEeiBUataQqP5Qw" name="e2" covered="_pcNTIMGGEeiBUataQqP5Qw" execution="_BPmP0MGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_BPmP0MGHEeiBUataQqP5Qw" name="exec2" covered="_pcNTIMGGEeiBUataQqP5Qw" finish="_BPmP0sGHEeiBUataQqP5Qw" start="_BPmP0cGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_Hy6y4MGHEeiBUataQqP5Qw" name="s3" covered="_pcNTIMGGEeiBUataQqP5Qw" message="_Hy6y4sGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_Hy6y4cGHEeiBUataQqP5Qw" name="r3" covered="_p-qf8MGGEeiBUataQqP5Qw" message="_Hy6y4sGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_BPmP0sGHEeiBUataQqP5Qw" name="f2" covered="_pcNTIMGGEeiBUataQqP5Qw" execution="_BPmP0MGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_Uhk20MGHEeiBUataQqP5Qw" name="s4" covered="_p-qf8MGGEeiBUataQqP5Qw" message="_Uhk20sGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_Uhk20cGHEeiBUataQqP5Qw" name="c4" covered="_NK150MGHEeiBUataQqP5Qw" message="_Uhk20sGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_VulcgMGHEeiBUataQqP5Qw" name="s5" covered="_p-qf8MGGEeiBUataQqP5Qw" message="_VulcgsGHEeiBUataQqP5Qw"/>
+    <fragment xmi:type="uml:DestructionOccurrenceSpecification" xmi:id="_VulcgcGHEeiBUataQqP5Qw" name="d5" covered="_NK150MGHEeiBUataQqP5Qw" message="_VulcgsGHEeiBUataQqP5Qw"/>
+    <message xmi:type="uml:Message" xmi:id="_1rU7YsGGEeiBUataQqP5Qw" name="m1" receiveEvent="_1rU7YcGGEeiBUataQqP5Qw" sendEvent="_1rU7YMGGEeiBUataQqP5Qw"/>
+    <message xmi:type="uml:Message" xmi:id="_8U3bMsGGEeiBUataQqP5Qw" name="m2" messageSort="reply" receiveEvent="_8U3bMcGGEeiBUataQqP5Qw" sendEvent="_8U3bMMGGEeiBUataQqP5Qw"/>
+    <message xmi:type="uml:Message" xmi:id="_Hy6y4sGHEeiBUataQqP5Qw" name="m3" messageSort="asynchCall" receiveEvent="_Hy6y4cGHEeiBUataQqP5Qw" sendEvent="_Hy6y4MGHEeiBUataQqP5Qw"/>
+    <message xmi:type="uml:Message" xmi:id="_Uhk20sGHEeiBUataQqP5Qw" name="m4" messageSort="createMessage" receiveEvent="_Uhk20cGHEeiBUataQqP5Qw" sendEvent="_Uhk20MGHEeiBUataQqP5Qw"/>
+    <message xmi:type="uml:Message" xmi:id="_VulcgsGHEeiBUataQqP5Qw" name="m5" messageSort="deleteMessage" receiveEvent="_VulcgcGHEeiBUataQqP5Qw" sendEvent="_VulcgMGHEeiBUataQqP5Qw"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/EditorFixture.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/EditorFixture.java
@@ -218,7 +218,16 @@ public class EditorFixture extends ModelFixture {
 
 	protected IProject getProject(Description description) {
 		if (project == null) {
-			project = ResourcesPlugin.getWorkspace().getRoot().getProject(description.getMethodName());
+			String projectName = description.getMethodName();
+			if (projectName == null) {
+				// It's a class rule, then
+				projectName = description.getDisplayName();
+				// Note that if there's no dot, this gets the substring from zero
+				projectName = projectName.substring(projectName.lastIndexOf('.') + 1);
+				// Strip out all non-letters
+				projectName = projectName.replaceAll("\\P{L}", "");
+			}
+			project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 
 			try {
 				if (!project.exists()) {

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionOccurrenceTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionOccurrenceTest.java
@@ -135,8 +135,9 @@ public class MExecutionOccurrenceTest extends MOccurrenceTest {
 
 	@Override
 	public void testGetTop() {
-		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {execution y}
-		assertThat(getFixture().getTop(), isPresent(117));
+		// Note that this diagram has no interaction name label!
+		// 12 {frame} + 5 {insets} + 25 {lifeline} + 25 {head} + 25 {execution y}
+		assertThat(getFixture().getTop(), isPresent(92));
 	}
 
 	@Override

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionTest.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
-import org.eclipse.uml2.uml.InteractionFragment;
 
 import junit.textui.TestRunner;
 
@@ -92,9 +91,9 @@ public class MExecutionTest extends MElementTest {
 	protected void initializeFixture() {
 		/* remove test may remove execution -> avoid NPE */
 		List<MExecution> executions = interaction.getLifelines().get(1).getExecutions();
-		if(executions.isEmpty()) {
+		if (executions.isEmpty()) {
 			setFixture(null);
-		}else {
+		} else {
 			setFixture(executions.get(0));
 		}
 	}
@@ -126,13 +125,14 @@ public class MExecutionTest extends MElementTest {
 
 	@Override
 	public void testGetTop() {
-		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {y}
-		assertThat(getFixture().getTop(), isPresent(117));
+		// Note that this diagram has no interaction name label!
+		// 12 {frame} + 5 {insets} + 25 {lifeline} + 25 {head} + 25 {y}
+		assertThat(getFixture().getTop(), isPresent(92));
 	}
 
 	@Override
 	public void testGetBottom() {
-		assertThat(getFixture().getBottom(), isPresent(267)); // 117 {top} + 150 {height}
+		assertThat(getFixture().getBottom(), isPresent(242)); // 92 {top} + 150 {height}
 	}
 
 	@Override
@@ -189,32 +189,32 @@ public class MExecutionTest extends MElementTest {
 		super.testGetDiagramView();
 		assertThat(getFixture().getDiagramView().get().getType(), is("Shape_Execution_Specification"));
 	}
-	
+
 	public void testRemove() {
 		MExecution execution = getFixture();
-		
+
 		/* act */
 		Command command = execution.remove();
 		assertThat(command, executable());
 		execute(command);
-		
+
 		/* assert execution with messages removed */
 		/* assert logical representation */
 		assertEquals(2, interaction.getLifelines().size());
 		assertTrue(interaction.getLifelines().get(1).getExecutions().isEmpty());
 		assertTrue(interaction.getMessages().isEmpty());
-		
+
 		/* assert semantics */
 		assertEquals(2, umlInteraction.getLifelines().size());
 		assertTrue(umlInteraction.getLifelines().get(1).getCoveredBys().isEmpty());
 		assertTrue(umlInteraction.getFragments().isEmpty());
 		assertTrue(umlInteraction.getMessages().isEmpty());
-		
+
 		/* assert diagram */
 		assertTrue(sequenceDiagram.getEdges().isEmpty());
 		Optional<Shape> lifeLineView = interaction.getLifelines().get(1).getDiagramView();
 		assertTrue(lifeLineView.isPresent());
-		assertFalse(findTypeInChildren(lifeLineView.get(),"Shape_Execution_Specification").isPresent());
+		assertFalse(findTypeInChildren(lifeLineView.get(), "Shape_Execution_Specification").isPresent());
 	}
 
 } // MExecutionTest

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MLifelineTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MLifelineTest.java
@@ -219,13 +219,14 @@ public class MLifelineTest extends MElementTest {
 
 	@Override
 	public void testGetTop() {
-		assertThat(getFixture().getTop(), isPresent(67)); // 12 {frame} + 30 {title} + {25} y
+		// Note that this diagram has no interaction name label!
+		assertThat(getFixture().getTop(), isPresent(42)); // 12 {frame} + 5 {insets} + {25} y
 	}
 
 	@Override
 	public void testGetBottom() {
 		// The lifeline header has a specified height
-		assertThat(getFixture().getBottom(), isPresent(92)); // 67 {top} + 25 {height}
+		assertThat(getFixture().getBottom(), isPresent(67)); // 42 {top} + 25 {height}
 	}
 
 	@Override
@@ -335,9 +336,9 @@ public class MLifelineTest extends MElementTest {
 		ExecutionSpecification execSpec = create(command);
 		MExecution exec = getFixture().getExecution(execSpec).get();
 
-		// 267 {message} + 15 {offset}
-		assertThat(exec.getTop(), isPresent(282));
-		assertThat(exec.getBottom(), isPresent(332));
+		// 242 {message} + 15 {offset}
+		assertThat(exec.getTop(), isPresent(257));
+		assertThat(exec.getBottom(), isPresent(307));
 		assertThat(exec.getElement(), instanceOf(ActionExecutionSpecification.class));
 		assertThat(((ActionExecutionSpecification)exec.getElement()).getAction(), is(action));
 	}
@@ -360,9 +361,9 @@ public class MLifelineTest extends MElementTest {
 		ExecutionSpecification execSpec = create(command);
 		MExecution exec = getFixture().getExecution(execSpec).get();
 
-		// 267 {message} + 15 {offset}
-		assertThat(exec.getTop(), isPresent(282));
-		assertThat(exec.getBottom(), isPresent(332));
+		// 242 {message} + 15 {offset}
+		assertThat(exec.getTop(), isPresent(257));
+		assertThat(exec.getBottom(), isPresent(307));
 		assertThat(exec.getElement(), instanceOf(ActionExecutionSpecification.class));
 
 		// We didn't actually supply the action, as such
@@ -390,9 +391,9 @@ public class MLifelineTest extends MElementTest {
 		Message umlMessage = create(command);
 		MMessage message = interaction.getMessage(umlMessage).get();
 
-		// 267 {message} + 25 {offset}
-		assertThat(message.getTop(), isPresent(292));
-		assertThat(message.getBottom(), isPresent(292));
+		// 242 {message} + 25 {offset}
+		assertThat(message.getTop(), isPresent(267));
+		assertThat(message.getBottom(), isPresent(267));
 		assertThat(umlMessage.getSignature(), is(operation));
 		assertThat(umlMessage.getMessageSort(), is(MessageSort.SYNCH_CALL_LITERAL));
 		assertThat(umlMessage.getMessageKind(), is(MessageKind.COMPLETE_LITERAL));
@@ -439,10 +440,10 @@ public class MLifelineTest extends MElementTest {
 		Message umlMessage = create(command);
 		MMessage message = interaction.getMessage(umlMessage).get();
 
-		// 267 {message} + 25 {offset}
-		assertThat(message.getTop(), isPresent(292));
-		// 30 pixels of slope
-		assertThat(message.getBottom(), isPresent(312));
+		// 242 {message} + 25 {offset}
+		assertThat(message.getTop(), isPresent(267));
+		// 20 pixels of slope
+		assertThat(message.getBottom(), isPresent(287));
 		assertThat(umlMessage.getSignature(), is(operation));
 		assertThat(umlMessage.getMessageSort(), is(MessageSort.ASYNCH_SIGNAL_LITERAL));
 		assertThat(umlMessage.getMessageKind(), is(MessageKind.COMPLETE_LITERAL));

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageEndTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageEndTest.java
@@ -121,8 +121,9 @@ public class MMessageEndTest extends MOccurrenceTest {
 
 	@Override
 	public void testGetTop() {
-		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {anchor}
-		assertThat(getFixture().getTop(), isPresent(117));
+		// Note that this diagram has no interaction name label!
+		// 12 {frame} + 5 {insets} + 25 {lifeline} + 25 {head} + 25 {anchor}
+		assertThat(getFixture().getTop(), isPresent(92));
 	}
 
 	@Override

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageTest.java
@@ -121,14 +121,16 @@ public class MMessageTest extends MElementTest {
 
 	@Override
 	public void testGetTop() {
-		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {anchor}
-		assertThat(getFixture().getTop(), isPresent(117));
+		// Note that this diagram has no interaction name label!
+		// 12 {frame} + 5 {insets} + 25 {lifeline} + 25 {head} + 25 {anchor}
+		assertThat(getFixture().getTop(), isPresent(92));
 	}
 
 	@Override
 	public void testGetBottom() {
-		// 12 {frame} + 30 {title} + 25 {lifeline} + 25 {head} + 25 {anchor}
-		assertThat(getFixture().getBottom(), isPresent(117));
+		// Note that this diagram has no interaction name label!
+		// 12 {frame} + 5 {insets} + 25 {lifeline} + 25 {head} + 25 {anchor}
+		assertThat(getFixture().getBottom(), isPresent(92));
 	}
 
 	@Override

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/DefaultLayoutHelperTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/tests/DefaultLayoutHelperTest.java
@@ -24,6 +24,7 @@ import org.eclipse.gmf.runtime.notation.Bounds;
 import org.eclipse.gmf.runtime.notation.Node;
 import org.eclipse.gmf.runtime.notation.NotationFactory;
 import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultFontHelper;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutConstraints;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.DefaultLayoutHelper;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
@@ -71,7 +72,8 @@ public class DefaultLayoutHelperTest {
 
 	@Before
 	public void createSUT() {
-		helper = new DefaultLayoutHelper(model.getEditingDomain(), DefaultLayoutConstraints::new);
+		helper = new DefaultLayoutHelper(model.getEditingDomain(), DefaultLayoutConstraints::new,
+				DefaultFontHelper::new);
 	}
 
 	@After

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTestB.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTestB.java
@@ -79,7 +79,7 @@ public class CreateMessageTestB {
 		/* setup */
 		MLifeline lifeline1 = interaction().getLifelines().get(0);
 		MLifeline lifeline2 = interaction().getLifelines().get(1);
-		CreationCommand<Message> command = lifeline1.insertMessageAfter(lifeline1, 25, lifeline2,
+		CreationCommand<Message> command = lifeline1.insertMessageAfter(lifeline1, 15, lifeline2,
 				MessageSort.CREATE_MESSAGE_LITERAL, null);
 
 		/* act */
@@ -92,6 +92,7 @@ public class CreateMessageTestB {
 		assertEquals(6, interaction().getMessages().size());
 		assertEquals(MessageSort.CREATE_MESSAGE_LITERAL,
 				interaction().getMessages().get(5).getElement().getMessageSort());
+		// Moved by 15 plus the padding because the create message was drawn too close to M1
 		assertEquals(model.getLifelineBodyTop(interaction().getLifelines().get(0)) + 25,
 				interaction().getMessages().get(5).getTop().getAsInt());
 
@@ -103,6 +104,8 @@ public class CreateMessageTestB {
 		assertEquals(nudgedLifeline2Top, interaction().getLifelines().get(1).getTop().getAsInt());
 
 		int delta = nudgedLifeline2Top - lifeline2Top;
+		// Accounti for padding between the new create message and M1
+		int deltaPad = delta + 10;
 		assertEquals(lifeline3Top + delta, interaction().getLifelines().get(2).getTop().getAsInt());
 		assertEquals(message1Top + delta, interaction().getMessages().get(0).getTop().getAsInt());
 		assertEquals(message2Top + delta, interaction().getMessages().get(4).getTop().getAsInt());
@@ -112,8 +115,8 @@ public class CreateMessageTestB {
 		assertEquals(message1Top + delta, interaction().getMessages().get(0).getBottom().getAsInt());
 		assertEquals(message2Top + delta, interaction().getMessages().get(4).getBottom().getAsInt());
 		assertEquals(message3Top + delta, interaction().getMessages().get(1).getBottom().getAsInt());
-		assertEquals(message4Top + delta, interaction().getMessages().get(2).getBottom().getAsInt());
-		assertEquals(message5Top + delta, interaction().getMessages().get(3).getBottom().getAsInt());
+		assertEquals(message4Top + deltaPad, interaction().getMessages().get(2).getBottom().getAsInt());
+		assertEquals(message5Top + deltaPad, interaction().getMessages().get(3).getBottom().getAsInt());
 	}
 
 	@Test


### PR DESCRIPTION
The *Logical Model* depends on a plugged-in `LayoutHelper` to determine X and Y positioning of notation views in the diagram without reference to the GEF presentation layer. However, this calculation is off by 3 in the Y direction and that error blocks testing of a fix for Issue #76.

So, add a temporary fudge factor to adjust the Y calculation by 3 until we can determine the root cause of the disparity and fix it properly.  Add a JUnit test that compares all computed Y values against actual GEF-rendered geometry for regression testing of this and a proper solution.

Other consequence updates to tests:
- can un-ignore a test that was ignored because of this Y error
- some layout test assertions have to be adjusted by 3
- other tests that create elements too close to other elements now are affected by the padding feature, so they need to account for that

In regression testing it was observed that the message reconnection constraints tests as written didn’t do what they were intended to do and so always skipped on an assumption violation; these are now fixed.