### PR TITLE
Fix #73 Corner attachment on executions

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/MessageFigure.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/MessageFigure.java
@@ -13,7 +13,11 @@
 package org.eclipse.papyrus.uml.diagram.sequence.figure;
 
 import org.eclipse.draw2d.ConnectionAnchor;
+import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.gmf.runtime.draw2d.ui.figures.PolylineConnectionEx;
+import org.eclipse.papyrus.uml.diagram.sequence.figure.anchors.IExecutionAnchor;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.anchors.MessageSourceAnchor;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.anchors.MessageTargetAnchor;
 
@@ -40,6 +44,41 @@ public class MessageFigure extends PolylineConnectionEx {
 		}
 
 		return super.getConnectionAnchor(terminal);
+	}
+
+	@Override
+	public void validate() {
+		super.validate();
+
+		MessageDirection direction = computeDirection();
+		if (getSourceAnchor() instanceof IExecutionAnchor) {
+			((IExecutionAnchor)getSourceAnchor()).setConnectionSide(direction.getExecutionSide(true));
+		}
+		if (getTargetAnchor() instanceof IExecutionAnchor) {
+			((IExecutionAnchor)getTargetAnchor()).setConnectionSide(direction.getExecutionSide(false));
+		}
+	}
+
+	MessageDirection computeDirection() {
+		PointList points = getPoints();
+		Point source = points.getFirstPoint();
+		Point target = points.getLastPoint();
+
+		return (target.x >= source.x) ? MessageDirection.LEFT_TO_RIGHT : MessageDirection.RIGHT_TO_LEFT;
+	}
+
+	//
+	// Nested types
+	//
+
+	enum MessageDirection {
+		LEFT_TO_RIGHT, RIGHT_TO_LEFT;
+
+		int getExecutionSide(boolean sourceAnchor) {
+			return sourceAnchor //
+					? (this == RIGHT_TO_LEFT) ? PositionConstants.LEFT : PositionConstants.RIGHT
+					: (this == LEFT_TO_RIGHT) ? PositionConstants.LEFT : PositionConstants.RIGHT;
+		}
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationEndAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationEndAnchor.java
@@ -11,16 +11,29 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.diagram.sequence.figure.anchors;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.draw2d.AbstractConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.anchors.AnchorParser.AnchorKind;
 
-public class ExecutionSpecificationEndAnchor extends AbstractConnectionAnchor implements ISequenceAnchor {
+public class ExecutionSpecificationEndAnchor extends AbstractConnectionAnchor implements IExecutionAnchor {
+
+	private int side = PositionConstants.LEFT;
 
 	public ExecutionSpecificationEndAnchor(IFigure figure) {
 		super(figure);
+	}
+
+	@Override
+	public void setConnectionSide(int side) {
+		Assert.isTrue((side & PositionConstants.LEFT_CENTER_RIGHT) != 0);
+		if (side != this.side) {
+			this.side = side;
+			fireAnchorMoved();
+		}
 	}
 
 	@Override
@@ -29,7 +42,17 @@ public class ExecutionSpecificationEndAnchor extends AbstractConnectionAnchor im
 		getOwner().translateToAbsolute(body);
 
 		Point location = new Point(0, 0);
-		location.translate(body.getBottom()); // End + Center
+		switch (side) {
+			case PositionConstants.LEFT:
+				location.translate(body.getBottomLeft()); // End + Left
+				break;
+			case PositionConstants.CENTER:
+				location.translate(body.getBottom()); // End + Center
+				break;
+			case PositionConstants.RIGHT:
+				location.translate(body.getBottomRight()); // End + Right
+				break;
+		}
 
 		return location;
 	}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationStartAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationStartAnchor.java
@@ -11,16 +11,29 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.diagram.sequence.figure.anchors;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.draw2d.AbstractConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.anchors.AnchorParser.AnchorKind;
 
-public class ExecutionSpecificationStartAnchor extends AbstractConnectionAnchor implements ISequenceAnchor {
+public class ExecutionSpecificationStartAnchor extends AbstractConnectionAnchor implements IExecutionAnchor {
+
+	private int side = PositionConstants.CENTER;
 
 	public ExecutionSpecificationStartAnchor(IFigure figure) {
 		super(figure);
+	}
+
+	@Override
+	public void setConnectionSide(int side) {
+		Assert.isTrue((side & PositionConstants.LEFT_CENTER_RIGHT) != 0);
+		if (side != this.side) {
+			this.side = side;
+			fireAnchorMoved();
+		}
 	}
 
 	@Override
@@ -29,7 +42,17 @@ public class ExecutionSpecificationStartAnchor extends AbstractConnectionAnchor 
 		getOwner().translateToAbsolute(body);
 
 		Point location = new Point(0, 0);
-		location.translate(body.getTop()); // Start + Center
+		switch (side) {
+			case PositionConstants.LEFT:
+				location.translate(body.getTopLeft()); // Start + Left
+				break;
+			case PositionConstants.CENTER:
+				location.translate(body.getTop()); // Start + Center
+				break;
+			case PositionConstants.RIGHT:
+				location.translate(body.getTopRight()); // Start + Right
+				break;
+		}
 
 		return location;
 	}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/IExecutionAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/IExecutionAnchor.java
@@ -1,0 +1,28 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.figure.anchors;
+
+/**
+ * Protocol for connection anchors on execution specifications.
+ */
+public interface IExecutionAnchor extends ISequenceAnchor {
+	/**
+	 * Set the side of the execution on which the message connection is attached (whether incoming or
+	 * outgoing). This is a dynamic property of the layout; not a component of the
+	 * {@link ISequenceAnchor#getTerminal() terminal} specification.
+	 * 
+	 * @param side
+	 *            the message attachment side
+	 */
+	void setConnectionSide(int side);
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/META-INF/MANIFEST.MF
@@ -15,11 +15,14 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.papyrus.uml.interaction.graph;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.papyrus.uml.interaction.model;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.papyrus.uml.service.types;bundle-version="[3.1.0,4.0.0)",
- org.eclipse.papyrus.infra.gmfdiag.preferences;bundle-version="[3.0.0,4.0.0)"
+ org.eclipse.papyrus.infra.gmfdiag.preferences;bundle-version="[3.0.0,4.0.0)",
+ org.eclipse.papyrus.uml.diagram.css;bundle-version="[2.0.0,3.0.0)",
+ org.eclipse.e4.ui.css.core;bundle-version="[0.12.101,1.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: org.eclipse.papyrus.uml.diagram.sequence.runtime.internal;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
+ org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.css;x-internal:=true,
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",
  org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.factories;x-friends:="org.eclipse.papyrus.uml.diagram.sequence.contribution",

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/plugin.xml
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/plugin.xml
@@ -36,4 +36,11 @@
             </adapter>
          </factory>
       </extension>
+      <extension
+            point="org.eclipse.papyrus.infra.gmfdiag.css.domElementAdapter">
+         <factory
+               factory="org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.css.LightweightSequenceCSSElementProviderFactory"
+               order="20">
+         </factory>
+      </extension>
 </plugin>

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/css/LightweightSequenceCSSElementProvider.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/css/LightweightSequenceCSSElementProvider.java
@@ -1,0 +1,40 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.css;
+
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.infra.gmfdiag.css.engine.ExtendedCSSEngine;
+import org.eclipse.papyrus.uml.diagram.css.dom.GMFUMLElementProvider;
+import org.w3c.dom.Element;
+
+/**
+ * CSS element provider for the <em>Lightweight Sequence Diagram</em>.
+ */
+@SuppressWarnings("restriction")
+class LightweightSequenceCSSElementProvider extends GMFUMLElementProvider {
+
+	/**
+	 * Initializes me.
+	 */
+	public LightweightSequenceCSSElementProvider() {
+		super();
+	}
+
+	@Override
+	public Element getElement(Object element, CSSEngine engine) {
+		// Casts serve as their own assertions, with useful messages when failed
+		return new LightweightSequenceElementAdapter((View)element, (ExtendedCSSEngine)engine);
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/css/LightweightSequenceCSSElementProviderFactory.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/css/LightweightSequenceCSSElementProviderFactory.java
@@ -1,0 +1,42 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.css;
+
+import org.eclipse.papyrus.infra.gmfdiag.css.notation.CSSDiagram;
+import org.eclipse.papyrus.infra.gmfdiag.css.provider.IPapyrusElementProvider;
+import org.eclipse.papyrus.uml.diagram.css.dom.GMFUMLElementProviderFactory;
+import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
+
+/**
+ * CSS element provider factory for the <em>Lightweight Sequence Diagram</em>.
+ */
+public class LightweightSequenceCSSElementProviderFactory extends GMFUMLElementProviderFactory {
+
+	/**
+	 * Initializes me.
+	 */
+	public LightweightSequenceCSSElementProviderFactory() {
+		super();
+	}
+
+	@Override
+	public boolean isProviderFor(CSSDiagram diagram) {
+		return ViewTypes.LIGHTWEIGHT_SEQUENCE_DIAGRAM.equals(diagram.getType());
+	}
+
+	@Override
+	public IPapyrusElementProvider createProvider(CSSDiagram diagram) {
+		return new LightweightSequenceCSSElementProvider();
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/css/LightweightSequenceElementAdapter.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/css/LightweightSequenceElementAdapter.java
@@ -1,0 +1,70 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.css;
+
+import org.eclipse.emf.transaction.Transaction;
+import org.eclipse.emf.transaction.impl.InternalTransactionalEditingDomain;
+import org.eclipse.emf.transaction.util.TransactionUtil;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.infra.gmfdiag.css.engine.ExtendedCSSEngine;
+import org.eclipse.papyrus.uml.diagram.css.dom.GMFUMLElementAdapter;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
+
+/**
+ * CSS element adapter for the <em>Lightweight Sequence Diagram</em>.
+ */
+@SuppressWarnings("restriction")
+class LightweightSequenceElementAdapter extends GMFUMLElementAdapter {
+
+	private InternalTransactionalEditingDomain editingDomain;
+
+	/**
+	 * Initializes me.
+	 *
+	 * @param view
+	 * @param engine
+	 */
+	public LightweightSequenceElementAdapter(View view, ExtendedCSSEngine engine) {
+		super(view, engine);
+
+		editingDomain = (InternalTransactionalEditingDomain)TransactionUtil.getEditingDomain(view);
+	}
+
+	@Override
+	public void dispose() {
+		editingDomain = null;
+		super.dispose();
+	}
+
+	@Override
+	public void notationPropertyChanged() {
+		if (shouldNotify()) {
+			super.notationPropertyChanged();
+		}
+	}
+
+	@Override
+	public void semanticPropertyChanged() {
+		if (shouldNotify()) {
+			super.semanticPropertyChanged();
+		}
+	}
+
+	boolean shouldNotify() {
+		// Don't refresh the diagram if we're preparing a pessimistic compound command,
+		// which involves executing commands which will immediately be undone
+		Transaction activeTransaction = (editingDomain == null) ? null : editingDomain.getActiveTransaction();
+		return (activeTransaction == null) || !Boolean.TRUE
+				.equals(activeTransaction.getOptions().get(CompoundModelCommand.OPTION_COMMAND_PREPARATION));
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
@@ -643,9 +643,18 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 				// First, delete the occurrence
 				DestroyElementCommand.destroy(occurrence.getElement());
 
-				// Then, hook up the execution
+				// Then, hook up the execution semantics
 				started.ifPresent(exec -> exec.getElement().setStart(msgOcc.get()));
 				finished.ifPresent(exec -> exec.getElement().setFinish(msgOcc.get()));
+
+				// And the execution visuals
+				Optional<Connector> messageView = msgEnd.getOwner().getDiagramView();
+				messageView.ifPresent(connector -> {
+					started.flatMap(MExecution::getDiagramView).ifPresent(
+							exec -> getDiagramHelper().reconnectTarget(connector, exec, 0).execute());
+					finished.flatMap(MExecution::getDiagramView).ifPresent(exec -> getDiagramHelper()
+							.reconnectSource(connector, exec, Integer.MAX_VALUE).execute());
+				});
 
 				return CommandResult.newOKCommandResult();
 			}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
@@ -592,6 +592,9 @@
         <eTypeArguments eClassifier="ecore:EClass ../../org.eclipse.gmf.runtime.notation/model/notation.ecore#//IdentityAnchor"/>
       </eGenericType>
     </eOperations>
+    <eOperations name="replaceBy" lowerBound="1" eType="#//Command">
+      <eParameters name="messageEnd" lowerBound="1" eType="#//MMessageEnd"/>
+    </eOperations>
     <eGenericSuperTypes eClassifier="#//MOccurrence">
       <eTypeArguments eClassifier="ecore:EClass platform:/plugin/org.eclipse.uml2.uml/model/UML.ecore#//ExecutionOccurrenceSpecification"/>
     </eGenericSuperTypes>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
@@ -179,6 +179,9 @@
     <genClasses ecoreClass="seqd.ecore#//MExecutionOccurrence">
       <genOperations ecoreOperation="seqd.ecore#//MExecutionOccurrence/getOwner"/>
       <genOperations ecoreOperation="seqd.ecore#//MExecutionOccurrence/getDiagramView"/>
+      <genOperations ecoreOperation="seqd.ecore#//MExecutionOccurrence/replaceBy">
+        <genParameters ecoreParameter="seqd.ecore#//MExecutionOccurrence/replaceBy/messageEnd"/>
+      </genOperations>
     </genClasses>
     <genClasses ecoreClass="seqd.ecore#//MMessageEnd">
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute seqd.ecore#//MMessageEnd/send"/>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
@@ -1263,13 +1263,21 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MEXECUTION_OCCURRENCE___GET_DIAGRAM_VIEW = MOCCURRENCE_OPERATION_COUNT + 1;
 
 	/**
+	 * The operation id for the '<em>Replace By</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION_OCCURRENCE___REPLACE_BY__MMESSAGEEND = MOCCURRENCE_OPERATION_COUNT + 2;
+
+	/**
 	 * The number of operations of the '<em>MExecution Occurrence</em>' class. <!-- begin-user-doc --> <!--
 	 * end-user-doc -->
 	 * 
 	 * @generated
 	 * @ordered
 	 */
-	int MEXECUTION_OCCURRENCE_OPERATION_COUNT = MOCCURRENCE_OPERATION_COUNT + 2;
+	int MEXECUTION_OCCURRENCE_OPERATION_COUNT = MOCCURRENCE_OPERATION_COUNT + 3;
 
 	/**
 	 * The meta object id for the
@@ -2710,6 +2718,17 @@ public interface SequenceDiagramPackage extends EPackage {
 	EOperation getMExecutionOccurrence__GetDiagramView();
 
 	/**
+	 * Returns the meta object for the
+	 * '{@link org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence#replaceBy(org.eclipse.papyrus.uml.interaction.model.MMessageEnd)
+	 * <em>Replace By</em>}' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the '<em>Replace By</em>' operation.
+	 * @see org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence#replaceBy(org.eclipse.papyrus.uml.interaction.model.MMessageEnd)
+	 * @generated
+	 */
+	EOperation getMExecutionOccurrence__ReplaceBy__MMessageEnd();
+
+	/**
 	 * Returns the meta object for class '{@link org.eclipse.papyrus.uml.interaction.model.MMessageEnd
 	 * <em>MMessage End</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
@@ -3552,6 +3571,15 @@ public interface SequenceDiagramPackage extends EPackage {
 		 */
 		EOperation MEXECUTION_OCCURRENCE___GET_DIAGRAM_VIEW = eINSTANCE
 				.getMExecutionOccurrence__GetDiagramView();
+
+		/**
+		 * The meta object literal for the '<em><b>Replace By</b></em>' operation. <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * 
+		 * @generated
+		 */
+		EOperation MEXECUTION_OCCURRENCE___REPLACE_BY__MMESSAGEEND = eINSTANCE
+				.getMExecutionOccurrence__ReplaceBy__MMessageEnd();
 
 		/**
 		 * The meta object literal for the

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionOccurrenceImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionOccurrenceImpl.java
@@ -15,12 +15,15 @@ package org.eclipse.papyrus.uml.interaction.internal.model.impl;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.gmf.runtime.notation.IdentityAnchor;
 import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.RemoveExecutionOccurrenceCommand;
 import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.uml2.uml.ExecutionOccurrenceSpecification;
 
 /**
@@ -73,9 +76,24 @@ public class MExecutionOccurrenceImpl extends MOccurrenceImpl<ExecutionOccurrenc
 		return getAnchor(getElement());
 	}
 
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated NOT
+	 */
+	@Override
+	public Command replaceBy(MMessageEnd messageEnd) {
+		return new ReplaceOccurrenceCommand(this, messageEnd);
+	}
+
 	@Override
 	public Optional<MLifeline> getCovered() {
 		return Optional.of(getOwner());
+	}
+
+	@Override
+	public Command remove() {
+		return new RemoveExecutionOccurrenceCommand(this);
 	}
 
 	/**
@@ -90,6 +108,8 @@ public class MExecutionOccurrenceImpl extends MOccurrenceImpl<ExecutionOccurrenc
 				return getOwner();
 			case SequenceDiagramPackage.MEXECUTION_OCCURRENCE___GET_DIAGRAM_VIEW:
 				return getDiagramView();
+			case SequenceDiagramPackage.MEXECUTION_OCCURRENCE___REPLACE_BY__MMESSAGEEND:
+				return replaceBy((MMessageEnd)arguments.get(0));
 		}
 		return super.eInvoke(operationID, arguments);
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/ReplaceOccurrenceCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/ReplaceOccurrenceCommand.java
@@ -1,0 +1,99 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.UnexecutableCommand;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.gmf.runtime.notation.Connector;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.ModelCommand;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
+import org.eclipse.uml2.uml.OccurrenceSpecification;
+import org.eclipse.uml2.uml.UMLPackage;
+
+/**
+ * A command that replaces an {@link MExecutionOccurrence} by an {@link MMessageEnd}.
+ */
+public class ReplaceOccurrenceCommand extends ModelCommand<MExecutionOccurrenceImpl> {
+
+	private final MMessageEnd end;
+
+	/**
+	 * Initializes me.
+	 *
+	 * @param target
+	 *            the execution occurrence to be replaced
+	 * @param end
+	 *            the message end that replaces the occurrence
+	 */
+	public ReplaceOccurrenceCommand(MExecutionOccurrenceImpl target, MMessageEnd end) {
+		super(target);
+
+		this.end = end;
+	}
+
+	@Override
+	protected Command createCommand() {
+		Optional<MExecution> started = getTarget().getStartedExecution();
+		Optional<MExecution> finished = getTarget().getFinishedExecution();
+
+		// If this occurrence starts and finishes an execution, or if it
+		// neither starts nor finishes an execution, then something's awry.
+		// Likewise if the message end is not an occurrence (e.g., a gate)
+		if ((started.isPresent() == finished.isPresent())
+				|| !(end.getElement() instanceof OccurrenceSpecification)) {
+			return UnexecutableCommand.INSTANCE;
+		}
+
+		// Moreover, it does not make sense to replace an execution start by a message send
+		// nor an execution finish by a message receive
+		if ((getTarget().isStart() != end.isReceive()) || (getTarget().isFinish() != end.isSend())) {
+			return UnexecutableCommand.INSTANCE;
+		}
+
+		// First, delete me
+		Command result = getTarget().remove();
+
+		// Then, hook up the execution semantics
+		result = started
+				.map(exec -> SetCommand.create(getEditingDomain(), exec.getElement(),
+						UMLPackage.Literals.EXECUTION_SPECIFICATION__START, end.getElement()))
+				.map(chaining(result)).orElse(result);
+		result = finished
+				.map(exec -> SetCommand.create(getEditingDomain(), exec.getElement(),
+						UMLPackage.Literals.EXECUTION_SPECIFICATION__FINISH, end.getElement()))
+				.map(chaining(result)).orElse(result);
+
+		// And the execution visuals
+		Optional<Connector> messageView = end.getOwner().getDiagramView();
+		result = messageView.map(connector -> {
+			List<Command> visuals = new ArrayList<>(2);
+			started.flatMap(MExecution::getDiagramView)
+					.map(exec -> diagramHelper().reconnectTarget(connector, exec, 0)).ifPresent(visuals::add);
+			finished.flatMap(MExecution::getDiagramView)
+					.map(exec -> diagramHelper().reconnectSource(connector, exec, Integer.MAX_VALUE))
+					.ifPresent(visuals::add);
+			return visuals.stream();
+		}).orElse(Stream.empty()).reduce(chaining()) //
+				.map(chaining(result)).orElse(result);
+
+		return result;
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
@@ -892,6 +892,16 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
+	public EOperation getMExecutionOccurrence__ReplaceBy__MMessageEnd() {
+		return mExecutionOccurrenceEClass.getEOperations().get(2);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
 	public EClass getMMessageEnd() {
 		return mMessageEndEClass;
 	}
@@ -1222,6 +1232,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		mExecutionOccurrenceEClass = createEClass(MEXECUTION_OCCURRENCE);
 		createEOperation(mExecutionOccurrenceEClass, MEXECUTION_OCCURRENCE___GET_OWNER);
 		createEOperation(mExecutionOccurrenceEClass, MEXECUTION_OCCURRENCE___GET_DIAGRAM_VIEW);
+		createEOperation(mExecutionOccurrenceEClass, MEXECUTION_OCCURRENCE___REPLACE_BY__MMESSAGEEND);
 
 		mMessageEndEClass = createEClass(MMESSAGE_END);
 		createEAttribute(mMessageEndEClass, MMESSAGE_END__SEND);
@@ -1797,6 +1808,10 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		g2 = createEGenericType(theNotationPackage.getIdentityAnchor());
 		g1.getETypeArguments().add(g2);
 		initEOperation(op, g1);
+
+		op = initEOperation(getMExecutionOccurrence__ReplaceBy__MMessageEnd(), this.getCommand(), "replaceBy", //$NON-NLS-1$
+				1, 1, IS_UNIQUE, IS_ORDERED);
+		addEParameter(op, this.getMMessageEnd(), "messageEnd", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEClass(mMessageEndEClass, MMessageEnd.class, "MMessageEnd", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
 				IS_GENERATED_INSTANCE_CLASS);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MExecutionOccurrence.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MExecutionOccurrence.java
@@ -14,6 +14,7 @@ package org.eclipse.papyrus.uml.interaction.model;
 
 import java.util.Optional;
 
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.gmf.runtime.notation.IdentityAnchor;
 import org.eclipse.uml2.uml.ExecutionOccurrenceSpecification;
 
@@ -45,5 +46,14 @@ public interface MExecutionOccurrence extends MOccurrence<ExecutionOccurrenceSpe
 	 */
 	@Override
 	Optional<IdentityAnchor> getDiagramView();
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @model dataType="org.eclipse.papyrus.uml.interaction.model.Command" required="true"
+	 *        messageEndRequired="true"
+	 * @generated
+	 */
+	Command replaceBy(MMessageEnd messageEnd);
 
 } // MExecutionOccurrence

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/AddLifelineCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/AddLifelineCommand.java
@@ -30,13 +30,11 @@ import org.eclipse.uml2.uml.UMLPackage;
  *
  * @author Christian W. Damus
  */
-public class AddLifelineCommand extends ModelCommand<MInteractionImpl> implements CreationCommand<Lifeline> {
+public class AddLifelineCommand extends ModelCommand.Creation<MInteractionImpl, Lifeline> {
 
 	private final int xOffset;
 
 	private final int height;
-
-	private CreationCommand<Lifeline> resultCommand;
 
 	/**
 	 * Initializes me.
@@ -49,20 +47,10 @@ public class AddLifelineCommand extends ModelCommand<MInteractionImpl> implement
 	 *            the height of the lifeline, or {@code -1} for the default
 	 */
 	public AddLifelineCommand(MInteractionImpl owner, int xOffset, int height) {
-		super(owner);
+		super(owner, Lifeline.class);
 
 		this.xOffset = xOffset;
 		this.height = height;
-	}
-
-	@Override
-	public Class<? extends Lifeline> getType() {
-		return Lifeline.class;
-	}
-
-	@Override
-	public Lifeline getNewObject() {
-		return (resultCommand == null) ? null : resultCommand.getNewObject();
 	}
 
 	@Override
@@ -70,7 +58,7 @@ public class AddLifelineCommand extends ModelCommand<MInteractionImpl> implement
 		SemanticHelper semantics = semanticHelper();
 		CreationParameters params = CreationParameters.in(getTarget().getElement(),
 				UMLPackage.Literals.INTERACTION__LIFELINE);
-		resultCommand = semantics.createLifeline(params);
+		CreationCommand<Lifeline> resultCommand = setResult(semantics.createLifeline(params));
 
 		Shape frame = diagramHelper().getInteractionFrame(getTarget().getDiagramView().get());
 		Compartment compartment = diagramHelper().getShapeCompartment(frame);
@@ -90,4 +78,5 @@ public class AddLifelineCommand extends ModelCommand<MInteractionImpl> implement
 
 		return result;
 	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/CompoundModelCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/CompoundModelCommand.java
@@ -56,7 +56,7 @@ public class CompoundModelCommand extends StrictCompoundCommand {
 	 * @param second
 	 *            the second composed command
 	 */
-	CompoundModelCommand(Command first, Command second) {
+	protected CompoundModelCommand(Command first, Command second) {
 		super();
 
 		// The whole point of our compounds is that each step may have
@@ -91,11 +91,23 @@ public class CompoundModelCommand extends StrictCompoundCommand {
 		if (first instanceof CompoundModelCommand) {
 			((CompoundModelCommand)first).append(second);
 			return first;
-		} else if (TRANSACTIONAL_EDITING_DOMAIN_CLASS.isInstance(editingDomain)) {
+		} else if (isTransactional(editingDomain)) {
 			return new TransactionalCompoundModelCommand(editingDomain, first, second);
 		}
 
 		return new CompoundModelCommand(first, second);
+	}
+
+	/**
+	 * Queries whether an editing domain is of the {@linkplain TransactionalEditingDomain transactional}
+	 * variety, without requiring the <em>EMF Transaction API</em> to be on the classpath.
+	 * 
+	 * @param editingDomain
+	 *            an editing domain
+	 * @return whether it is a {@link TransactionalEditingDomain}
+	 */
+	protected static boolean isTransactional(EditingDomain editingDomain) {
+		return TRANSACTIONAL_EDITING_DOMAIN_CLASS.isInstance(editingDomain);
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
@@ -45,7 +45,7 @@ import org.eclipse.uml2.uml.UMLPackage;
  *
  * @author Christian W. Damus
  */
-public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implements CreationCommand<ExecutionSpecification> {
+public class InsertExecutionCommand extends ModelCommand.Creation<MLifelineImpl, ExecutionSpecification> {
 
 	private final MElement<?> before;
 
@@ -56,8 +56,6 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 	private final Element specification;
 
 	private final EClass eClass;
-
-	private CreationCommand<ExecutionSpecification> resultCommand;
 
 	/**
 	 * Initializes me.
@@ -76,7 +74,7 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 	public InsertExecutionCommand(MLifelineImpl owner, MElement<?> before, int offset, int height,
 			Element specification) {
 
-		super(owner);
+		super(owner, ExecutionSpecification.class);
 
 		checkInteraction(before);
 		if (specification != null && !(specification instanceof Action)
@@ -109,7 +107,7 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 	public InsertExecutionCommand(MLifelineImpl owner, MElement<?> before, int offset, int height,
 			EClass eClass) {
 
-		super(owner);
+		super(owner, ExecutionSpecification.class);
 
 		checkInteraction(before);
 		if (!UMLPackage.Literals.EXECUTION_SPECIFICATION.isSuperTypeOf(eClass) || eClass.isAbstract()) {
@@ -121,16 +119,6 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 		this.height = height;
 		this.specification = null;
 		this.eClass = eClass;
-	}
-
-	@Override
-	public Class<? extends ExecutionSpecification> getType() {
-		return ExecutionSpecification.class;
-	}
-
-	@Override
-	public ExecutionSpecification getNewObject() {
-		return (resultCommand == null) ? null : resultCommand.getNewObject();
 	}
 
 	@Override
@@ -166,7 +154,8 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 		execParams.setEClass(eClass);
 		execParams.setInsertBefore(
 				() -> insertAt.map(MElement::getElement).map(Element.class::cast).orElse(null));
-		resultCommand = semantics.createExecutionSpecification(specification, execParams);
+		CreationCommand<ExecutionSpecification> resultCommand = setResult(
+				semantics.createExecutionSpecification(specification, execParams));
 		CreationParameters startParams = CreationParameters.before(resultCommand);
 		CreationCommand<OccurrenceSpecification> start = semantics.createStart(resultCommand, startParams);
 		CreationParameters finishParams = CreationParameters.after(resultCommand);
@@ -267,4 +256,5 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 		View headerView = getTarget().getDiagramView().get();
 		return (Shape)ViewUtil.getChildBySemanticHint(headerView, ViewTypes.LIFELINE_BODY);
 	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/ModelCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/ModelCommand.java
@@ -33,6 +33,7 @@ import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MInteractionImpl;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
@@ -251,7 +252,6 @@ public abstract class ModelCommand<T extends MElementImpl<?>> extends CommandWra
 	 * @see #getTimeline(MInteraction)
 	 * @see #getInsertionPoint(List, int)
 	 */
-	@SuppressWarnings("unchecked")
 	private static <T extends MElement<? extends Element>> T ySearch(Class<T> type, int top) {
 		return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type },
 				(proxy, method, args) -> {
@@ -338,4 +338,50 @@ public abstract class ModelCommand<T extends MElementImpl<?>> extends CommandWra
 			}
 		}).forEach(elementsBelow::add);
 	}
+
+	//
+	// Nested types
+	//
+
+	public static class Creation<T extends MElementImpl<?>, U extends Element> extends ModelCommand<T> implements CreationCommand<U> {
+		private final Class<? extends U> type;
+
+		private CreationCommand<U> resultCommand;
+
+		/**
+		 * Initializes me.
+		 *
+		 * @param target
+		 *            the logical model element on which I operate
+		 * @param type
+		 *            the type of UML element that I create
+		 */
+		public Creation(T target, Class<? extends U> type) {
+			super(target);
+
+			this.type = type;
+		}
+
+		@Override
+		public CreationCommand<U> chain(Command next) {
+			return andThen(getEditingDomain(), next);
+		}
+
+		@Override
+		public Class<? extends U> getType() {
+			return type;
+		}
+
+		@Override
+		public U getNewObject() {
+			return (resultCommand == null) ? null : resultCommand.get();
+		}
+
+		protected CreationCommand<U> setResult(CreationCommand<U> resultCommand) {
+			this.resultCommand = resultCommand;
+			return resultCommand;
+		}
+
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/ModelCommandWithDependencies.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/ModelCommandWithDependencies.java
@@ -14,6 +14,8 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
+import org.eclipse.uml2.uml.Element;
 
 /**
  * Partial implementation of a mutation operation on the logical model.
@@ -42,4 +44,50 @@ public abstract class ModelCommandWithDependencies<T extends MElementImpl<?>> ex
 	}
 
 	protected abstract Command doCreateCommand();
+
+	//
+	// Nested types
+	//
+
+	public static abstract class Creation<T extends MElementImpl<?>, U extends Element> extends ModelCommandWithDependencies<T> implements CreationCommand<U> {
+		private final Class<? extends U> type;
+
+		private CreationCommand<U> resultCommand;
+
+		/**
+		 * Initializes me.
+		 *
+		 * @param target
+		 *            the logical model element on which I operate
+		 * @param type
+		 *            the type of UML element that I create
+		 */
+		public Creation(T target, Class<? extends U> type) {
+			super(target);
+
+			this.type = type;
+		}
+
+		@Override
+		public CreationCommand<U> chain(Command next) {
+			return andThen(getEditingDomain(), next);
+		}
+
+		@Override
+		public Class<? extends U> getType() {
+			return type;
+		}
+
+		@Override
+		public U getNewObject() {
+			return (resultCommand == null) ? null : resultCommand.get();
+		}
+
+		protected CreationCommand<U> setResult(CreationCommand<U> resultCommand) {
+			this.resultCommand = resultCommand;
+			return resultCommand;
+		}
+
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionOccurrenceCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionOccurrenceCommand.java
@@ -1,0 +1,39 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.DeleteCommand;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MExecutionOccurrenceImpl;
+
+/**
+ * A command to remove an execution occurrence.
+ */
+public class RemoveExecutionOccurrenceCommand extends ModelCommand<MExecutionOccurrenceImpl> {
+
+	/**
+	 * Initializes me.
+	 *
+	 * @param target
+	 *            the execution occurrence to remove
+	 */
+	public RemoveExecutionOccurrenceCommand(MExecutionOccurrenceImpl target) {
+		super(target);
+	}
+
+	@Override
+	protected Command createCommand() {
+		// Execution occurrences don't have any notation to worry about
+		return DeleteCommand.create(getEditingDomain(), getTarget().getElement());
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
@@ -34,6 +34,7 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MOccurrenceImpl;
 import org.eclipse.papyrus.uml.interaction.model.MDestruction;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
@@ -183,8 +184,15 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 							Shape lifelineBody = getLifelineBody().get();
 							int newYPosition = yPosition.orElseGet(() -> end.getTop().getAsInt());
 
-							// Are we connecting to an execution specification?
-							Optional<Shape> executionShape = executionShapeAt(lifelineBody, newYPosition);
+							// Are we connected to an execution that will be moving with us?
+							// If so, no reattachment will be necessary
+							Optional<MExecution> exec = (end.isFinish() || end.isStart()) ? end.getExecution()
+									: Optional.empty();
+							Optional<Shape> executionShape = exec.flatMap(MExecution::getDiagramView);
+							if (!executionShape.isPresent()) {
+								// Are we connecting to an execution specification?
+								executionShape = executionShapeAt(lifelineBody, newYPosition);
+							}
 							Shape newAttachedShape = executionShape.orElse(lifelineBody);
 
 							if (end.isSend()) {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
@@ -270,8 +270,9 @@ public class DefaultDiagramHelper implements DiagramHelper {
 	}
 
 	@Override
-	public Command createMessageConnector(Supplier<Message> message, Supplier<? extends View> source,
-			IntSupplier sourceY, Supplier<? extends View> target, IntSupplier targetY,
+	public CreationCommand<Connector> createMessageConnector(Supplier<Message> message,
+			Supplier<? extends View> source, IntSupplier sourceY, Supplier<? extends View> target,
+			IntSupplier targetY,
 			BiFunction<? super OccurrenceSpecification, ? super MessageEnd, Optional<Command>> collisionHandler) {
 
 		// TODO: The Logical Model is required to have no dependencies on the diagram editor,
@@ -345,7 +346,7 @@ public class DefaultDiagramHelper implements DiagramHelper {
 		DeferredSetCommand setTarget = new DeferredSetCommand(editingDomain, createMessage,
 				NotationPackage.Literals.EDGE__TARGET, target);
 
-		Command result = createMessage.chain(setSource).chain(setTarget);
+		CreationCommand<Connector> result = createMessage.chain(setSource).chain(setTarget);
 
 		if (collisionHandler != null) {
 			CommandWrapper deferredCollisionHandler = new CommandWrapper() {
@@ -437,6 +438,18 @@ public class DefaultDiagramHelper implements DiagramHelper {
 	}
 
 	@Override
+	public Command reconnectSource(Supplier<? extends Connector> connector,
+			Supplier<? extends Shape> newSource, IntSupplier yPosition) {
+
+		return new CommandWrapper() {
+			@Override
+			protected Command createCommand() {
+				return reconnectSource(connector.get(), newSource.get(), yPosition.getAsInt());
+			}
+		};
+	}
+
+	@Override
 	public Command reconnectTarget(Connector connector, Shape newTarget, int yPosition) {
 		Command result = (connector.getTarget() == newTarget) ? IdentityCommand.INSTANCE
 				: SetCommand.create(editingDomain, connector, NotationPackage.Literals.EDGE__TARGET,
@@ -451,6 +464,18 @@ public class DefaultDiagramHelper implements DiagramHelper {
 				NotationPackage.Literals.IDENTITY_ANCHOR__ID, newID));
 
 		return result;
+	}
+
+	@Override
+	public Command reconnectTarget(Supplier<? extends Connector> connector,
+			Supplier<? extends Shape> newTarget, IntSupplier yPosition) {
+
+		return new CommandWrapper() {
+			@Override
+			protected Command createCommand() {
+				return reconnectTarget(connector.get(), newTarget.get(), yPosition.getAsInt());
+			}
+		};
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/CreationCommandImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/CreationCommandImpl.java
@@ -16,7 +16,6 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CommandWrapper;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.domain.EditingDomain;
-import org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 
 /**
@@ -89,7 +88,7 @@ public class CreationCommandImpl<T extends EObject> extends CommandWrapper imple
 	}
 
 	@Override
-	public Command chain(Command next) {
-		return CompoundModelCommand.compose(domain, this, next);
+	public CreationCommand<T> chain(Command next) {
+		return andThen(domain, next);
 	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DiagramHelper.java
@@ -221,7 +221,7 @@ public interface DiagramHelper {
 	 *            the Y position on the target shape at which to anchor the {@code connector}
 	 * @return the command to effect the target end re-connection
 	 */
-	Command reconnectTarget(Connector connector, Shape newSource, int yPosition);
+	Command reconnectTarget(Connector connector, Shape newTarget, int yPosition);
 
 	/**
 	 * Obtain a command to delete a given {@code connector}.

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/DiagramHelper.java
@@ -170,7 +170,7 @@ public interface DiagramHelper {
 	 *            {@linkplain Command#chain(Command) chain} to the result. May be {@code null}
 	 * @return the message connector creation command
 	 */
-	Command createMessageConnector(Supplier<Message> message, //
+	CreationCommand<Connector> createMessageConnector(Supplier<Message> message, //
 			Supplier<? extends View> source, IntSupplier sourceY, //
 			Supplier<? extends View> target, IntSupplier targetY, //
 			BiFunction<? super OccurrenceSpecification, ? super MessageEnd, Optional<Command>> collisionHandler);
@@ -211,6 +211,20 @@ public interface DiagramHelper {
 	Command reconnectSource(Connector connector, Shape newSource, int yPosition);
 
 	/**
+	 * Obtain a deferred command that reconnects the future source end of a {@code connector}.
+	 * 
+	 * @param connector
+	 *            the future connector to reconnect at its source end
+	 * @param newSource
+	 *            the future source-attached view for the connector
+	 * @param yPosition
+	 *            the future Y position on the source shape at which to anchor the {@code connector}
+	 * @return the command to effect the source end re-connection
+	 */
+	Command reconnectSource(Supplier<? extends Connector> connector, Supplier<? extends Shape> newSource,
+			IntSupplier yPosition);
+
+	/**
 	 * Obtain a command that reconnects the target end of a {@code connector}.
 	 * 
 	 * @param connector
@@ -222,6 +236,20 @@ public interface DiagramHelper {
 	 * @return the command to effect the target end re-connection
 	 */
 	Command reconnectTarget(Connector connector, Shape newTarget, int yPosition);
+
+	/**
+	 * Obtain a deferred command that reconnects the future target end of a {@code connector}.
+	 * 
+	 * @param connector
+	 *            the future connector to reconnect at its target end
+	 * @param newTarget
+	 *            the future target-attached view for the connector
+	 * @param yPosition
+	 *            the future Y position on the target shape at which to anchor the {@code connector}
+	 * @return the command to effect the target end re-connection
+	 */
+	Command reconnectTarget(Supplier<? extends Connector> connector, Supplier<? extends Shape> newTarget,
+			IntSupplier yPosition);
 
 	/**
 	 * Obtain a command to delete a given {@code connector}.

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
@@ -219,11 +219,20 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		//
 
 		EditPart getExecutionEditPart() {
-			@SuppressWarnings("unchecked")
 			Optional<EditPart> editPart = Optional.of(messageEP).map(ConnectionEditPart.class::cast)
-					.map(ConnectionEditPart::getTarget).flatMap(lifeline -> lifeline.getChildren().stream()
-							.filter(ExecutionSpecificationEditPart.class::isInstance).findFirst());
+					.map(ConnectionEditPart::getTarget)
+					.filter(ExecutionSpecificationEditPart.class::isInstance);
 			return assuming(editPart, "No execution edit-part created");
+		}
+
+		@Override
+		int getGrabX() {
+			return super.getGrabX() - (EXEC_WIDTH / 2);
+		}
+
+		@Override
+		int getNewRecvX() {
+			return super.getNewRecvX() - (EXEC_WIDTH / 2);
 		}
 
 	}
@@ -489,7 +498,8 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		protected void switchLifeline(VerificationMode mode) {
 			super.switchLifeline(mode);
 
-			int execRight = getNewRecvX() + (EXEC_WIDTH / 2);
+			// Note that the new receive X is the *left* side of the execution
+			int execRight = getNewRecvX() + EXEC_WIDTH;
 
 			// Verify visuals of messages spanned by the execution
 			MMessage m2 = requireMessage("m2");
@@ -523,7 +533,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			// Verify old visuals of messages spanned by the execution
 			MMessage m2 = requireMessage("m2");
 			EditPart m2EP = requireEditPart(m2);
-			mode.verify("m2 is not routed correctly", m2EP, runs(execRight, m2Y, getNewRecvX(), m2Y));
+			mode.verify("m2 is not routed correctly", m2EP, runs(execRight, m2Y, LIFELINE_3_BODY_X, m2Y));
 			MMessage m3 = requireMessage("m3");
 			EditPart m3EP = requireEditPart(m3);
 			mode.verify(m3EP, runs(execRight, m3Y, LIFELINE_4_BODY_X, m3Y));
@@ -554,6 +564,17 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			messageEP = requireEditPart(request);
 			assumeThat(messageEP, runs(sendX, mesgY, getGrabX(), mesgY));
 		}
+
+		@Override
+		int getGrabX() {
+			return super.getGrabX() - (EXEC_WIDTH / 2);
+		}
+
+		@Override
+		int getNewRecvX() {
+			return super.getNewRecvX() - (EXEC_WIDTH / 2);
+		}
+
 	}
 
 	//

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageSnappingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageSnappingUITest.java
@@ -84,6 +84,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 
 	private static final boolean EXEC_FINISH = false;
 	private static final int EXEC_HEIGHT = 60;
+	private static final int EXEC_WIDTH = 10;
 
 	private final boolean snapping;
 	private final EditorFixture.Modifiers modifiers;
@@ -129,7 +130,8 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 
 				// The receiving end snaps to the exec start and the sending end matches
 				int execTop = getTop(execEP);
-				assertThat(messageEP, withModifiers(runs(LL1_BODY_X, execTop, LL2_BODY_X, execTop, 1)));
+				assertThat(messageEP,
+						withModifiers(runs(LL1_BODY_X, execTop, left(LL2_BODY_X), execTop, 1)));
 
 				// The message receive event starts the execution
 				Message message = (Message) messageEP.getAdapter(EObject.class);
@@ -163,7 +165,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 
 		// The receiving end snaps to the exec start. The sending end doesn't match
 		int execTop = getTop(execEP);
-		assertThat(messageEP, withModifiers(runs(LL1_BODY_X, 120, LL2_BODY_X, execTop, 1)));
+		assertThat(messageEP, withModifiers(runs(LL1_BODY_X, 120, left(LL2_BODY_X), execTop, 1)));
 
 		// The message receive event starts the execution
 		Message message = (Message) messageEP.getAdapter(EObject.class);
@@ -179,7 +181,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 
 		// The sending end snaps to the exec start and the receiving end matches
 		int execBottom = getBottom(execEP);
-		assertThat(messageEP, withModifiers(runs(LL2_BODY_X, execBottom, LL1_BODY_X, execBottom, 1)));
+		assertThat(messageEP, withModifiers(runs(left(LL2_BODY_X), execBottom, LL1_BODY_X, execBottom, 1)));
 
 		// The message send event finishes the execution
 		Message message = (Message) messageEP.getAdapter(EObject.class);
@@ -200,7 +202,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 				not(isPoint(midMessage.x(), midMessage.y(), 5)));
 
 		int execTop = getTop(execEP);
-		assertThat(messageEP, withModifiers(runs(LL1_BODY_X, execTop, LL2_BODY_X, execTop, 1)));
+		assertThat(messageEP, withModifiers(runs(LL1_BODY_X, execTop, left(LL2_BODY_X), execTop, 1)));
 	}
 
 	@Test
@@ -213,7 +215,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 		editor.with(modifiers,
 				() -> editor.moveSelection(midMessage, at(midMessage.x(), withinMagnet(EXEC_FINISH))));
 		int execBottom = getBottom(execEP);
-		assertThat(messageEP, withModifiers(runs(LL2_BODY_X, execBottom, LL1_BODY_X, execBottom, 1)));
+		assertThat(messageEP, withModifiers(runs(left(LL2_BODY_X), execBottom, LL1_BODY_X, execBottom, 1)));
 	}
 
 	/**
@@ -238,7 +240,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 						at(LL2_BODY_X, withinMagnet(newBottomY, EXEC_FINISH)),
 						at(LL1_BODY_X, withinMagnet(newBottomY, EXEC_FINISH))));
 		assertThat("No snap: infer that magnet not moved", messageEP,
-				runs(LL2_BODY_X, newBottomY, LL1_BODY_X, newBottomY, 1));
+				runs(left(LL2_BODY_X), newBottomY, LL1_BODY_X, newBottomY, 1));
 	}
 
 	/**
@@ -269,7 +271,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 						at(LL1_BODY_X, withinMagnet(newTopY, EXEC_START)),
 						at(LL2_BODY_X, withinMagnet(newTopY, EXEC_START))));
 		assertThat("No snap: infer that magnet not moved", messageEP,
-				runs(LL1_BODY_X, newTopY, LL2_BODY_X, newTopY, 1));
+				runs(LL1_BODY_X, newTopY, left(LL2_BODY_X), newTopY, 1));
 	}
 
 	//
@@ -304,6 +306,13 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 
 	int withinMagnet(int y, boolean execStart) {
 		return execStart ? y - 9 : y + 9;
+	}
+
+	/**
+	 * Left side of an execution centred on {@code x}.
+	 */
+	int left(int x) {
+		return x - (EXEC_WIDTH / 2);
 	}
 
 	static Point getMessageGrabPoint(EditPart editPart) {

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageCreationUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageCreationUITest.java
@@ -46,8 +46,9 @@ import org.junit.runners.Parameterized.Parameters;
 public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest {
 
 	@ClassRule
-	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().dontCreateExecutionsForSyncMessages();
-	
+	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
+			.dontCreateExecutionsForSyncMessages();
+
 	// Horizontal position of the first lifeline's body
 	private static final int LIFELINE_1_BODY_X = 121;
 
@@ -79,6 +80,14 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 
 	@Test
 	public void createSelfMessage() {
+		if (mode == CreationMode.WITH_EXECUTION) {
+			new LightweightSeqDPrefs().createExecutionsForSyncMessages().run(this::doCreateSelfMessage);
+		} else {
+			doCreateSelfMessage();
+		}
+	}
+
+	private void doCreateSelfMessage() {
 		IElementType type = SequenceElementTypes.getMessageType(messageSort);
 
 		EditPart messageEP;
@@ -109,7 +118,10 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 			}
 			break;
 		default:
-			assertThat(messageEP, runs(x(), top(), x(), bottom(), 2));
+			if (mode != CreationMode.WITH_EXECUTION) {
+				assertThat(messageEP, runs(x(), top(), x(), bottom(), 2));
+			} // TODO: Assert the self-message shape with execution when we draw it properly
+
 			break;
 		}
 	}
@@ -124,6 +136,7 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 				{ MessageSort.SYNCH_CALL_LITERAL, CreationMode.ON_LIFELINE }, //
 				{ MessageSort.SYNCH_CALL_LITERAL, CreationMode.ON_EXECUTION }, //
 				{ MessageSort.SYNCH_CALL_LITERAL, CreationMode.ON_LIFELINE_TALL }, //
+				{ MessageSort.SYNCH_CALL_LITERAL, CreationMode.WITH_EXECUTION }, //
 				{ MessageSort.ASYNCH_CALL_LITERAL, CreationMode.ON_LIFELINE }, //
 				{ MessageSort.ASYNCH_CALL_LITERAL, CreationMode.ON_EXECUTION }, //
 				{ MessageSort.ASYNCH_CALL_LITERAL, CreationMode.ON_LIFELINE_TALL }, //
@@ -192,7 +205,9 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 		// Draw a tall self-message shape (with a gap, not just in one place)
 		ON_LIFELINE_TALL,
 		// Draw a self-message around an existing execution occurrence
-		AROUND_OCCURRENCE;
+		AROUND_OCCURRENCE,
+		// Create an execution occurrence for the sync call message
+		WITH_EXECUTION;
 
 		@Override
 		public String toString() {

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-busy.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-busy.notation
@@ -52,16 +52,16 @@
     <owner xmi:type="uml:Interaction" href="execution-busy.uml#_7-T4wMvAEei-2PpXSl-dWw"/>
   </styles>
   <element xmi:type="uml:Interaction" href="execution-busy.uml#_7-T4wMvAEei-2PpXSl-dWw"/>
-  <edges xmi:type="notation:Connector" xmi:id="_FtpE0MvBEei-2PpXSl-dWw" type="Edge_Message" source="_9UPw88vAEei-2PpXSl-dWw" target="_-EVxI8vAEei-2PpXSl-dWw">
+  <edges xmi:type="notation:Connector" xmi:id="_FtpE0MvBEei-2PpXSl-dWw" type="Edge_Message" source="_9UPw88vAEei-2PpXSl-dWw" target="_FtukYMvBEei-2PpXSl-dWw">
     <element xmi:type="uml:Message" href="execution-busy.uml#_FtkzYcvBEei-2PpXSl-dWw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FtpE0cvBEei-2PpXSl-dWw"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FtpE0svBEei-2PpXSl-dWw" id="53"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FtpE08vBEei-2PpXSl-dWw" id="53"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FtpE08vBEei-2PpXSl-dWw" id="start"/>
   </edges>
-  <edges xmi:type="notation:Connector" xmi:id="_FtsvMMvBEei-2PpXSl-dWw" type="Edge_Message" source="_-EVxI8vAEei-2PpXSl-dWw" target="_9UPw88vAEei-2PpXSl-dWw">
+  <edges xmi:type="notation:Connector" xmi:id="_FtsvMMvBEei-2PpXSl-dWw" type="Edge_Message" source="_FtukYMvBEei-2PpXSl-dWw" target="_9UPw88vAEei-2PpXSl-dWw">
     <element xmi:type="uml:Message" href="execution-busy.uml#_FtsIIsvBEei-2PpXSl-dWw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FtsvMcvBEei-2PpXSl-dWw"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FtsvMsvBEei-2PpXSl-dWw" id="168"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FtsvMsvBEei-2PpXSl-dWw" id="end"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FtsvM8vBEei-2PpXSl-dWw" id="168"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_cNxC0MvBEei-2PpXSl-dWw" type="Edge_Message" source="_FtukYMvBEei-2PpXSl-dWw" target="__vCYY8vAEei-2PpXSl-dWw">

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/LightweightSeqDPrefs.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/LightweightSeqDPrefs.java
@@ -81,7 +81,7 @@ public class LightweightSeqDPrefs extends ExternalResource {
 	}
 
 	@Override
-	protected void before() throws Throwable {
+	protected void before() {
 		befores.forEach(Runnable::run);
 	}
 
@@ -115,6 +115,23 @@ public class LightweightSeqDPrefs extends ExternalResource {
 		afters.add(0, wasDefault[0] // Reverse order in case of multiple setting of same preference
 				? () -> store.setToDefault(prefKey) //
 				: () -> setter.accept(store, prefKey, (T) oldValue[0]));
+	}
+
+	/**
+	 * Run some <em>ad hoc</em> runnable with the preferences that I specify.
+	 *
+	 * @param test
+	 *            some fragment of a test scenario to run with my preferences if
+	 *            effect
+	 */
+	public void run(Runnable test) {
+		before();
+
+		try {
+			test.run();
+		} finally {
+			after();
+		}
 	}
 
 	//

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MElementTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MElementTest.java
@@ -374,12 +374,18 @@ public abstract class MElementTest extends TestCase {
 	}
 
 	protected void execute(Command command) {
+		execute(command, true);
+	}
+
+	protected void execute(Command command, boolean reinitFixture) {
 		domain.getCommandStack().execute(command);
 		assertThat("Command not executed", domain.getCommandStack().getUndoCommand(), is(command));
 
-		// Reinitialize the logical model
-		interaction = MInteraction.getInstance(umlInteraction, sequenceDiagram);
-		initializeFixture();
+		if (reinitFixture) {
+			// Reinitialize the logical model
+			interaction = MInteraction.getInstance(umlInteraction, sequenceDiagram);
+			initializeFixture();
+		}
 	}
 
 	protected <T extends EObject> T create(CreationCommand<T> command) {

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionOccurrenceTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionOccurrenceTest.java
@@ -16,13 +16,17 @@ import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 
 import java.util.Optional;
 
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.MMessage;
+import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 
@@ -38,6 +42,8 @@ import junit.textui.TestRunner;
  * Owner</em>}</li>
  * <li>{@link org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence#getDiagramView() <em>Get Diagram
  * View</em>}</li>
+ * <li>{@link org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence#replaceBy(org.eclipse.papyrus.uml.interaction.model.MMessageEnd)
+ * <em>Replace By</em>}</li>
  * </ul>
  * </p>
  * 
@@ -210,6 +216,43 @@ public class MExecutionOccurrenceTest extends MOccurrenceTest {
 	public void testGetDiagramView() {
 		assertThat(getFixture().getDiagramView(), not(isPresent()));
 		// TODO: Case of GeneralOrdering edge anchored on an execution occurrence
+	}
+
+	/**
+	 * Tests the
+	 * '{@link org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence#replaceBy(org.eclipse.papyrus.uml.interaction.model.MMessageEnd)
+	 * <em>Replace By</em>}' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @see org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence#replaceBy(org.eclipse.papyrus.uml.interaction.model.MMessageEnd)
+	 * @generated NOT
+	 */
+	public void testReplaceBy__MMessageEnd() {
+		MMessage message = getFixture().getInteraction().getMessages().get(0);
+		MMessageEnd end = message.getReceive().get();
+		ExecutionSpecification exec = getFixture().getElement().getExecution();
+
+		Command replace = getFixture().replaceBy(end);
+		assertThat("Replace command not executable", replace, executable());
+
+		// Don't attempt to re-initialize the fixture
+		execute(replace, false);
+
+		assertThat("Execution occurrence not replaced", exec.getStart(), is(end.getElement()));
+		assertThat("Occurrence not removed", getFixture().getElement().eContainer(), nullValue());
+	}
+
+	@Override
+	public void testRemove() {
+		Command remove = getFixture().remove();
+		assertThat("Remove command not executable", remove, executable());
+
+		ExecutionSpecification exec = getFixture().getElement().getExecution();
+
+		// Don't attempt to re-initialize the fixture
+		execute(remove, false);
+
+		assertThat("Execution still has a start occurrence", exec.getStart(), nullValue());
+		assertThat("Occurrence not removed", getFixture().getElement().eContainer(), nullValue());
 	}
 
 } // MExecutionOccurrenceTest

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MLifelineTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MLifelineTest.java
@@ -499,11 +499,23 @@ public class MLifelineTest extends MElementTest {
 		// The edge connects the lifeline bodies (not the heads)
 		Edge edge = message.getDiagramView().get();
 		assertThat(edge.getSource(), notNullValue());
-		assertThat(edge.getSource().getType(), containsString("Body"));
-		assertThat(edge.getSource().getElement(), is(getFixture().getElement()));
+		if (message.getSend().get().getFinishedExecution().isPresent()) {
+			assertThat(edge.getSource().getType(), containsString("Execution"));
+			assertThat(edge.getSource().getElement(),
+					is(message.getSend().get().getFinishedExecution().get().getElement()));
+		} else {
+			assertThat(edge.getSource().getType(), containsString("Body"));
+			assertThat(edge.getSource().getElement(), is(getFixture().getElement()));
+		}
 		assertThat(edge.getTarget(), notNullValue());
-		assertThat(edge.getTarget().getType(), containsString("Body"));
-		assertThat(edge.getTarget().getElement(), is(receiver.getElement()));
+		if (message.getReceive().get().getStartedExecution().isPresent()) {
+			assertThat(edge.getTarget().getType(), containsString("Execution"));
+			assertThat(edge.getTarget().getElement(),
+					is(message.getReceive().get().getStartedExecution().get().getElement()));
+		} else {
+			assertThat(edge.getTarget().getType(), containsString("Body"));
+			assertThat(edge.getTarget().getElement(), is(receiver.getElement()));
+		}
 	}
 
 	/**


### PR DESCRIPTION
Ensure that messages attached to execution specifications by either `start` or `end` anchor are visually attached to the corner on the side from which they are either incoming or outgoing (as applicable) the execution specification.

Requires updates to several JUnit tests that previously asserted message end-points on lifeline stems.

Also updating the `InsertMessageCommand` to ensure correct corner attachment of the execution specification that it creates for synchronous messages.  In this work, it was necessary to update the `DiagramHelper` to provide a `CreationCommand<Connector>` instead of just an opaque `Command` for the creation of message views, which in turn necessitated the definition of a `CompoundCommand` that provides the `CreationCommand` protocol, as the creation of a message connector comprises several steps.