### PR TITLE
Move Lifeline

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineHeaderEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/LifelineHeaderEditPart.java
@@ -17,6 +17,7 @@ import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.ConnectionEditPart;
+import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
@@ -31,6 +32,7 @@ import org.eclipse.papyrus.uml.diagram.sequence.figure.LifelineHeaderFigure;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.InteractionSemanticEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineHeaderGraphicalNodeEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineHeaderResizeEditPolicy;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.LifelineHeaderDragTracker;
 import org.eclipse.papyrus.uml.tools.utils.UMLUtil;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Lifeline;
@@ -140,6 +142,11 @@ public class LifelineHeaderEditPart extends AbstractBorderedShapeEditPart implem
 		} else {
 			borderItemContainer.add(borderItemEditPart.getFigure(), new BorderItemLocator(getMainFigure()));
 		}
+	}
+
+	@Override
+	public DragTracker getDragTracker(Request request) {
+		return new LifelineHeaderDragTracker(this);
 	}
 
 	public static class LifelineBodyBorderItemLocator extends BorderItemLocator {

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineHeaderResizeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineHeaderResizeEditPolicy.java
@@ -82,9 +82,19 @@ public class LifelineHeaderResizeEditPolicy extends ResizableShapeEditPolicy {
 		super.showChangeBoundsFeedback(newRequest);
 	}
 
-	@SuppressWarnings("boxing")
 	@Override
 	protected Command getMoveCommand(ChangeBoundsRequest request) {
+		if (PrivateRequestUtils.isAllowSemanticReordering(request)) {
+			// TODO when pressing ctrl it currently allows any move. This should also make place and fix the
+			// order of elements in the uml model
+			return super.getMoveCommand(request);
+		} else {
+			return getMoveLifelineCommand(request);
+		}
+	}
+
+	@SuppressWarnings("boxing")
+	private Command getMoveLifelineCommand(ChangeBoundsRequest request) {
 		List<MLifeline> leftToRight = getInteraction().getLifelines().stream()//
 				.sorted((ll1, ll2) -> {
 					int ll1Left = ll1.getDiagramView().map(layoutHelper()::getLeft).orElse(-1);

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/LifelineHeaderDragTracker.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/LifelineHeaderDragTracker.java
@@ -1,0 +1,38 @@
+/*****************************************************************************
+ * Copyright (c) 2018 EclipseSource and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Johannes Faltermeier - Initial API and implementation
+ *   
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.PrivateToolUtils.getAllowSemanticReorderingModifier;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.gmf.runtime.diagram.ui.tools.DragEditPartsTrackerEx;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils;
+
+public class LifelineHeaderDragTracker extends DragEditPartsTrackerEx {
+
+	public LifelineHeaderDragTracker(EditPart sourceEditPart) {
+		super(sourceEditPart);
+	}
+
+	@Override
+	protected boolean isCloneActive() {
+		return false;
+	}
+
+	@Override
+	protected void updateTargetRequest() {
+		super.updateTargetRequest();
+		PrivateRequestUtils.setAllowSemanticReordering(getTargetRequest(),
+				getCurrentInput().isModKeyDown(getAllowSemanticReorderingModifier()));
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutConstraints.java
@@ -20,6 +20,8 @@ import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Mo
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.LINE;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Modifiers.NO_MODIFIER;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.BOTTOM;
+import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.LEFT;
+import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.RIGHT;
 import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativePosition.TOP;
 
 import java.util.HashMap;
@@ -276,6 +278,9 @@ public class DefaultLayoutConstraints implements LayoutConstraints {
 		result.put(forOrientation(BOTTOM, ViewTypes.EXECUTION_SPECIFICATION), 5);
 		result.put(forOrientation(TOP, ViewTypes.MESSAGE), 20);// TODO this should be 5 + font size
 		result.put(forOrientation(BOTTOM, ViewTypes.MESSAGE), 5);
+
+		result.put(forOrientation(LEFT, ViewTypes.LIFELINE_HEADER), 5);
+		result.put(forOrientation(RIGHT, ViewTypes.LIFELINE_HEADER), 5);
 
 		return result;
 	}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/InteractionCreationEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/InteractionCreationEditPolicyUITest.java
@@ -49,4 +49,43 @@ public class InteractionCreationEditPolicyUITest extends AbstractGraphicalEditPo
 		// the Y position is not determined by the input
 		assertThat(lifelineEP, isAt(isNear(99), not(90)));
 	}
+
+	@Test
+	public void createLifelineOnTopOfOther() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(99, 90), DEFAULT_SIZE);
+
+		/* act */
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(115, 90), DEFAULT_SIZE);
+
+		// the Y position is not determined by the input
+		assertThat(lifelineEP1, isAt(isNear(99), not(90)));
+		assertThat(lifelineEP2, isAt(isNear(209), not(90)));
+	}
+
+	@Test
+	public void createLifelineToTheRight() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(99, 90), DEFAULT_SIZE);
+
+		/* act */
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(215, 90), DEFAULT_SIZE);
+
+		// the Y position is not determined by the input
+		assertThat(lifelineEP1, isAt(isNear(99), not(90)));
+		assertThat(lifelineEP2, isAt(isNear(215), not(90)));
+	}
+
+	@Test
+	public void createLifelineToTheLeft() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(99, 90), DEFAULT_SIZE);
+
+		/* act */
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(89, 90), DEFAULT_SIZE);
+
+		// the Y position is not determined by the input
+		assertThat(lifelineEP2, isAt(isNear(89), not(90)));
+		assertThat(lifelineEP1, isAt(isNear(209), not(90)));
+	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineMoveUITest.java
@@ -7,15 +7,24 @@ import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.Arrays;
+
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.swt.SWT;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 @SuppressWarnings("restriction")
 @ModelResource("empty.di")
 @Maximized
