### PR TITLE
Issue #346: Horizontal padding of lifelines on creation

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
@@ -20,6 +20,8 @@ import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Mo
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.LINE;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.NO_MODIFIER;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.BOTTOM;
+import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.LEFT;
+import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.RIGHT;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.TOP;
 
 import java.util.HashMap;
@@ -276,6 +278,9 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 		result.put(forOrientation(BOTTOM, ViewTypes.EXECUTION_SPECIFICATION), 5);
 		result.put(forOrientation(TOP, ViewTypes.MESSAGE), 20);// TODO this should be 5 + font size
 		result.put(forOrientation(BOTTOM, ViewTypes.MESSAGE), 5);
+
+		result.put(forOrientation(LEFT, ViewTypes.LIFELINE_HEADER), 5);
+		result.put(forOrientation(RIGHT, ViewTypes.LIFELINE_HEADER), 5);
 
 		return result;
 	}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/InteractionCreationEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/InteractionCreationEditPolicyUITest.java
@@ -49,4 +49,43 @@ public class InteractionCreationEditPolicyUITest extends AbstractGraphicalEditPo
 		// the Y position is not determined by the input
 		assertThat(lifelineEP, isAt(isNear(99), not(90)));
 	}
+
+	@Test
+	public void createLifelineOnTopOfOther() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(99, 90), DEFAULT_SIZE);
+
+		/* act */
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(115, 90), DEFAULT_SIZE);
+
+		// the Y position is not determined by the input
+		assertThat(lifelineEP1, isAt(isNear(99), not(90)));
+		assertThat(lifelineEP2, isAt(isNear(209), not(90)));
+	}
+
+	@Test
+	public void createLifelineToTheRight() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(99, 90), DEFAULT_SIZE);
+
+		/* act */
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(215, 90), DEFAULT_SIZE);
+
+		// the Y position is not determined by the input
+		assertThat(lifelineEP1, isAt(isNear(99), not(90)));
+		assertThat(lifelineEP2, isAt(isNear(215), not(90)));
+	}
+
+	@Test
+	public void createLifelineToTheLeft() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(99, 90), DEFAULT_SIZE);
+
+		/* act */
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(89, 90), DEFAULT_SIZE);
+
+		// the Y position is not determined by the input
+		assertThat(lifelineEP2, isAt(isNear(89), not(90)));
+		assertThat(lifelineEP1, isAt(isNear(209), not(90)));
+	}
 }

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -24,6 +24,7 @@ import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateSyncMessag
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.SemanticOrderAfterCreationOfElementOnTopTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.SemanticOrderAfterInsertingBetweenMsgStartAndFinishTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.padding.CreateExecutionPaddingTest;
+import org.eclipse.papyrus.uml.interaction.model.tests.creation.padding.CreateLifelinePaddingTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.padding.CreateMessagePaddingTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.BasicDeletionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.CreationMessageDeletionTest;
@@ -51,7 +52,7 @@ import org.junit.runners.Suite.SuiteClasses;
 		SemanticOrderAfterInsertingBetweenMsgStartAndFinishTest.class, //
 		LogicalModelAdapterTest.class, //
 		LogicalModelPredicatesTest.class, //
-		CreateExecutionPaddingTest.class, CreateMessagePaddingTest.class//
+		CreateExecutionPaddingTest.class, CreateMessagePaddingTest.class, CreateLifelinePaddingTest.class//
 })
 
 public class SeqDCustomTests {

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/padding/CreateLifelinePaddingTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/padding/CreateLifelinePaddingTest.java
@@ -1,0 +1,158 @@
+package org.eclipse.papyrus.uml.interaction.model.tests.creation.padding;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.Lifeline;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ModelResource({"two-lifelines.uml", "two-lifelines.notation" })
+public class CreateLifelinePaddingTest {
+
+	@Rule
+	public final ModelEditFixture model = new ModelEditFixture();
+
+	private MInteraction interaction;
+
+	private int ll1Left;
+
+	private int ll1Right;
+
+	private int ll2Left;
+
+	private int ll2Right;
+
+	private MInteraction interaction() {
+		if (interaction == null) {
+			interaction = model.getMInteraction();
+		}
+		return interaction;
+	}
+
+	private void execute(Command command) {
+		model.execute(command);
+		/* force reinit after change */
+		interaction = null;
+	}
+
+	@Before
+	public void addTwoLifelines() {
+		execute(interaction().getLifelines().get(0).remove());
+		execute(interaction().getLifelines().get(0).remove());
+		execute(interaction().addLifeline(10, 500));
+		execute(interaction().addLifeline(120, 500));
+		ll1Left = interaction().getLifelines().get(0).getLeft().getAsInt();
+		ll1Right = interaction().getLifelines().get(0).getRight().getAsInt();
+		ll2Left = interaction().getLifelines().get(1).getLeft().getAsInt();
+		ll2Right = interaction().getLifelines().get(1).getRight().getAsInt();
+	}
+
+	@Test
+	public void insertToTheRight_paddingFineAlready() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(300, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll2Left, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right, interaction().getLifelines().get(1).getRight().getAsInt());
+		assertEquals(ll2Left + (300 - 120), interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll2Right + (300 - 120), interaction().getLifelines().get(2).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertToTheRight_paddingTooSmall() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(225, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll2Left, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right, interaction().getLifelines().get(1).getRight().getAsInt());
+		assertEquals(ll2Left + (225 - 120) + 5, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll2Right + (225 - 120) + 5, interaction().getLifelines().get(2).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertOnTop_secondLifeline() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(140, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll2Left, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right, interaction().getLifelines().get(1).getRight().getAsInt());
+		assertEquals(ll2Left + 110, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll2Right + 110, interaction().getLifelines().get(2).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertOnTop_firstLifeline() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(30, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll1Left + 110, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll1Right + 110, interaction().getLifelines().get(2).getRight().getAsInt());
+		assertEquals(ll2Left + 110, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right + 110, interaction().getLifelines().get(1).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertInBetween() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(115, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll1Left + 110, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll1Right + 110, interaction().getLifelines().get(2).getRight().getAsInt());
+		assertEquals(ll2Left + 110, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right + 110, interaction().getLifelines().get(1).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertToTheLeft() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(5, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left - 5, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll1Right - 5, interaction().getLifelines().get(2).getRight().getAsInt());
+		assertEquals(ll1Left + 110, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right + 110, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll2Left + 110, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right + 110, interaction().getLifelines().get(1).getRight().getAsInt());
+	}
+
+}


### PR DESCRIPTION
* Check if inserting on top of existing lifeline. if so, prevent overlap by moving self to the right
* In InteractionLayoutEditPolicy honour the x-position produced by the AddLifelineCommand, instead of forcing the mouse location in the editor
* Padding on move should be handled with issue #31 and issue #32 