### PR TITLE
Add parser for lifeline header label

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/messages.properties
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/messages.properties
@@ -111,3 +111,6 @@ SynchronousMessagePreferencesLabel=Synchronous Messages
 CreateExecutionAfterSyncMessageAutomaticallyLabel=Create execution specification for synchronous messages
 CreateReplyMessageAutomaticallyLabel=Create reply messages for synchronous calls
 CreateSynchronousMessagePopupCommandLabel=Create synchronous message
+LifelineLabelSelector=[{0}]
+LifelineLabelType=\ : {0}
+LifelineLabelDecomposition=\ ref {0}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/Messages.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/Messages.java
@@ -126,4 +126,10 @@ public class Messages extends NLS {
 	public static String CreateExecutionAfterSyncMessageAutomaticallyLabel;
 
 	public static String CreateSynchronousMessagePopupCommandLabel;
+
+	public static String LifelineLabelSelector;
+
+	public static String LifelineLabelType;
+
+	public static String LifelineLabelDecomposition;
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineNameEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineNameEditPart.java
@@ -11,15 +11,19 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts;
 
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes.Lifeline_Shape;
+import static org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes.LIFELINE_NAME;
+
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gmf.runtime.common.ui.services.parser.IParser;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.TextCompartmentEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.label.ILabelDelegate;
 import org.eclipse.gmf.runtime.diagram.ui.label.WrappingLabelDelegate;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.WrappingLabel;
 import org.eclipse.gmf.runtime.notation.View;
-import org.eclipse.uml2.uml.NamedElement;
+import org.eclipse.papyrus.infra.gmfdiag.common.parsers.ParserUtil;
 
 public class LifelineNameEditPart extends TextCompartmentEditPart {
 
@@ -47,15 +51,15 @@ public class LifelineNameEditPart extends TextCompartmentEditPart {
 	}
 
 	@Override
-	protected String getLabelText() {
-		// TODO remove override to get normal parser working
-		// return super.getLabelText();
-
-		EObject element = resolveSemanticElement();
-		if (NamedElement.class.isInstance(element)) {
-			return NamedElement.class.cast(element).getName();
+	public IParser getParser() {
+		if (parser == null) {
+			parser = ParserUtil.getParser(Lifeline_Shape, getParserElement(), this, LIFELINE_NAME);
 		}
-		return null;
+		return parser;
+	}
+
+	protected EObject getParserElement() {
+		return resolveSemanticElement();
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/parsers/LifelineHeaderParser.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/parsers/LifelineHeaderParser.java
@@ -1,0 +1,192 @@
+/*****************************************************************************
+ * Copyright (c) 2009 CEA and others
+ *
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Atos Origin - Initial API and implementation
+ *   Nicolas FAUVERGUE (ALL4TEC) nicolas.fauvergue@all4tec.net - Bug 496905
+ *   Philip Langer - adapted for the use in lightweight sequence diagrams
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.parsers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.gmf.runtime.emf.ui.services.parser.ISemanticParser;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.Messages;
+import org.eclipse.papyrus.uml.internationalization.utils.utils.UMLLabelInternationalization;
+import org.eclipse.papyrus.uml.tools.utils.ValueSpecificationUtil;
+import org.eclipse.uml2.uml.ConnectableElement;
+import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.Expression;
+import org.eclipse.uml2.uml.Interaction;
+import org.eclipse.uml2.uml.Lifeline;
+import org.eclipse.uml2.uml.LiteralSpecification;
+import org.eclipse.uml2.uml.OpaqueExpression;
+import org.eclipse.uml2.uml.PartDecomposition;
+import org.eclipse.uml2.uml.TimeExpression;
+import org.eclipse.uml2.uml.Type;
+import org.eclipse.uml2.uml.UMLPackage;
+import org.eclipse.uml2.uml.ValueSpecification;
+
+/**
+ * A specific parser for the Lifeline header. This parser of refreshing the text displayed by the lifeline.
+ * <p>
+ * This class is largely based on the
+ * org.eclipse.papyrus.uml.diagram.sequence.parser.custom.LifelineCustomParsers of the Papyrus Photon project,
+ * except for the following functional changes:
+ * <ul>
+ * <li>Selector should always be enclosed in brackets, also if it is an expression</li>
+ * <li>Prevent new lines as not forseen in UML standard</li>
+ * </ul>
+ * </p>
+ */
+public class LifelineHeaderParser extends MessageFormatParser implements ISemanticParser {
+
+	public LifelineHeaderParser() {
+		super(new EAttribute[] {UMLPackage.Literals.NAMED_ELEMENT__NAME });
+	}
+
+	protected EStructuralFeature getEStructuralFeature(Object notification) {
+		EStructuralFeature featureImpl = null;
+		if (notification instanceof Notification) {
+			Object feature = ((Notification)notification).getFeature();
+			if (feature instanceof EStructuralFeature) {
+				featureImpl = (EStructuralFeature)feature;
+			}
+		}
+		return featureImpl;
+	}
+
+	@Override
+	public boolean isAffectingEvent(Object event, int flags) {
+		EStructuralFeature feature = getEStructuralFeature(event);
+		return isValidFeature(feature);
+	}
+
+	@Override
+	public String getPrintString(IAdaptable element, int flags) {
+		Object obj = element.getAdapter(EObject.class);
+		StringBuffer sb = new StringBuffer();
+		if (obj instanceof Lifeline) {
+			Lifeline lifeline = (Lifeline)obj;
+			ConnectableElement connectableElement = lifeline.getRepresents();
+			ValueSpecification selector = lifeline.getSelector();
+			if (connectableElement != null) {
+				// Add ConnectableElement Name
+				String connectableElementName = UMLLabelInternationalization.getInstance()
+						.getLabel(connectableElement);
+				if (connectableElementName != null) {
+					sb.append(connectableElementName);
+				}
+				// Add the selector if it is a LiteralSpecification
+				if (selector instanceof LiteralSpecification) {
+					sb.append(NLS.bind(Messages.LifelineLabelSelector,
+							ValueSpecificationUtil.getSpecificationValue(selector, true)));
+				}
+				// Add the type name
+				Type type = connectableElement.getType();
+				if (type != null && type.getName() != null
+						&& UMLLabelInternationalization.getInstance().getLabel(type).length() > 0) {
+					sb.append(NLS.bind(Messages.LifelineLabelType,
+							UMLLabelInternationalization.getInstance().getLabel(type)));
+				}
+			}
+			// Add the selector if it is an Expression
+			if (selector instanceof Expression || selector instanceof OpaqueExpression
+					|| selector instanceof TimeExpression) {
+				String specificationValue = ValueSpecificationUtil.getSpecificationValue(selector);
+				if (specificationValue != null && specificationValue.length() > 0) {
+					sb.append(NLS.bind(Messages.LifelineLabelSelector, specificationValue));
+				}
+			}
+			// Add the decomposition
+			PartDecomposition partDecomposition = lifeline.getDecomposedAs();
+			if (partDecomposition != null) {
+				Interaction refersTo = partDecomposition.getRefersTo();
+				if (refersTo != null) {
+					sb.append(NLS.bind(Messages.LifelineLabelDecomposition,
+							UMLLabelInternationalization.getInstance().getLabel(refersTo)));
+				}
+			}
+			// LifelineIndent cannot be empty so if the stringBuffer is empty we add the name of the
+			// lifeline -- this case occurs when creating the lifeline for example
+			if (sb.length() == 0) {
+				sb.append(UMLLabelInternationalization.getInstance().getLabel(lifeline));
+			}
+		}
+		return sb.toString();
+	}
+
+	@Override
+	public boolean areSemanticElementsAffected(EObject listener, Object notification) {
+		EStructuralFeature feature = getEStructuralFeature(notification);
+		return isValidFeature(feature);
+	}
+
+	@Override
+	public List<Element> getSemanticElementsBeingParsed(EObject element) {
+		List<Element> semanticElementsBeingParsed = new ArrayList<>();
+		if (element instanceof Lifeline) {
+			Lifeline lifeline = (Lifeline)element;
+			// Add the lifeline
+			semanticElementsBeingParsed.add(lifeline);
+			// Add the selector
+			if (lifeline.getSelector() != null) {
+				semanticElementsBeingParsed.add(lifeline.getSelector());
+			}
+			// Add the partDecomposition
+			PartDecomposition partDecomposition = lifeline.getDecomposedAs();
+			if (partDecomposition != null) {
+				semanticElementsBeingParsed.add(partDecomposition);
+				// Add the Interaction refered by the partDecomposition
+				if (partDecomposition.getRefersTo() != null) {
+					semanticElementsBeingParsed.add(partDecomposition.getRefersTo());
+				}
+			}
+			// Add the connectableElement and its type if it has any
+			ConnectableElement connectableElement = lifeline.getRepresents();
+			if (connectableElement != null) {
+				semanticElementsBeingParsed.add(connectableElement);
+				if (connectableElement.getType() != null) {
+					semanticElementsBeingParsed.add(connectableElement.getType());
+				}
+			}
+		}
+		return semanticElementsBeingParsed;
+	}
+
+	/**
+	 * Determines if the given feature has to be taken into account in this parser
+	 *
+	 * @param feature
+	 *            the feature to test
+	 * @return true if is valid, false otherwise
+	 */
+	private boolean isValidFeature(EStructuralFeature feature) {
+		return UMLPackage.eINSTANCE.getNamedElement_Name().equals(feature)
+				|| UMLPackage.eINSTANCE.getTypedElement_Type().equals(feature)
+				|| UMLPackage.eINSTANCE.getLiteralInteger_Value().equals(feature)
+				|| UMLPackage.eINSTANCE.getLiteralUnlimitedNatural_Value().equals(feature)
+				|| UMLPackage.eINSTANCE.getLiteralBoolean_Value().equals(feature)
+				|| UMLPackage.eINSTANCE.getLiteralString_Value().equals(feature)
+				|| UMLPackage.eINSTANCE.getOpaqueExpression_Body().equals(feature)
+				|| UMLPackage.eINSTANCE.getLifeline_Selector().equals(feature)
+				|| UMLPackage.eINSTANCE.getLifeline_DecomposedAs().equals(feature)
+				|| UMLPackage.eINSTANCE.getLifeline_Represents().equals(feature)
+				|| UMLPackage.eINSTANCE.getInteractionUse_RefersTo().equals(feature);
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/providers/SequenceElementTypes.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/providers/SequenceElementTypes.java
@@ -91,11 +91,9 @@ public final class SequenceElementTypes {
 		Object type = hint.getAdapter(IElementType.class);
 		if (elements == null) {
 			elements = new IdentityHashMap<IElementType, ENamedElement>();
-
 			elements.put(Package_SequenceDiagram, UMLPackage.eINSTANCE.getPackage());
-
 			elements.put(Interaction_Shape, UMLPackage.eINSTANCE.getInteraction());
-
+			elements.put(Lifeline_Shape, UMLPackage.eINSTANCE.getLifeline());
 		}
 		return elements.get(type);
 	}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/providers/SequenceParserProvider.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/providers/SequenceParserProvider.java
@@ -23,23 +23,28 @@ import org.eclipse.gmf.runtime.common.ui.services.parser.ParserService;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
 import org.eclipse.gmf.runtime.emf.ui.services.parser.ParserHintAdapter;
 import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.parsers.LifelineHeaderParser;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.parsers.MessageFormatParser;
 import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
 import org.eclipse.uml2.uml.UMLPackage;
 
 public class SequenceParserProvider extends AbstractProvider implements IParserProvider {
 
+	private IParser interaction_NameLabel_Parser;
+
+	private IParser lifeline_NameLabel_Parser;
+
 	protected IParser getParser(String visualID) {
 		if (visualID != null) {
 			switch (visualID) {
 				case ViewTypes.INTERACTION_NAME:
 					return getInteraction_NameLabel_Parser();
+				case ViewTypes.LIFELINE_NAME:
+					return getLifeline_NameLabel_Parser();
 			}
 		}
 		return null;
 	}
-
-	private IParser interaction_NameLabel_Parser;
 
 	private IParser getInteraction_NameLabel_Parser() {
 		if (interaction_NameLabel_Parser == null) {
@@ -51,6 +56,13 @@ public class SequenceParserProvider extends AbstractProvider implements IParserP
 			interaction_NameLabel_Parser = parser;
 		}
 		return interaction_NameLabel_Parser;
+	}
+
+	private IParser getLifeline_NameLabel_Parser() {
+		if (lifeline_NameLabel_Parser == null) {
+			lifeline_NameLabel_Parser = new LifelineHeaderParser();
+		}
+		return lifeline_NameLabel_Parser;
 	}
 
 	public static IParser getParser(IElementType type, EObject object, String parserHint) {


### PR DESCRIPTION
Fix #247 by integrating the lifeline header label parser from Papyrus
Photon. This parser has mostly been added as is except for the following
fixes:

  * Selector should always be enclosed in brackets
  * Prevent new lines as not forseen in UML standard

Signed-off-by: Philip Langer <planger@eclipsesource.com>