+@RunWith(Parameterized.class)
 public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 
 	private static final int LIFELINE_1_X = 50;
@@ -23,6 +32,25 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 	private static final int LIFELINE_3_X = 350;
 
 	private static final int LIFELINE_HEADER_Y = 80;
+
+	private EditorFixture.Modifiers modifiers;
+	private boolean ctrlPressed;
+
+	public LifelineMoveUITest(boolean ctrlPressed, String label) {
+		super();
+		this.ctrlPressed = ctrlPressed;
+		this.modifiers = ctrlPressed
+				? editor.modifierKey(Platform.OS_MACOSX.equals(Platform.getOS()) ? SWT.COMMAND : SWT.CTRL)
+				: editor.unmodified();
+	}
+
+	@Parameters(name = "{1}")
+	public static Iterable<Object[]> parameters() {
+		return Arrays.asList(new Object[][] { //
+				{ true, "ctrl pressed" }, //
+				{ false, "no modifier pressed" }, //
+		});
+	}
 
 	@Test
 	public void moveLeftAllowed() {
@@ -35,7 +63,8 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 				DEFAULT_SIZE);
 
 		/* act */
-		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X + 10, LIFELINE_HEADER_Y));
+		editor.with(modifiers, () -> editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y),
+				at(LIFELINE_2_X + 10, LIFELINE_HEADER_Y)));
 
 		/* assert */
 		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
@@ -54,7 +83,8 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 				DEFAULT_SIZE);
 
 		/* act */
-		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X + 90, LIFELINE_HEADER_Y));
+		editor.with(modifiers, () -> editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y),
+				at(LIFELINE_2_X + 90, LIFELINE_HEADER_Y)));
 
 		/* assert */
 		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
@@ -73,11 +103,16 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 				DEFAULT_SIZE);
 
 		/* act */
-		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X, LIFELINE_HEADER_Y));
+		editor.with(modifiers, () -> editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y),
+				at(LIFELINE_2_X, LIFELINE_HEADER_Y)));
 
 		/* assert */
 		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
-		assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		if (ctrlPressed) {
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X - 50), not(LIFELINE_HEADER_Y)));
+		} else {
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		}
 		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
 	}
 
@@ -92,11 +127,16 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 				DEFAULT_SIZE);
 
 		/* act */
-		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X + 100, LIFELINE_HEADER_Y));
+		editor.with(modifiers, () -> editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y),
+				at(LIFELINE_2_X + 100, LIFELINE_HEADER_Y)));
 
 		/* assert */
 		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
-		assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		if (ctrlPressed) {
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X + 50), not(LIFELINE_HEADER_Y)));
+		} else {
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		}
 		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
 	}
 
@@ -111,11 +151,16 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 				DEFAULT_SIZE);
 
 		/* act */
