### PR TITLE
Fix #70 Change lifeline covered by an execution specification

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.papyrus.uml.service.types;bundle-version="[3.1.0,4.0.0)",
  org.eclipse.papyrus.infra.gmfdiag.preferences;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.papyrus.uml.diagram.css;bundle-version="[2.0.0,3.0.0)",
- org.eclipse.e4.ui.css.core;bundle-version="[0.12.101,1.0.0)"
+ org.eclipse.e4.ui.css.core;bundle-version="[0.12.101,1.0.0)",
+ org.eclipse.papyrus.infra.gmfdiag.dnd;bundle-version="[1.3.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/ExecutionSpecificationEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/ExecutionSpecificationEditPart.java
@@ -150,11 +150,12 @@ public class ExecutionSpecificationEditPart extends BorderedBorderItemEditPart i
 	// The superclass does not delegate to edit-policies to get the drag tracker
 	@Override
 	public DragTracker getDragTracker(Request request) {
+		// We support dragging and dropping onto another lifeline
 		return new SequenceDragTracker(this) {
 
 			@Override
 			protected boolean isMove() {
-				return true;
+				return super.isMove();
 			}
 		};
 	}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/ExecutionSpecificationEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/ExecutionSpecificationEditPart.java
@@ -22,8 +22,10 @@ import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.Request;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.BorderedBorderItemEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IBorderItemEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editpolicies.EditPolicyRoles;
@@ -37,6 +39,7 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.E
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.ExecutionSpecificationGraphicalNodeEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.InteractionSemanticEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.locators.ExecutionSpecificationBorderItemLocator;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.SequenceDragTracker;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 
@@ -144,4 +147,15 @@ public class ExecutionSpecificationEditPart extends BorderedBorderItemEditPart i
 		}
 	}
 
+	// The superclass does not delegate to edit-policies to get the drag tracker
+	@Override
+	public DragTracker getDragTracker(Request request) {
+		return new SequenceDragTracker(this) {
+
+			@Override
+			protected boolean isMove() {
+				return true;
+			}
+		};
+	}
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDragEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDragEditPolicy.java
@@ -246,10 +246,12 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 
 	@Override
 	protected void showChangeBoundsFeedback(ChangeBoundsRequest request) {
+		Point moveDelta = request.getMoveDelta();
 		Dimension sizeDelta = request.getSizeDelta();
+
 		if ((sizeDelta != null) && ((sizeDelta.width != 0) || (sizeDelta.height != 0))) {
 			// If there's a resize involved, then don't support dropping on another lifeline
-			showMoveFeedback(request.getMoveDelta());
+			showChangeBoundsFeedback(request.getMoveDelta(), sizeDelta);
 			return;
 		}
 
@@ -261,7 +263,7 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 			}
 		}
 		if (thisLifeline == null) {
-			showMoveFeedback(request.getMoveDelta());
+			showChangeBoundsFeedback(moveDelta, sizeDelta);
 			return;
 		}
 
@@ -270,7 +272,7 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 				Collections.singleton(thisLifeline.getFigure()), LifelineBodyEditPart.class::isInstance);
 		if (!(dropLifeline instanceof LifelineBodyEditPart)) {
 			// Not dropping on some other lifeline
-			showMoveFeedback(request.getMoveDelta());
+			showChangeBoundsFeedback(moveDelta, sizeDelta);
 			return;
 		}
 
@@ -279,29 +281,35 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 		IBorderItemLocator borderItemLocator = new OnLineBorderItemLocator(dropLifelineFigure);
 
 		// Constrain the lifeline drop to the original Y location
-		Point moveDelta = request.getMoveDelta().getCopy();
+		moveDelta = moveDelta.getCopy();
 		moveDelta.setY(0);
 
-		showMoveFeedback(moveDelta, dropLifelineFigure, borderItemLocator);
+		showChangeBoundsFeedback(moveDelta, null, dropLifelineFigure, borderItemLocator);
 	}
 