-		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X + 350, LIFELINE_HEADER_Y));
+		editor.with(modifiers, () -> editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y),
+				at(LIFELINE_2_X + 350, LIFELINE_HEADER_Y)));
 
 		/* assert */
 		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
-		assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		if (ctrlPressed) {
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X + 300), not(LIFELINE_HEADER_Y)));
+		} else {
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		}
 		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
 	}
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineMoveUITest.java
@@ -111,7 +111,7 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 		if (ctrlPressed) {
 			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X - 50), not(LIFELINE_HEADER_Y)));
 		} else {
-			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X - 40), not(LIFELINE_HEADER_Y)));
 		}
 		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
 	}
@@ -135,7 +135,7 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 		if (ctrlPressed) {
 			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X + 50), not(LIFELINE_HEADER_Y)));
 		} else {
-			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X + 40), not(LIFELINE_HEADER_Y)));
 		}
 		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
 	}
@@ -159,7 +159,7 @@ public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
 		if (ctrlPressed) {
 			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X + 300), not(LIFELINE_HEADER_Y)));
 		} else {
-			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+			assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X + 40), not(LIFELINE_HEADER_Y)));
 		}
 		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
 	}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineMoveUITest.java
@@ -1,0 +1,122 @@
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isAt;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.DEFAULT_SIZE;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.at;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.isNear;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+@ModelResource("empty.di")
+@Maximized
+public class LifelineMoveUITest extends AbstractGraphicalEditPolicyUITest {
+
+	private static final int LIFELINE_1_X = 50;
+	private static final int LIFELINE_2_X = 200;
+	private static final int LIFELINE_3_X = 350;
+
+	private static final int LIFELINE_HEADER_Y = 80;
+
+	@Test
+	public void moveLeftAllowed() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_1_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_2_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP3 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_3_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+
+		/* act */
+		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X + 10, LIFELINE_HEADER_Y));
+
+		/* assert */
+		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X - 40), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
+	}
+
+	@Test
+	public void moveRightAllowed() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_1_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_2_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP3 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_3_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+
+		/* act */
+		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X + 90, LIFELINE_HEADER_Y));
+
+		/* assert */
+		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X + 40), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
+	}
+
+	@Test
+	public void moveLeftPaddingTooSmall() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_1_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_2_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP3 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_3_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+
+		/* act */
+		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X, LIFELINE_HEADER_Y));
+
+		/* assert */
+		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
+	}
+
+	@Test
+	public void moveRightPaddingTooSmall() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_1_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_2_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP3 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_3_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+
+		/* act */
+		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X + 100, LIFELINE_HEADER_Y));
+
+		/* assert */
+		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
+	}
+
+	@Test
+	public void moveRightAttemptedReorder() {
+		/* setup */
+		EditPart lifelineEP1 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_1_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP2 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_2_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+		EditPart lifelineEP3 = createShape(SequenceElementTypes.Lifeline_Shape, at(LIFELINE_3_X, LIFELINE_HEADER_Y),
+				DEFAULT_SIZE);
+
+		/* act */
+		editor.moveSelection(at(LIFELINE_2_X + 50, LIFELINE_HEADER_Y), at(LIFELINE_2_X + 350, LIFELINE_HEADER_Y));
+
+		/* assert */
+		assertThat(lifelineEP1, isAt(isNear(LIFELINE_1_X), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP2, isAt(isNear(LIFELINE_2_X), not(LIFELINE_HEADER_Y)));
+		assertThat(lifelineEP3, isAt(isNear(LIFELINE_3_X), not(LIFELINE_HEADER_Y)));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -24,6 +24,7 @@ import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateSyncMessag
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.SemanticOrderAfterCreationOfElementOnTopTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.SemanticOrderAfterInsertingBetweenMsgStartAndFinishTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.padding.CreateExecutionPaddingTest;
+import org.eclipse.papyrus.uml.interaction.model.tests.creation.padding.CreateLifelinePaddingTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.padding.CreateMessagePaddingTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.BasicDeletionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.CreationMessageDeletionTest;
@@ -51,7 +52,7 @@ import org.junit.runners.Suite.SuiteClasses;
 		SemanticOrderAfterInsertingBetweenMsgStartAndFinishTest.class, //
 		LogicalModelAdapterTest.class, //
 		LogicalModelPredicatesTest.class, //
-		CreateExecutionPaddingTest.class, CreateMessagePaddingTest.class//
+		CreateExecutionPaddingTest.class, CreateMessagePaddingTest.class, CreateLifelinePaddingTest.class//
 })
 
 public class SeqDCustomTests {

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/padding/CreateLifelinePaddingTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/padding/CreateLifelinePaddingTest.java
@@ -1,0 +1,158 @@
+package org.eclipse.papyrus.uml.interaction.model.tests.creation.padding;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.Lifeline;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ModelResource({"two-lifelines.uml", "two-lifelines.notation" })
+public class CreateLifelinePaddingTest {
+
+	@Rule
+	public final ModelEditFixture model = new ModelEditFixture();
+
+	private MInteraction interaction;
+
+	private int ll1Left;
+
+	private int ll1Right;
+
+	private int ll2Left;
+
+	private int ll2Right;
+
+	private MInteraction interaction() {
+		if (interaction == null) {
+			interaction = model.getMInteraction();
+		}
+		return interaction;
+	}
+
+	private void execute(Command command) {
+		model.execute(command);
+		/* force reinit after change */
+		interaction = null;
+	}
+
+	@Before
+	public void addTwoLifelines() {
+		execute(interaction().getLifelines().get(0).remove());
+		execute(interaction().getLifelines().get(0).remove());
+		execute(interaction().addLifeline(10, 500));
+		execute(interaction().addLifeline(120, 500));
+		ll1Left = interaction().getLifelines().get(0).getLeft().getAsInt();
+		ll1Right = interaction().getLifelines().get(0).getRight().getAsInt();
+		ll2Left = interaction().getLifelines().get(1).getLeft().getAsInt();
+		ll2Right = interaction().getLifelines().get(1).getRight().getAsInt();
+	}
+
+	@Test
+	public void insertToTheRight_paddingFineAlready() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(300, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll2Left, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right, interaction().getLifelines().get(1).getRight().getAsInt());
+		assertEquals(ll2Left + (300 - 120), interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll2Right + (300 - 120), interaction().getLifelines().get(2).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertToTheRight_paddingTooSmall() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(225, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll2Left, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right, interaction().getLifelines().get(1).getRight().getAsInt());
+		assertEquals(ll2Left + (225 - 120) + 5, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll2Right + (225 - 120) + 5, interaction().getLifelines().get(2).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertOnTop_secondLifeline() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(140, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll2Left, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right, interaction().getLifelines().get(1).getRight().getAsInt());
+		assertEquals(ll2Left + 110, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll2Right + 110, interaction().getLifelines().get(2).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertOnTop_firstLifeline() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(30, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll1Left + 110, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll1Right + 110, interaction().getLifelines().get(2).getRight().getAsInt());
+		assertEquals(ll2Left + 110, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right + 110, interaction().getLifelines().get(1).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertInBetween() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(115, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll1Left + 110, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll1Right + 110, interaction().getLifelines().get(2).getRight().getAsInt());
+		assertEquals(ll2Left + 110, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right + 110, interaction().getLifelines().get(1).getRight().getAsInt());
+	}
+
+	@Test
+	public void insertToTheLeft() {
+		/* setup */
+		CreationCommand<Lifeline> command = interaction().addLifeline(5, 500);
+
+		/* act */
+		execute(command);
+
+		/* assert */
+		assertEquals(ll1Left - 5, interaction().getLifelines().get(2).getLeft().getAsInt());
+		assertEquals(ll1Right - 5, interaction().getLifelines().get(2).getRight().getAsInt());
+		assertEquals(ll1Left + 110, interaction().getLifelines().get(0).getLeft().getAsInt());
+		assertEquals(ll1Right + 110, interaction().getLifelines().get(0).getRight().getAsInt());
+		assertEquals(ll2Left + 110, interaction().getLifelines().get(1).getLeft().getAsInt());
+		assertEquals(ll2Right + 110, interaction().getLifelines().get(1).getRight().getAsInt());
+	}
+
+}


### PR DESCRIPTION
**This PR depends on https://github.com/eclipsesource/papyrus-seqd/pull/392** 

When no modifier key is pressed:
* only allow move of lifeline between its left and right neighbour while honouring padding constraints
* when moving further than our neighbours, move as far as possible

When modifier key is pressed:
* allow any move as before
* should include reorder logic (see issue #32)