-	protected void showMoveFeedback(Point moveDelta) {
+	protected void showChangeBoundsFeedback(Point moveDelta, Dimension sizeDelta) {
 		IBorderItemEditPart borderItemEP = (IBorderItemEditPart)getHost();
 		IBorderItemLocator borderItemLocator = borderItemEP.getBorderItemLocator();
 
 		if (borderItemLocator != null) {
-			showMoveFeedback(moveDelta, ((GraphicalEditPart)getHost().getParent()).getFigure(),
-					borderItemLocator);
+			showChangeBoundsFeedback(moveDelta, sizeDelta,
+					((GraphicalEditPart)getHost().getParent()).getFigure(), borderItemLocator);
 		}
 	}
 
-	protected void showMoveFeedback(Point moveDelta, IFigure onLifeline, IBorderItemLocator locator) {
+	protected void showChangeBoundsFeedback(Point moveDelta, Dimension sizeDelta, IFigure onLifeline,
+			IBorderItemLocator locator) {
+
 		if (locator != null) {
 			IBorderItemEditPart borderItemEP = (IBorderItemEditPart)getHost();
 			IFigure feedback = getDragSourceFeedbackFigure();
 			PrecisionRectangle rect = new PrecisionRectangle(getInitialFeedbackBounds().getCopy());
 			getHostFigure().getParent().translateToAbsolute(rect);
+
 			rect.translate(moveDelta);
+			if (sizeDelta != null) {
+				rect.resize(sizeDelta);
+			}
 
 			// And bring it into the lifeline's coördinate space
 			Rectangle lifelineBounds = onLifeline.getBounds().getCopy();

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineBodyDropEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineBodyDropEditPolicy.java
@@ -1,0 +1,81 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
+
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.commands.UnexecutableCommand;
+import org.eclipse.gmf.runtime.diagram.ui.editpolicies.DragDropEditPolicy;
+import org.eclipse.gmf.runtime.diagram.ui.requests.DropObjectsRequest;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.util.Optionals;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Lifeline;
+
+/**
+ * Edit policy for dropping elements onto the lifeline body.
+ */
+public class LifelineBodyDropEditPolicy extends DragDropEditPolicy implements ISequenceEditPolicy {
+
+	/**
+	 * Initializes me.
+	 */
+	public LifelineBodyDropEditPolicy() {
+		super();
+	}
+
+	@Override
+	protected Command getDropElementCommand(EObject element, DropObjectsRequest request) {
+		Command result = null;
+
+		if (element instanceof ExecutionSpecification) {
+			Optional<MExecution> exec = Optionals
+					.as(getInteraction().getElement((ExecutionSpecification)element), MExecution.class);
+			return exec.map(e -> getDropExecutionCommand(e, request)).orElse(null);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Obtain a command that drops an {@code execution} specification onto the host lifeline.
+	 * 
+	 * @param execution
+	 *            an execution specification to drop
+	 * @param request
+	 *            the drop request
+	 * @return the command, or {@code null} if none
+	 */
+	protected Command getDropExecutionCommand(MExecution execution, DropObjectsRequest request) {
+		Optional<MLifeline> lifeline = getHostLifeline();
+
+		if (!PrivateRequestUtils.isAllowSemanticReordering(request)) {
+			// Block the operation if the semantic override modifier is not applied
+			return UnexecutableCommand.INSTANCE;
+		}
+
+		return lifeline.map(ll -> wrap(execution.setOwner(ll, OptionalInt.empty(), OptionalInt.empty())))
+				.orElse(null);
+	}
+
+	protected Optional<MLifeline> getHostLifeline() {
+		Optional<Lifeline> lifeline = as(Optional.ofNullable(getHostObject()), Lifeline.class);
+		return lifeline.flatMap(getInteraction()::getLifeline);
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ResizableBorderItemPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ResizableBorderItemPolicy.java
@@ -69,11 +69,11 @@ public class ResizableBorderItemPolicy extends BorderItemResizableEditPolicy {
 
 		Rectangle newBounds = bounds.translate(scaledMovedDelta).resize(scaledSizeDelta);
 
-		return getSetBoundsCommand(request, (Node)shapeView, newBounds);
+		return getResizeCommand(request, (Node)shapeView, newBounds);
 	}
 
 	/**
-	 * Get a command to change the bounds of the given execution specification shape.
+	 * Get a command to change the bounds of the given execution specification shape on <em>resize</em>.
 	 * 
 	 * @param request
 	 *            the change-bounds request
@@ -83,7 +83,54 @@ public class ResizableBorderItemPolicy extends BorderItemResizableEditPolicy {
 	 *            the new bounds requested for the execution specification
 	 * @return the command
 	 */
-	protected Command getSetBoundsCommand(ChangeBoundsRequest request, Node execShape, Rectangle newBounds) {
+	protected Command getResizeCommand(ChangeBoundsRequest request, Node execShape, Rectangle newBounds) {
+		TransactionalEditingDomain editingDomain = ((IGraphicalEditPart)getHost()).getEditingDomain();
+		ICommand result = new SetBoundsCommand(editingDomain,
+				DiagramUIMessages.SetLocationCommand_Label_Resize, new EObjectAdapter(execShape), newBounds);
+		return new ICommandProxy(result);
+	}
+
+	@Override
+	protected Command getMoveCommand(ChangeBoundsRequest request) {
+		IFigure figure = getHostFigure();
+		if (figure == null) {
+			return super.getMoveCommand(request);
+		}
+
+		View shapeView = NotationHelper.findView(getHost());
+		Integer x = (Integer)ViewUtil.getStructuralFeatureValue(shapeView,
+				NotationPackage.eINSTANCE.getLocation_X());
+		Integer y = (Integer)ViewUtil.getStructuralFeatureValue(shapeView,
+				NotationPackage.eINSTANCE.getLocation_Y());
+		Integer width = (Integer)ViewUtil.getStructuralFeatureValue(shapeView,
+				NotationPackage.eINSTANCE.getSize_Width());
+		Integer height = (Integer)ViewUtil.getStructuralFeatureValue(shapeView,
+				NotationPackage.eINSTANCE.getSize_Height());
+
+		Rectangle bounds = new Rectangle(x.intValue(), y.intValue(), width.intValue(), height.intValue());
+
+		// apply transformation with scaling to get new bounds (missing from getTrasnformedRectangle)
+		double scale = FigureUtils.getScale(getHostFigure());
+		Point scaledMovedDelta = request.getMoveDelta().getCopy();
+		scaledMovedDelta.performScale(1 / scale);
+
+		Rectangle newBounds = bounds.translate(scaledMovedDelta);
+
+		return getMoveCommand(request, (Node)shapeView, newBounds);
+	}
+
+	/**
+	 * Get a command to change the bounds of the given execution specification shape on <em>move</em>.
+	 * 
+	 * @param request
+	 *            the change-bounds request
+	 * @param execShape
+	 *            the execution specification shape to change
+	 * @param newBounds
+	 *            the new bounds requested for the execution specification
+	 * @return the command
+	 */
+	protected Command getMoveCommand(ChangeBoundsRequest request, Node execShape, Rectangle newBounds) {
 		TransactionalEditingDomain editingDomain = ((IGraphicalEditPart)getHost()).getEditingDomain();
 		ICommand result = new SetBoundsCommand(editingDomain,
 				DiagramUIMessages.SetLocationCommand_Label_Resize, new EObjectAdapter(execShape), newBounds);

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/locators/OnLineBorderItemLocator.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/locators/OnLineBorderItemLocator.java
@@ -50,8 +50,8 @@ public class OnLineBorderItemLocator implements IBorderItemLocator {
 	@Override
 	public Rectangle getValidLocation(Rectangle proposedLocation, IFigure borderItem) {
 		Rectangle body = headerBodyFigure.getBounds().getCopy();
-		Point location = new Point(body.x - getConstraint().width / 2, body.y + getConstraint().y);
-		Rectangle newBounds = getConstraint().getCopy();
+		Point location = new Point(body.x - proposedLocation.width / 2, body.y + proposedLocation.y);
+		Rectangle newBounds = proposedLocation.getCopy();
 		newBounds.setLocation(location);
 		return newBounds;
 	}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/SequenceDragTracker.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/SequenceDragTracker.java
@@ -15,8 +15,7 @@ package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.PrivateToolUtils.getAllowSemanticReorderingModifier;
 
 import org.eclipse.gef.EditPart;
-import org.eclipse.gef.requests.ChangeBoundsRequest;
-import org.eclipse.gmf.runtime.diagram.ui.requests.RequestConstants;
+import org.eclipse.gef.commands.Command;
 import org.eclipse.papyrus.infra.gmfdiag.common.snap.PapyrusDragEditPartsTrackerEx;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.LifelineBodyEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils;
@@ -40,25 +39,19 @@ public class SequenceDragTracker extends PapyrusDragEditPartsTrackerEx {
 	protected void updateTargetRequest() {
 		super.updateTargetRequest();
 
-		ChangeBoundsRequest request = (ChangeBoundsRequest)getTargetRequest();
-		if (!"".isEmpty() && !isTargetLocked()) {
-			EditPart editPart = null;
-			if (getCurrentViewer() != null) {
-				editPart = getCurrentViewer().findObjectAtExcluding(getLocation(), getExclusionSet());
-			}
-			if (editPart instanceof LifelineBodyEditPart) {
-				EditPart sourceLifeline = getLifelineBodyEditPart(getSourceEditPart());
-				if (sourceLifeline != null && sourceLifeline != editPart) {
-					// It's a drop
-					request.setType(RequestConstants.REQ_DROP);
-				}
-			}
-		}
-
 		// All requests of interest for re-ordering have location
 
 		PrivateRequestUtils.setAllowSemanticReordering(getTargetRequest(),
 				getCurrentInput().isModKeyDown(getAllowSemanticReorderingModifier()));
+	}
+
+	@Override
+	protected Command getCommand() {
+		if (getTargetEditPart() == null) {
+			return null;
+		}
+
+		return super.getCommand();
 	}
 
 	protected EditPart getLifelineBodyEditPart(EditPart editPart) {
@@ -72,4 +65,14 @@ public class SequenceDragTracker extends PapyrusDragEditPartsTrackerEx {
 
 		return result;
 	}
+
+	/**
+	 * We don't do clone in this diagram (and {@code Ctrl} is used for semantic re-ordering override on Linux
+	 * platform).
+	 */
+	@Override
+	protected void setCloneActive(boolean cloneActive) {
+		super.setCloneActive(false);
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/SequenceDragTracker.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/SequenceDragTracker.java
@@ -1,0 +1,46 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.PrivateToolUtils.getAllowSemanticReorderingModifier;
+
+import org.eclipse.gef.EditPart;
+import org.eclipse.gmf.runtime.diagram.ui.tools.DragEditPartsTrackerEx;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils;
+
+/**
+ * A drag tracker for the sequence diagram that injects custom keyboard modifier information into the requests
+ * that it produces.
+ */
+public class SequenceDragTracker extends DragEditPartsTrackerEx {
+
+	/**
+	 * Initializes me.
+	 *
+	 * @param sourceEditPart
+	 */
+	public SequenceDragTracker(EditPart sourceEditPart) {
+		super(sourceEditPart);
+	}
+
+	@Override
+	protected void updateTargetRequest() {
+		super.updateTargetRequest();
+
+		// All requests of interest for re-ordering have location
+
+		PrivateRequestUtils.setAllowSemanticReordering(getTargetRequest(),
+				getCurrentInput().isModKeyDown(getAllowSemanticReorderingModifier()));
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/SequenceDragTracker.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/tools/SequenceDragTracker.java
@@ -15,14 +15,17 @@ package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.PrivateToolUtils.getAllowSemanticReorderingModifier;
 
 import org.eclipse.gef.EditPart;
-import org.eclipse.gmf.runtime.diagram.ui.tools.DragEditPartsTrackerEx;
+import org.eclipse.gef.requests.ChangeBoundsRequest;
+import org.eclipse.gmf.runtime.diagram.ui.requests.RequestConstants;
+import org.eclipse.papyrus.infra.gmfdiag.common.snap.PapyrusDragEditPartsTrackerEx;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.LifelineBodyEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils;
 
 /**
  * A drag tracker for the sequence diagram that injects custom keyboard modifier information into the requests
  * that it produces.
  */
-public class SequenceDragTracker extends DragEditPartsTrackerEx {
+public class SequenceDragTracker extends PapyrusDragEditPartsTrackerEx {
 
 	/**
 	 * Initializes me.
@@ -37,10 +40,36 @@ public class SequenceDragTracker extends DragEditPartsTrackerEx {
 	protected void updateTargetRequest() {
 		super.updateTargetRequest();
 
+		ChangeBoundsRequest request = (ChangeBoundsRequest)getTargetRequest();
+		if (!"".isEmpty() && !isTargetLocked()) {
+			EditPart editPart = null;
+			if (getCurrentViewer() != null) {
+				editPart = getCurrentViewer().findObjectAtExcluding(getLocation(), getExclusionSet());
+			}
+			if (editPart instanceof LifelineBodyEditPart) {
+				EditPart sourceLifeline = getLifelineBodyEditPart(getSourceEditPart());
+				if (sourceLifeline != null && sourceLifeline != editPart) {
+					// It's a drop
+					request.setType(RequestConstants.REQ_DROP);
+				}
+			}
+		}
+
 		// All requests of interest for re-ordering have location
 
 		PrivateRequestUtils.setAllowSemanticReordering(getTargetRequest(),
 				getCurrentInput().isModKeyDown(getAllowSemanticReorderingModifier()));
 	}
 
+	protected EditPart getLifelineBodyEditPart(EditPart editPart) {
+		EditPart result = null;
+
+		for (EditPart next = editPart; (result == null) && (next != null); next = next.getParent()) {
+			if (next instanceof LifelineBodyEditPart) {
+				result = next;
+			}
+		}
+
+		return result;
+	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/PendingVerticalExtentData.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/PendingVerticalExtentData.java
@@ -75,6 +75,18 @@ public final class PendingVerticalExtentData {
 	}
 
 	/**
+	 * Queries whether an {@code element} is being moved.
+	 * 
+	 * @param element
+	 *            an element
+	 * @return {@code true} if it is being moved; {@code false}, otherwise, for example if it is being
+	 *         reshaped (only top or bottom being moved but not both) or not being changed at all
+	 */
+	public boolean isMoving() {
+		return top.isPresent() && bottom.isPresent();
+	}
+
+	/**
 	 * Query the pending top of an {@code element}.
 	 * 
 	 * @param element
@@ -117,6 +129,20 @@ public final class PendingVerticalExtentData {
 			data.top = pendingTop;
 			data.bottom = pendingBottom;
 		}
+	}
+
+	/**
+	 * Queries whether an {@code element} is {@linkplain #isMoving() being moved}.
+	 * 
+	 * @param element
+	 *            an element
+	 * @return {@code true} if it is being moved; {@code false}, otherwise, for example if it is being
+	 *         reshaped (only top or bottom being moved but not both) or not being changed at all
+	 * @see #isMoving()
+	 */
+	public static boolean isMoving(MElement<? extends Element> element) {
+		return DependencyContext.get().get(element, PendingVerticalExtentData.class)
+				.map(PendingVerticalExtentData::isMoving).orElse(Boolean.FALSE).booleanValue();
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
 import java.util.function.IntUnaryOperator;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
@@ -237,4 +238,16 @@ public class Optionals {
 		return a.orElse(Integer.MAX_VALUE) < b.orElse(Integer.MIN_VALUE);
 	}
 
+	/**
+	 * Filter an optional integer {@code value}.
+	 * 
+	 * @param value
+	 *            an optional integer value
+	 * @param predicate
+	 *            an integer predicate
+	 * @return the {@code value} if it satisfies the {@code predicate}, otherwise empty
+	 */
+	public static OptionalInt filter(OptionalInt value, IntPredicate predicate) {
+		return (value.isPresent() && predicate.test(value.getAsInt())) ? value : OptionalInt.empty();
+	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
@@ -222,4 +222,19 @@ public class Optionals {
 	public static <T> Stream<T> stream(Optional<? extends T>... optionals) {
 		return Stream.of(optionals).filter(Optional::isPresent).map(Optional::get);
 	}
+
+	/**
+	 * Is an optional integer less than another?
+	 * 
+	 * @param a
+	 *            an optional integer
+	 * @param b
+	 *            another optional integer
+	 * @return {@code true} if both values are present and {@code a} is less than {@code b}; {@code false}
+	 *         under any other circumstance
+	 */
+	public static boolean lessThan(OptionalInt a, OptionalInt b) {
+		return a.orElse(Integer.MAX_VALUE) < b.orElse(Integer.MIN_VALUE);
+	}
+
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -29,57 +29,28 @@ import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.Lifeline;
 import org.eclipse.uml2.uml.Message;
-import org.eclipse.uml2.uml.NamedElement;
-import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
 
 /**
  * Test cases for the {@code ExecutionSpecificationDragEditPolicy} class.
- *
- * @author Christian W. Damus
  */
-@ModelResource("kitchen-sink.di")
-@Maximized
-public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
+@RunWith(Enclosed.class)
+public class ExecutionSpecificationDragEditPolicyUITest {
 
-	@SuppressWarnings("hiding")
 	@ClassRule
 	public static TestRule TOLERANCE = GEFMatchers.defaultTolerance(1);
-
-	private ExecutionSpecification exec;
-
-	private EditPart execEP;
-
-	private Message request;
-
-	private EditPart requestEP;
-
-	private Message reply;
-
-	private EditPart replyEP;
-
-	private ExecutionSpecification exec2;
-
-	private EditPart exec2EP;
-
-	private Lifeline l1;
-
-	private EditPart l1EP;
-
-	private Lifeline l2;
-
-	private EditPart l2EP;
-
-	private Message m3;
-
-	private EditPart m3EP;
 
 	/**
 	 * Initializes me.
@@ -88,159 +59,277 @@ public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphica
 		super();
 	}
 
-	@Test
-	public void moveExecutionUp() {
-		moveExecution(-50);
-	}
-
-	void moveExecution(int delta) {
-		Point requestSend = getSource(requestEP);
-		Point requestRecv = getTarget(requestEP);
-		Point replySend = getSource(replyEP);
-		Point replyRecv = getTarget(replyEP);
-		Rectangle execBounds = getBounds(execEP);
-
-		// First, select the execution to activate selection handles
-		Point grabAt = getCenter(execEP);
-		editor.select(grabAt);
-
-		Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
-		editor.drag(grabAt, dropAt);
-
-		execBounds.translate(0, delta);
-		requestSend.translate(0, delta);
-		requestRecv.translate(0, delta);
-		replySend.translate(0, delta);
-		replyRecv.translate(0, delta);
-
-		assertThat("Execution not moved", execEP, isBounded(isRect(execBounds)));
-		assertThat("Request message not moved", requestEP, runs(isPoint(requestSend), isPoint(requestRecv)));
-		assertThat("Reply message not moved", replyEP, runs(isPoint(replySend), isPoint(replyRecv)));
-	}
-
-	@Test
-	public void moveExecutionDown() {
-		// Move the execution close enough to the next one below that it must be nudged
-		moveExecution(35);
-
-		Rectangle execBounds = getBounds(execEP);
-
-		int padding = 10;
-		assertThat("Next execution not nudged", exec2EP,
-				isBounded(anything(), is(execBounds.bottom() + padding), anything(), anything()));
-	}
-
-	/**
-	 * Verify that a move that would require semantic re-ordering is blocked without the keyboard modifier.
-	 */
-	@Test
-	public void attemptMoveWithSemanticReordering() {
-		int delta = 60;
-		Rectangle execBounds = getBounds(execEP);
-
-		// First, select the execution to activate selection handles
-		Point grabAt = getCenter(execEP);
-		editor.select(grabAt);
-
-		Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
-		editor.drag(grabAt, dropAt);
-
-		assertThat("Execution moved", execEP, isBounded(isRect(execBounds)));
-	}
-
-	/**
-	 * Verify that a move that requires semantic re-ordering is allowed with the keyboard modifier.
-	 */
-	@Test
-	public void moveWithSemanticReordering() {
-		int delta = 60;
-		Rectangle execBounds = getBounds(execEP);
-
-		// First, select the execution to activate selection handles
-		Point grabAt = getCenter(execEP);
-		editor.select(grabAt);
-
-		Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
-		editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
-
-		execBounds.translate(0, delta);
-		assertThat("Execution not moved", execEP, isBounded(isRect(execBounds)));
-	}
-
-	/**
-	 * Verify that a change of lifeline is blocked without the keyboard modifier.
-	 */
-	@Test
-	public void attemptChangeLifeline() {
-		int l1X = getBounds(l1EP).getCenter().x();
-		int l2X = getBounds(l2EP).getCenter().x();
-		int exec2Top = getTop(exec2EP);
-
-		// First, select the execution to activate selection handles
-		Point grabAt = getCenter(exec2EP);
-		editor.select(grabAt);
-
-		Point dropAt = new Point(l2X, grabAt.y());
-		editor.drag(grabAt, dropAt);
-		// Drag-and-drop creates a new edit-part
-		exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
-
-		assertThat("Execution was moved", exec2EP, isAt(l1X - (EXEC_WIDTH / 2), exec2Top));
-	}
-
-	/**
-	 * Verify drag and drop of execution specification to another lifeline.
-	 */
-	@Test
-	public void changeLifeline() {
-		int l2X = getBounds(l2EP).getCenter().x();
-		int exec2Top = getTop(exec2EP);
-
-		// First, select the execution to activate selection handles
-		Point grabAt = getCenter(exec2EP);
-		editor.select(grabAt);
-
-		Point dropAt = new Point(l2X, grabAt.y());
-		editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
-		// Drag-and-drop creates a new edit-part
-		exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
-
-		assertThat("Execution not moved", exec2EP, isAt(l2X - (EXEC_WIDTH / 2), exec2Top));
-
-		PointList m3Points = getPoints(m3EP);
-		assertThat("Not a self-message", m3Points.size(), gt(2));
-
-		Point m3Send = m3Points.getFirstPoint();
-		Point m3Recv = m3Points.getLastPoint();
-		assertThat(m3Send, isPoint(is(l2X + (EXEC_WIDTH / 2)), anything()));
-		assertThat(m3Recv, isPoint(is(l2X + (EXEC_WIDTH / 2)), gte(m3Send.y() + 20)));
-	}
-
 	//
-	// Nested types
+	// Nested test suites
 	//
 
-	@Before
-	public void findFixtures() {
-		exec = getElement("exec1", ExecutionSpecification.class);
-		execEP = getChildByEObject(exec, editor.getDiagramEditPart(), false);
+	/**
+	 * Basic move/resize drag-and-drop use cases.
+	 */
+	@ModelResource("kitchen-sink.di")
+	@Maximized
+	public static class Basic extends AbstractGraphicalEditPolicyUITest {
+		@Rule
+		public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
 
-		request = getElement("m1", Message.class);
-		requestEP = getChildByEObject(request, editor.getDiagramEditPart(), true);
-		reply = getElement("m2", Message.class);
-		replyEP = getChildByEObject(reply, editor.getDiagramEditPart(), true);
-		exec2 = getElement("exec2", ExecutionSpecification.class);
-		exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
+		@AutoFixture("exec1")
+		private ExecutionSpecification exec;
 
-		l1 = getElement("L1", Lifeline.class);
-		l1EP = getChildByEObject(l1, editor.getDiagramEditPart(), false);
-		l2 = getElement("L2", Lifeline.class);
-		l2EP = getChildByEObject(l2, editor.getDiagramEditPart(), false);
-		m3 = getElement("m3", Message.class);
-		m3EP = getChildByEObject(m3, editor.getDiagramEditPart(), true);
+		@AutoFixture
+		private EditPart execEP;
+
+		@AutoFixture("m1")
+		private Message request;
+
+		@AutoFixture
+		private EditPart requestEP;
+
+		@AutoFixture("m2")
+		private Message reply;
+
+		@AutoFixture
+		private EditPart replyEP;
+
+		@AutoFixture
+		private ExecutionSpecification exec2;
+
+		@AutoFixture
+		private EditPart exec2EP;
+
+		@AutoFixture("L1")
+		private Lifeline l1;
+
+		@AutoFixture
+		private EditPart l1EP;
+
+		@AutoFixture("L2")
+		private Lifeline l2;
+
+		@AutoFixture
+		private EditPart l2EP;
+
+		@AutoFixture
+		private Message m3;
+
+		@AutoFixture
+		private EditPart m3EP;
+
+		/**
+		 * Initializes me.
+		 */
+		public Basic() {
+			super();
+		}
+
+		@Test
+		public void moveExecutionUp() {
+			moveExecution(-50);
+		}
+
+		void moveExecution(int delta) {
+			Point requestSend = getSource(requestEP);
+			Point requestRecv = getTarget(requestEP);
+			Point replySend = getSource(replyEP);
+			Point replyRecv = getTarget(replyEP);
+			Rectangle execBounds = getBounds(execEP);
+
+			// First, select the execution to activate selection handles
+			Point grabAt = getCenter(execEP);
+			editor.select(grabAt);
+
+			Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+			editor.drag(grabAt, dropAt);
+
+			execBounds.translate(0, delta);
+			requestSend.translate(0, delta);
+			requestRecv.translate(0, delta);
+			replySend.translate(0, delta);
+			replyRecv.translate(0, delta);
+
+			assertThat("Execution not moved", execEP, isBounded(isRect(execBounds)));
+			assertThat("Request message not moved", requestEP,
+					runs(isPoint(requestSend), isPoint(requestRecv)));
+			assertThat("Reply message not moved", replyEP, runs(isPoint(replySend), isPoint(replyRecv)));
+		}
+
+		@Test
+		public void moveExecutionDown() {
+			// Move the execution close enough to the next one below that it must be nudged
+			moveExecution(35);
+
+			Rectangle execBounds = getBounds(execEP);
+
+			int padding = 10;
+			assertThat("Next execution not nudged", exec2EP,
+					isBounded(anything(), is(execBounds.bottom() + padding), anything(), anything()));
+		}
+
+		/**
+		 * Verify that a move that would require semantic re-ordering is blocked without the keyboard
+		 * modifier.
+		 */
+		@Test
+		public void attemptMoveWithSemanticReordering() {
+			int delta = 60;
+			Rectangle execBounds = getBounds(execEP);
+
+			// First, select the execution to activate selection handles
+			Point grabAt = getCenter(execEP);
+			editor.select(grabAt);
+
+			Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+			editor.drag(grabAt, dropAt);
+
+			assertThat("Execution moved", execEP, isBounded(isRect(execBounds)));
+		}
+
+		/**
+		 * Verify that a move that requires semantic re-ordering is allowed with the keyboard modifier.
+		 */
+		@Test
+		public void moveWithSemanticReordering() {
+			int delta = 60;
+			Rectangle execBounds = getBounds(execEP);
+
+			// First, select the execution to activate selection handles
+			Point grabAt = getCenter(execEP);
+			editor.select(grabAt);
+
+			Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+			editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+
+			execBounds.translate(0, delta);
+			assertThat("Execution not moved", execEP, isBounded(isRect(execBounds)));
+		}
+
+		/**
+		 * Verify that a change of lifeline is blocked without the keyboard modifier.
+		 */
+		@Test
+		public void attemptChangeLifeline() {
+			int l1X = getBounds(l1EP).getCenter().x();
+			int l2X = getBounds(l2EP).getCenter().x();
+			int exec2Top = getTop(exec2EP);
+
+			// First, select the execution to activate selection handles
+			Point grabAt = getCenter(exec2EP);
+			editor.select(grabAt);
+
+			Point dropAt = new Point(l2X, grabAt.y());
+			editor.drag(grabAt, dropAt);
+			// Drag-and-drop creates a new edit-part
+			exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
+
+			assertThat("Execution was moved", exec2EP, isAt(l1X - (EXEC_WIDTH / 2), exec2Top));
+		}
+
+		/**
+		 * Verify drag and drop of execution specification to another lifeline.
+		 */
+		@Test
+		public void changeLifeline() {
+			int l2X = getBounds(l2EP).getCenter().x();
+			int exec2Top = getTop(exec2EP);
+
+			// First, select the execution to activate selection handles
+			Point grabAt = getCenter(exec2EP);
+			editor.select(grabAt);
+
+			Point dropAt = new Point(l2X, grabAt.y());
+			editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+			// Drag-and-drop creates a new edit-part
+			exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
+
+			assertThat("Execution not moved", exec2EP, isAt(l2X - (EXEC_WIDTH / 2), exec2Top));
+
+			PointList m3Points = getPoints(m3EP);
+			assertThat("Not a self-message", m3Points.size(), gt(2));
+
+			Point m3Send = m3Points.getFirstPoint();
+			Point m3Recv = m3Points.getLastPoint();
+			assertThat(m3Send, isPoint(is(l2X + (EXEC_WIDTH / 2)), anything()));
+			assertThat(m3Recv, isPoint(is(l2X + (EXEC_WIDTH / 2)), gte(m3Send.y() + 20)));
+		}
+
 	}
 
-	protected <T extends NamedElement> T getElement(String name, Class<T> type) {
-		return editor.getElement("kitchen-sink::Scenario::" + name, type);
+	/**
+	 * Basic move/resize drag-and-drop use cases.
+	 */
+	@ModelResource("65-moving.di")
+	@Maximized
+	public static class WithMessagesAttached extends AbstractGraphicalEditPolicyUITest {
+		@Rule
+		public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+		@AutoFixture("exec1")
+		private ExecutionSpecification exec;
+
+		@AutoFixture
+		private EditPart execEP;
+
+		@AutoFixture
+		private Message async1;
+
+		@AutoFixture
+		private EditPart async1EP;
+
+		@AutoFixture
+		private Message async2;
+
+		@AutoFixture
+		private EditPart async2EP;
+
+		@AutoFixture
+		private Message async3;
+
+		@AutoFixture
+		private EditPart async3EP;
+
+		@AutoFixture
+		private ExecutionSpecification exec2;
+
+		@AutoFixture
+		private EditPart exec2EP;
+
+		/**
+		 * Initializes me.
+		 */
+		public WithMessagesAttached() {
+			super();
+		}
+
+		@Test
+		public void moveExecutionDown() {
+			int delta = 15;
+
+			PointList async1Geom = getPoints(async1EP);
+			PointList async2Geom = getPoints(async2EP);
+			PointList async3Geom = getPoints(async3EP);
+			Rectangle exec2Geom = getBounds(exec2EP);
+
+			// First, select the execution to activate selection handles
+			Point grabAt = getCenter(execEP);
+			editor.select(grabAt);
+
+			Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+			editor.drag(grabAt, dropAt);
+
+			async1Geom.translate(0, delta);
+			async2Geom.translate(0, delta);
+			async3Geom.translate(0, delta);
+			exec2Geom.translate(0, delta);
+
+			assertThat("Async message 1 was changed", async1EP,
+					runs(isPoint(async1Geom.getFirstPoint()), isPoint(async1Geom.getLastPoint())));
+			assertThat("Async message 2 was changed", async2EP,
+					runs(isPoint(async2Geom.getFirstPoint()), isPoint(async2Geom.getLastPoint())));
+			assertThat("Async message 3 was changed", async3EP,
+					runs(isPoint(async3Geom.getFirstPoint()), isPoint(async3Geom.getLastPoint())));
+			assertThat("Execution started by sunc message 2 not moved", exec2EP,
+					isAt(isPoint(exec2Geom.getLocation())));
+		}
+
 	}
+
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -1,0 +1,126 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.infra.gmfdiag.common.utils.DiagramEditPartsUtil.getChildByEObject;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.is;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isRect;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isBounded;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.runs;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Message;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+/**
+ * Test cases for the {@code ExecutionSpecificationDragEditPolicy} class.
+ *
+ * @author Christian W. Damus
+ */
+@ModelResource("kitchen-sink.di")
+@Maximized
+public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@ClassRule
+	public static TestRule TOLERANCE = GEFMatchers.defaultTolerance(1);
+
+	private ExecutionSpecification exec;
+	private EditPart execEP;
+
+	private Message request;
+	private EditPart requestEP;
+	private Message reply;
+	private EditPart replyEP;
+	private ExecutionSpecification exec2;
+	private EditPart exec2EP;
+
+	/**
+	 * Initializes me.
+	 */
+	public ExecutionSpecificationDragEditPolicyUITest() {
+		super();
+	}
+
+	@Test
+	public void moveExecutionUp() {
+		moveExecution(-50);
+	}
+
+	void moveExecution(int delta) {
+		Point requestSend = getSource(requestEP);
+		Point requestRecv = getTarget(requestEP);
+		Point replySend = getSource(replyEP);
+		Point replyRecv = getTarget(replyEP);
+		Rectangle execBounds = getBounds(execEP);
+
+		// First, select the execution to activate selection handles
+		Point grabAt = getCenter(execEP);
+		editor.select(grabAt);
+
+		Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+		editor.drag(grabAt, dropAt);
+
+		execBounds.translate(0, delta);
+		requestSend.translate(0, delta);
+		requestRecv.translate(0, delta);
+		replySend.translate(0, delta);
+		replyRecv.translate(0, delta);
+
+		assertThat("Execution not moved", execEP, isBounded(isRect(execBounds)));
+		assertThat("Request message not moved", requestEP,
+				runs(isPoint(requestSend), isPoint(requestRecv)));
+		assertThat("Reply message not moved", replyEP, runs(isPoint(replySend), isPoint(replyRecv)));
+	}
+
+	@Test
+	public void moveExecutionDown() {
+		// Move the execution close enough to the next one below that it must be nudged
+		moveExecution(35);
+
+		Rectangle execBounds = getBounds(execEP);
+
+		int padding = 10;
+		assertThat("Next execution not nudged", exec2EP,
+				isBounded(anything(), is(execBounds.bottom() + padding), anything(), anything()));
+	}
+
+	//
+	// Nested types
+	//
+
+	@Before
+	public void findFixtures() {
+		exec = editor.getElement("kitchen-sink::Scenario::exec1", ExecutionSpecification.class);
+		execEP = getChildByEObject(exec, editor.getDiagramEditPart(), false);
+
+		request = editor.getElement("kitchen-sink::Scenario::m1", Message.class);
+		requestEP = getChildByEObject(request, editor.getDiagramEditPart(), true);
+		reply = editor.getElement("kitchen-sink::Scenario::m2", Message.class);
+		replyEP = getChildByEObject(reply, editor.getDiagramEditPart(), true);
+		exec2 = editor.getElement("kitchen-sink::Scenario::exec2", ExecutionSpecification.class);
+		exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -106,6 +106,45 @@ public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphica
 				isBounded(anything(), is(execBounds.bottom() + padding), anything(), anything()));
 	}
 
+	/**
+	 * Verify that a move that would require semantic re-ordering is blocked without
+	 * the keyboard modifier.
+	 */
+	@Test
+	public void attemptMoveWithSemanticReordering() {
+		int delta = 60;
+		Rectangle execBounds = getBounds(execEP);
+
+		// First, select the execution to activate selection handles
+		Point grabAt = getCenter(execEP);
+		editor.select(grabAt);
+
+		Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+		editor.drag(grabAt, dropAt);
+
+		assertThat("Execution moved", execEP, isBounded(isRect(execBounds)));
+	}
+
+	/**
+	 * Verify that a move that requires semantic re-ordering is allowed with the
+	 * keyboard modifier.
+	 */
+	@Test
+	public void moveWithSemanticReordering() {
+		int delta = 60;
+		Rectangle execBounds = getBounds(execEP);
+
+		// First, select the execution to activate selection handles
+		Point grabAt = getCenter(execEP);
+		editor.select(grabAt);
+
+		Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+		editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+
+		execBounds.translate(0, delta);
+		assertThat("Execution not moved", execEP, isBounded(isRect(execBounds)));
+	}
+
 	//
 	// Nested types
 	//

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -16,19 +16,25 @@ import static org.eclipse.papyrus.infra.gmfdiag.common.utils.DiagramEditPartsUti
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.is;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isRect;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isAt;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isBounded;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.runs;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.gt;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.gte;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Lifeline;
 import org.eclipse.uml2.uml.Message;
+import org.eclipse.uml2.uml.NamedElement;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -43,18 +49,37 @@ import org.junit.rules.TestRule;
 @Maximized
 public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
 
+	@SuppressWarnings("hiding")
 	@ClassRule
 	public static TestRule TOLERANCE = GEFMatchers.defaultTolerance(1);
 
 	private ExecutionSpecification exec;
+
 	private EditPart execEP;
 
 	private Message request;
+
 	private EditPart requestEP;
+
 	private Message reply;
+
 	private EditPart replyEP;
+
 	private ExecutionSpecification exec2;
+
 	private EditPart exec2EP;
+
+	private Lifeline l1;
+
+	private EditPart l1EP;
+
+	private Lifeline l2;
+
+	private EditPart l2EP;
+
+	private Message m3;
+
+	private EditPart m3EP;
 
 	/**
 	 * Initializes me.
@@ -89,8 +114,7 @@ public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphica
 		replyRecv.translate(0, delta);
 
 		assertThat("Execution not moved", execEP, isBounded(isRect(execBounds)));
-		assertThat("Request message not moved", requestEP,
-				runs(isPoint(requestSend), isPoint(requestRecv)));
+		assertThat("Request message not moved", requestEP, runs(isPoint(requestSend), isPoint(requestRecv)));
 		assertThat("Reply message not moved", replyEP, runs(isPoint(replySend), isPoint(replyRecv)));
 	}
 
@@ -107,8 +131,7 @@ public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphica
 	}
 
 	/**
-	 * Verify that a move that would require semantic re-ordering is blocked without
-	 * the keyboard modifier.
+	 * Verify that a move that would require semantic re-ordering is blocked without the keyboard modifier.
 	 */
 	@Test
 	public void attemptMoveWithSemanticReordering() {
@@ -126,8 +149,7 @@ public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphica
 	}
 
 	/**
-	 * Verify that a move that requires semantic re-ordering is allowed with the
-	 * keyboard modifier.
+	 * Verify that a move that requires semantic re-ordering is allowed with the keyboard modifier.
 	 */
 	@Test
 	public void moveWithSemanticReordering() {
@@ -145,21 +167,80 @@ public class ExecutionSpecificationDragEditPolicyUITest extends AbstractGraphica
 		assertThat("Execution not moved", execEP, isBounded(isRect(execBounds)));
 	}
 
+	/**
+	 * Verify that a change of lifeline is blocked without the keyboard modifier.
+	 */
+	@Test
+	public void attemptChangeLifeline() {
+		int l1X = getBounds(l1EP).getCenter().x();
+		int l2X = getBounds(l2EP).getCenter().x();
+		int exec2Top = getTop(exec2EP);
+
+		// First, select the execution to activate selection handles
+		Point grabAt = getCenter(exec2EP);
+		editor.select(grabAt);
+
+		Point dropAt = new Point(l2X, grabAt.y());
+		editor.drag(grabAt, dropAt);
+		// Drag-and-drop creates a new edit-part
+		exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
+
+		assertThat("Execution was moved", exec2EP, isAt(l1X - (EXEC_WIDTH / 2), exec2Top));
+	}
+
+	/**
+	 * Verify drag and drop of execution specification to another lifeline.
+	 */
+	@Test
+	public void changeLifeline() {
+		int l2X = getBounds(l2EP).getCenter().x();
+		int exec2Top = getTop(exec2EP);
+
+		// First, select the execution to activate selection handles
+		Point grabAt = getCenter(exec2EP);
+		editor.select(grabAt);
+
+		Point dropAt = new Point(l2X, grabAt.y());
+		editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+		// Drag-and-drop creates a new edit-part
+		exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
+
+		assertThat("Execution not moved", exec2EP, isAt(l2X - (EXEC_WIDTH / 2), exec2Top));
+
+		PointList m3Points = getPoints(m3EP);
+		assertThat("Not a self-message", m3Points.size(), gt(2));
+
+		Point m3Send = m3Points.getFirstPoint();
+		Point m3Recv = m3Points.getLastPoint();
+		assertThat(m3Send, isPoint(is(l2X + (EXEC_WIDTH / 2)), anything()));
+		assertThat(m3Recv, isPoint(is(l2X + (EXEC_WIDTH / 2)), gte(m3Send.y() + 20)));
+	}
+
 	//
 	// Nested types
 	//
 
 	@Before
 	public void findFixtures() {
-		exec = editor.getElement("kitchen-sink::Scenario::exec1", ExecutionSpecification.class);
+		exec = getElement("exec1", ExecutionSpecification.class);
 		execEP = getChildByEObject(exec, editor.getDiagramEditPart(), false);
 
-		request = editor.getElement("kitchen-sink::Scenario::m1", Message.class);
+		request = getElement("m1", Message.class);
 		requestEP = getChildByEObject(request, editor.getDiagramEditPart(), true);
-		reply = editor.getElement("kitchen-sink::Scenario::m2", Message.class);
+		reply = getElement("m2", Message.class);
 		replyEP = getChildByEObject(reply, editor.getDiagramEditPart(), true);
-		exec2 = editor.getElement("kitchen-sink::Scenario::exec2", ExecutionSpecification.class);
+		exec2 = getElement("exec2", ExecutionSpecification.class);
 		exec2EP = getChildByEObject(exec2, editor.getDiagramEditPart(), false);
+
+		l1 = getElement("L1", Lifeline.class);
+		l1EP = getChildByEObject(l1, editor.getDiagramEditPart(), false);
+		l2 = getElement("L2", Lifeline.class);
+		l2EP = getChildByEObject(l2, editor.getDiagramEditPart(), false);
+		m3 = getElement("m3", Message.class);
+		m3EP = getChildByEObject(m3, editor.getDiagramEditPart(), true);
 	}
 
+	protected <T extends NamedElement> T getElement(String name, Class<T> type) {
+		return editor.getElement("kitchen-sink::Scenario::" + name, type);
+	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/parsers/tests/MessageParserTest_PTest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/parsers/tests/MessageParserTest_PTest.java
@@ -30,7 +30,7 @@ import org.eclipse.gmf.runtime.emf.core.util.EObjectAdapter;
 import org.eclipse.gmf.runtime.emf.ui.services.parser.ISemanticParser;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.parsers.MessageParser;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.ModelFixture;
-import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.ModelResource;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.eclipse.uml2.uml.Message;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -38,8 +38,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Tests for the {@link MessageParser} class. The parser needs a workspace for
- * Papyrus's i18n support.
+ * Tests for the {@link MessageParser} class. The parser needs a workspace for Papyrus's i18n support.
  *
  * @author Christian W. Damus
  */
@@ -81,8 +80,8 @@ public class MessageParserTest_PTest {
 	@Test
 	public void replyWithAssignedAndUnassignedOutputs() {
 		Message reply = model.getMessage("whatsIt", "thing");
-		assertThat(reply, rendersAs(
-				"thing::ok=getStuff(thing::content=text: \"Hello, world\", expiration: 60): true"));
+		assertThat(reply,
+				rendersAs("thing::ok=getStuff(thing::content=text: \"Hello, world\", expiration: 60): true"));
 	}
 
 	@Test
@@ -103,7 +102,7 @@ public class MessageParserTest_PTest {
 		Message reply = model.getMessage("whatsIt", "thing");
 
 		@SuppressWarnings("unchecked")
-		Set<Object> set = new HashSet<>(((ISemanticParser) parser).getSemanticElementsBeingParsed(reply));
+		Set<Object> set = new HashSet<>(((ISemanticParser)parser).getSemanticElementsBeingParsed(reply));
 
 		Iterator<?> iter = EcoreUtil.getAllContents(Collections.singleton(reply));
 		iter.forEachRemaining(next -> assertThat(set, hasItem(next)));

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixture.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixture.java
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * Copyright (c) 2018 Christian W. Damus and others.
- *
+ * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,21 +12,19 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This is the {@code ModelResource} type. Enjoy.
- *
- * @author Christian W. Damus
+ * Annotation for fields that represent fixtures in the contextual model or editor, usually an
+ * {@link EditorFixture}.
  */
 @Retention(RUNTIME)
-@Target({ TYPE, METHOD })
-public @interface ModelResource {
-	/** The paths relative to the test class of the model resources to load. */
-	String[] value();
+@Target(FIELD)
+public @interface AutoFixture {
+	/** An optional element name to search for, which may be qualified or not. */
+	String value() default "";
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixtureRule.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixtureRule.java
@@ -1,0 +1,381 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules;
+
+import static java.util.Collections.singleton;
+import static org.eclipse.uml2.common.util.UML2Util.getValidJavaIdentifier;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.infra.gmfdiag.common.utils.DiagramEditPartsUtil;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.uml2.uml.ActivityEdge;
+import org.eclipse.uml2.uml.AssociationClass;
+import org.eclipse.uml2.uml.Message;
+import org.eclipse.uml2.uml.NamedElement;
+import org.eclipse.uml2.uml.Namespace;
+import org.eclipse.uml2.uml.Relationship;
+import org.eclipse.uml2.uml.Transition;
+import org.eclipse.uml2.uml.util.UMLSwitch;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A test rule that automatically populates fields annotated with {@link AutoFixture @AutoFixture} from the
+ * test rule that is some kind of {@link ModelFixture}.
+ */
+public class AutoFixtureRule implements TestRule {
+
+	private static final Pattern EDIT_PART_FIXTURE = Pattern.compile(".*(?=EP|EditPart)");
+
+	private final Object test;
+
+	private BiFunction<ModelFixture, FieldAccess<?>, Object> resolver;
+
+	/**
+	 * Initializes me.
+	 */
+	public AutoFixtureRule(Object testOrTestClass) {
+		super();
+
+		this.test = testOrTestClass;
+
+		List<BiFunction<ModelFixture, FieldAccess<?>, Object>> resolvers = Arrays.asList(
+				this::resolveQualifiedName, //
+				this::resolveSimpleName, //
+				this::resolveEditPart);
+		resolver = (model, spec) -> resolvers.stream().map(r -> r.apply(model, spec)).filter(Objects::nonNull)
+				.findFirst().orElse(null);
+	}
+
+	@Override
+	public Statement apply(Statement base, Description description) {
+		return new Statement() {
+
+			@Override
+			public void evaluate() throws Throwable {
+				ModelFixture model = getField(ModelFixture.class).get();
+
+				getAutoFixtures().forEach(fixture -> {
+					fixture.set(resolver.apply(model, fixture));
+				});
+
+				try {
+					base.evaluate();
+				} finally {
+					getAutoFixtures().forEach(FieldAccess::clear);
+				}
+			}
+		};
+	}
+
+	private Stream<Field> getFields() {
+		return getFields(test);
+	}
+
+	private static Stream<Field> getFields(Object owner) {
+		boolean isStatic = owner instanceof Class<?>;
+		return isStatic ? getFields((Class<?>)owner, isStatic) : getFields(owner.getClass(), isStatic);
+	}
+
+	private static Stream<Field> getFields(Class<?> owner, boolean isStatic) {
+		Stream<Field> result = Stream.of(owner.getDeclaredFields())
+				.filter(f -> Modifier.isStatic(f.getModifiers()) == isStatic);
+
+		Class<?> superClass = owner.getSuperclass();
+		if ((superClass != null) && superClass != Object.class) {
+			result = Stream.concat(result, getFields(superClass, isStatic));
+		}
+
+		return result;
+	}
+
+	private <T> FieldAccess<T> getField(Class<T> type) {
+		return new FieldAccess<>(type, test);
+	}
+
+	private <T> FieldAccess<T> getField(String name, Class<T> type) {
+		return new FieldAccess<>(name, type, test);
+	}
+
+	private Stream<FieldAccess<?>> getAutoFixtures() {
+		List<?> list = getFields().collect(Collectors.toList());
+		return getFields().filter(f -> f.isAnnotationPresent(AutoFixture.class))
+				.map(f -> new FieldAccess<>(f, Object.class, test));
+	}
+
+	//
+	// Resolvers
+	//
+
+	private Object resolveQualifiedName(ModelFixture model, FieldAccess<?> fixture) {
+		Object result = null;
+
+		String[] parts = fixture.getFixtureName().split("::");
+		if ((parts.length > 0) && parts[0].equals(model.getModel().getName())) {
+			NamedElement next = model.getModel();
+
+			for (int i = 1; (next != null) && (i < parts.length); i++) {
+				if (!(next instanceof Namespace)) {
+					fail("Not a namespace: " + next);
+				}
+
+				next = ((Namespace)next).getMember(parts[i]);
+			}
+
+			result = next;
+		}
+
+		return fixture.asAssignable(result);
+	}
+
+	private Object resolveSimpleName(ModelFixture model, FieldAccess<?> fixture) {
+		Object result = null;
+
+		String name = fixture.getFixtureName();
+		if (!name.contains("::")) {
+			for (TreeIterator<EObject> iter = EcoreUtil
+					.getAllContents(singleton(model.getModel())); (result == null) && iter.hasNext();) {
+
+				EObject next = iter.next();
+				if (next instanceof NamedElement) {
+					if (name.equals(getValidJavaIdentifier(((NamedElement)next).getName()))
+							&& fixture.isAssignable(next)) {
+
+						result = next;
+					}
+				} else {
+					iter.prune();
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private Object resolveEditPart(ModelFixture model, FieldAccess<?> fixture) {
+		Object result = null;
+
+		if ((model instanceof EditorFixture) && fixture.isAssignable(EditPart.class)) {
+			EditorFixture editor = (EditorFixture)model;
+
+			FieldAccess<? extends EObject> element = getField(fixture.getFixtureName(EDIT_PART_FIXTURE),
+					EObject.class);
+			if (element != null) {
+				EObject fixtureElement = element.get();
+				result = DiagramEditPartsUtil.getChildByEObject(fixtureElement, editor.getDiagramEditPart(),
+						isEdge(fixtureElement));
+			}
+		}
+
+		return result;
+	}
+
+	@SuppressWarnings("hiding")
+	static boolean isEdge(EObject object) {
+		return new UMLSwitch<Boolean>() {
+			@Override
+			public Boolean caseMessage(Message object) {
+				return true;
+			}
+
+			@Override
+			public Boolean caseAssociationClass(AssociationClass object) {
+				return false;
+			}
+
+			@Override
+			public Boolean caseRelationship(Relationship object) {
+				return true;
+			}
+
+			@Override
+			public Boolean caseActivityEdge(ActivityEdge object) {
+				return true;
+			}
+
+			@Override
+			public Boolean caseTransition(Transition object) {
+				return true;
+			}
+
+			@Override
+			public Boolean defaultCase(EObject object) {
+				return false;
+			}
+		}.doSwitch(object);
+	}
+
+	//
+	// Nested types
+	//
+
+	private static final class FieldAccess<T> {
+		private final Field field;
+
+		private final Object owner;
+
+		private final Class<? extends T> type;
+
+		FieldAccess(Class<T> type, Object owner) {
+			super();
+
+			try {
+				this.field = getFields(owner).filter(f -> type.isAssignableFrom(f.getType())).findAny().get();
+				setAccessible();
+
+				this.owner = owner;
+				this.type = field.getType().asSubclass(type);
+			} catch (Exception e) {
+				e.printStackTrace();
+				fail(String.format("Cannnot access fixture of type %s", type.getName()));
+				throw new Error(); // Unreachable
+			}
+		}
+
+		FieldAccess(String name, Class<T> type, Object owner) {
+			super();
+
+			try {
+				this.field = getFields(owner).filter(f -> name.equals(f.getName())).findFirst().get();
+				setAccessible();
+
+				this.owner = owner;
+				this.type = field.getType().asSubclass(type);
+			} catch (Exception e) {
+				e.printStackTrace();
+				fail(String.format("Cannnot access fixture %s", name));
+				throw new Error(); // Unreachable
+			}
+		}
+
+		FieldAccess(Field field, Class<T> type, Object owner) {
+			super();
+
+			try {
+				this.field = field;
+				setAccessible();
+
+				this.owner = owner;
+				this.type = field.getType().asSubclass(type);
+			} catch (Exception e) {
+				e.printStackTrace();
+				fail(String.format("Cannnot access fixture %s", field.getName()));
+				throw new Error(); // Unreachable
+			}
+		}
+
+		private void setAccessible() {
+			if (!Modifier.isPublic(field.getModifiers())) {
+				field.setAccessible(true);
+			}
+		}
+
+		String getName() {
+			return field.getName();
+		}
+
+		String getFixtureName() {
+			AutoFixture auto = getAutoFixture();
+			String result = (auto == null) ? "" : auto.value();
+
+			return result.isEmpty() ? getName() : result;
+		}
+
+		String getFixtureName(Pattern regex) {
+			String result = getFixtureName();
+			Matcher m = regex.matcher(result);
+			if (m.find()) {
+				result = m.group();
+			}
+			return result;
+		}
+
+		AutoFixture getAutoFixture() {
+			return field.getAnnotation(AutoFixture.class);
+		}
+
+		boolean isAssignable(Object object) {
+			Class<?> objectType;
+
+			if (object == null) {
+				objectType = Void.class;
+			} else if ((object instanceof Class<?>)) {
+				objectType = (Class<?>)object;
+			} else {
+				objectType = object.getClass();
+			}
+
+			return field.getType().isAssignableFrom(objectType);
+		}
+
+		T asAssignable(Object object) {
+			return isAssignable(object) ? type.cast(object) : null;
+		}
+
+		T get() {
+			try {
+				return type.cast(field.get(owner));
+			} catch (Exception e) {
+				e.printStackTrace();
+				fail(String.format("Could not get fixture %s of type %s", field.getName(), type.getName()));
+				return null; // Unreachable
+			}
+		}
+
+		void set(Object resolved) {
+			if (resolved == null) {
+				fail(String.format("Could not resolve fixture %s of type %s", field.getName(),
+						type.getName()));
+				return; // Unreachable
+			}
+
+			if (type.isInstance(resolved)) {
+				try {
+					field.set(owner, resolved);
+				} catch (Exception e) {
+					e.printStackTrace();
+					fail(String.format("Could not set fixture %s of type %s", field.getName(),
+							type.getName()));
+				}
+			} else {
+				fail(String.format("Could not set a %s into fixture %s of type %s",
+						resolved.getClass().getName(), field.getName(), type.getName()));
+			}
+		}
+
+		void clear() {
+			try {
+				field.set(owner, null);
+			} catch (Exception e) {
+				e.printStackTrace();
+				// Best effort. Just continue with tests
+			}
+		}
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/ModelFixture.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/ModelFixture.java
@@ -12,88 +12,45 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules;
 
-import static org.hamcrest.CoreMatchers.anything;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.net.URL;
-import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 
-import org.eclipse.emf.common.EMFPlugin;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.eclipse.gmf.runtime.notation.Diagram;
-import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.util.MessageUtil;
-import org.eclipse.uml2.common.util.CacheAdapter;
-import org.eclipse.uml2.common.util.UML2Util;
 import org.eclipse.uml2.uml.Interaction;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.NamedElement;
-import org.eclipse.uml2.uml.Package;
-import org.eclipse.uml2.uml.UMLPackage;
-import org.eclipse.uml2.uml.resources.util.UMLResourcesUtil;
-import org.eclipse.uml2.uml.util.UMLUtil;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 /**
  * A test fixture that loads an UML model containing an {@link Interaction}.
  *
  * @author Christian W. Damus
  */
-public class ModelFixture implements TestRule {
+public class ModelFixture extends org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture {
 
 	private static final String SEQUENCE_DIAGRAM_TYPE = "PapyrusUMLSequenceDiagram"; //$NON-NLS-1$
-	// private static final String SEQUENCE_DIAGRAM_TYPE =
-	// "LightweightSequenceDiagram"; //$NON-NLS-1$
-
-	private final Class<?> testClass;
-	private final String path;
-
-	private ResourceSet rset;
-	private Package model;
-	private Interaction interaction;
-	private Optional<Diagram> sequenceDiagram;
 
 	/**
 	 * Initializes me.
 	 *
 	 * @param testClass
-	 *            the test class in which context to load the resource. May be
-	 *            {@code null} for an ordinary {@code Rule} but required for a
-	 *            {@link ClassRule}
+	 *            the test class in which context to load the resource. May be {@code null} for an ordinary
+	 *            {@code Rule} but required for a {@link ClassRule}
 	 * @param path
-	 *            the path relative to the {@code testClass} of the UML resource to
-	 *            load
+	 *            the path relative to the {@code testClass} of the UML resource to load
 	 */
 	public ModelFixture(Class<?> testClass, String path) {
-		super();
-
-		this.testClass = testClass;
-		this.path = path;
+		super(testClass, path);
 	}
 
 	/**
 	 * Initializes me.
 	 *
 	 * @param testClass
-	 *            the test class in which context to load the resource. May be
-	 *            {@code null} for an ordinary {@code Rule} but required for a
-	 *            {@link ClassRule}
+	 *            the test class in which context to load the resource. May be {@code null} for an ordinary
+	 *            {@code Rule} but required for a {@link ClassRule}
 	 */
 	public ModelFixture(Class<?> testClass) {
 		this(testClass, null);
@@ -103,8 +60,7 @@ public class ModelFixture implements TestRule {
 	 * Initializes me.
 	 *
 	 * @param path
-	 *            the path relative to the {@code testClass} of the UML resource to
-	 *            load
+	 *            the path relative to the {@code testClass} of the UML resource to load
 	 */
 	public ModelFixture(String path) {
 		this(null, path);
@@ -117,178 +73,21 @@ public class ModelFixture implements TestRule {
 		this(null, null);
 	}
 
-	public Package getModel() {
-		return model;
-	}
-
-	public Interaction getInteraction() {
-		return interaction;
-	}
-
-	public Optional<Diagram> getSequenceDiagram() {
-		return sequenceDiagram;
-	}
-
 	@Override
-	public Statement apply(Statement base, Description description) {
-		return new Statement() {
-
-			@Override
-			public void evaluate() throws Throwable {
-				starting(description);
-
-				try {
-					base.evaluate();
-				} finally {
-					finished(description);
-				}
-			}
-		};
-	}
-
-	protected void starting(Description description) {
-		Class<?> context = testClass;
-		if (context == null) {
-			context = description.getTestClass();
-			if (context == null) {
-				fail("Explicit test class required for @ClassRule");
-			}
-		}
-
-		final String[] paths = getPaths(description);
-		for (String path : paths) {
-			URL resourceURL = context.getResource(path);
-			if (resourceURL == null) {
-				fail("Resource not found: " + path);
-			}
-
-			if (rset == null) {
-				rset = new ResourceSetImpl();
-				if (!EMFPlugin.IS_ECLIPSE_RUNNING) {
-					standaloneSetup(rset);
-				}
-			}
-
-			Package package_ = UML2Util.load(rset, URI.createURI(resourceURL.toExternalForm(), true),
-					UMLPackage.Literals.PACKAGE);
-			if (model == null) {
-				model = package_;
-			}
-		}
-
-		assertThat("No UML package found in " + path, model, notNullValue());
-
-		interaction = (Interaction) UML2Util.findEObject(model.eAllContents(),
-				UMLPackage.Literals.INTERACTION::isInstance);
-		assertThat("No UML interaction found in " + path, interaction, notNullValue());
-
-		// Look for a sequence diagram
-		sequenceDiagram = CacheAdapter.getCacheAdapter(interaction).getInverseReferences(interaction)
-				.stream()
-				.filter(setting -> setting
-						.getEStructuralFeature() == NotationPackage.Literals.VIEW__ELEMENT)
-				.map(EStructuralFeature.Setting::getEObject).filter(Diagram.class::isInstance)
-				.map(Diagram.class::cast).filter(diagram -> SEQUENCE_DIAGRAM_TYPE.equals(diagram.getType()))
-				.findAny();
-	}
-
-	protected void finished(Description description) {
-		interaction = null;
-		model = null;
-
-		rset.getResources().forEach(Resource::unload);
-		rset.getResources().clear();
-		rset.eAdapters().clear();
-		rset = null;
-	}
-
-	protected String[] getPaths(Description description) {
-		String[] result;
-
-		if (path != null) {
-			result = new String[] { path };
-		} else {
-			ModelResource resource = description.getAnnotation(ModelResource.class);
-			if ((resource == null) && (description.getTestClass() != null)) {
-				resource = description.getTestClass().getAnnotation(ModelResource.class);
-			}
-			if (resource == null) {
-				fail("Required @ModelResource annotation is missing for " + description);
-			}
-			result = resource.value();
-		}
-
-		return result;
+	protected boolean isSequenceDiagram(Diagram diagram) {
+		return SEQUENCE_DIAGRAM_TYPE.equals(diagram.getType());
 	}
 
 	/**
-	 * Get the named element. Fails the test if the element is not found.
-	 *
-	 * @param qualifiedName
-	 *            the qualified name of an element to get
-	 * @return the element
-	 */
-	public NamedElement getElement(String qualifiedName) {
-		Collection<NamedElement> result = UMLUtil.findNamedElements(rset, qualifiedName);
-
-		assertThat("no such element: " + qualifiedName, result, hasItem(anything()));
-
-		return result.iterator().next();
-	}
-
-	/**
-	 * Get the named element. Fails the test if the element is not found.
-	 *
-	 * @param qualifiedName
-	 *            the qualified name of an element to get
-	 * @param type
-	 *            the type of element to retrieve
-	 *
-	 * @return the element
-	 *
-	 * @param <T>
-	 *            the element type to retrieve
-	 */
-	public <T extends NamedElement> T getElement(String qualifiedName, Class<T> type) {
-
-		Collection<NamedElement> result = UMLUtil.findNamedElements(rset, qualifiedName, false,
-				(EClass) UMLPackage.eINSTANCE.getEClassifier(type.getSimpleName()));
-
-		assertThat("no such element: " + qualifiedName, result, hasItem(anything()));
-
-		return type.cast(result.iterator().next());
-	}
-
-	/**
-	 * Configures a resource set for stand-alone test execution.
-	 *
-	 * @param rset
-	 *            a resource set to configure
-	 */
-	public static void standaloneSetup(ResourceSet rset) {
-		UMLResourcesUtil.init(rset);
-
-		// Initialize the diagram notation
-		NotationPackage.Literals.DIAGRAM.eClass();
-
-		rset.getResourceFactoryRegistry().getExtensionToFactoryMap().put("notation",
-				new XMIResourceFactoryImpl());
-	}
-
-	/**
-	 * Get the first available message between two lifelines in my
-	 * {@link #getInteraction() interaction}.
+	 * Get the first available message between two lifelines in my {@link #getInteraction() interaction}.
 	 *
 	 * @param from
 	 *            the sending lifeline name
 	 * @param to
 	 *            the receiving lifeline name
-	 *
 	 * @return the message
-	 *
 	 * @throws NoSuchElementException
 	 *             if no such message exists in the interaction
-	 *
 	 * @see #getInteraction()
 	 */
 	public Message getMessage(String from, String to) {
@@ -297,24 +96,19 @@ public class ModelFixture implements TestRule {
 	}
 
 	/**
-	 * Get a specific message between two lifelines in my {@link #getInteraction()
-	 * interaction}. This is a useful alternative to the simple
-	 * {@code #getMessage(String, String)} when there are multiple messages in the
-	 * same direction between two lifelines.
+	 * Get a specific message between two lifelines in my {@link #getInteraction() interaction}. This is a
+	 * useful alternative to the simple {@code #getMessage(String, String)} when there are multiple messages
+	 * in the same direction between two lifelines.
 	 *
 	 * @param from
 	 *            the sending lifeline name
 	 * @param to
 	 *            the receiving lifeline name
 	 * @param index
-	 *            which of the messages between the two lifelines, in sequence
-	 *            order, to retrieve
-	 *
+	 *            which of the messages between the two lifelines, in sequence order, to retrieve
 	 * @return the message
-	 *
 	 * @throws NoSuchElementException
 	 *             if no such message exists in the interaction
-	 *
 	 * @see #getInteraction()
 	 * @see #getMessage(String, String)
 	 */


### PR DESCRIPTION
Implement support for grabbing an execution occurrence and
- sliding it up or down the lifeline, with or without the keyboard modifier for semantic re-ordering
- dropping it onto another lifeline, which requires the keyboard modifier for semantic re-ordering
