### PR TITLE
376 - Anchor position on executions

### DIFF
--- a/examples/LightweightSequenceExample/65-moving.notation
+++ b/examples/LightweightSequenceExample/65-moving.notation
@@ -69,7 +69,7 @@
     <children xmi:type="notation:DecorationNode" xmi:id="_qvqcUeM2Eeic0KQPni2_MA" type="Edge_Message_Name"/>
     <element xmi:type="uml:Message" href="65-moving.uml#_qvp1QeM2Eeic0KQPni2_MA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qvqcUuM2Eeic0KQPni2_MA"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvqcU-M2Eeic0KQPni2_MA" id="right;34"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvqcU-M2Eeic0KQPni2_MA" id="34"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvqcVOM2Eeic0KQPni2_MA" id="start"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_qvrqcOM2Eeic0KQPni2_MA" type="Edge_Message" source="_qvrDYOM2Eeic0KQPni2_MA" target="_Y_QnseM0EeiMDaKTugkfaw">
@@ -77,6 +77,6 @@
     <element xmi:type="uml:Message" href="65-moving.uml#_qvrDZOM2Eeic0KQPni2_MA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qvrqcuM2Eeic0KQPni2_MA"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvrqc-M2Eeic0KQPni2_MA" id="end"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvrqdOM2Eeic0KQPni2_MA" id="right;150"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qvrqdOM2Eeic0KQPni2_MA" id="150"/>
   </edges>
 </notation:Diagram>

--- a/examples/LightweightSequenceExample/AnchorsModel.notation
+++ b/examples/LightweightSequenceExample/AnchorsModel.notation
@@ -274,7 +274,7 @@
       <element xmi:type="uml:Message" href="AnchorsModel.uml#_UxpL0Cb3EeihQLPTjNT1Rg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JkoO7iIXEeinxv2N8q8iQw"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JkoO7yIXEeinxv2N8q8iQw" id="45"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JkoO8CIXEeinxv2N8q8iQw" id="left;20"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JkoO8CIXEeinxv2N8q8iQw" id="20"/>
     </edges>
     <edges xmi:type="notation:Connector" xmi:id="_JkoO8SIXEeinxv2N8q8iQw" type="Edge_Message" source="_JkoO5iIXEeinxv2N8q8iQw" target="_8e1YmEFrEei1zqUjbAwdJw">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_JkoO8iIXEeinxv2N8q8iQw" source="PapyrusCSSForceValue">
@@ -282,7 +282,7 @@
       </eAnnotations>
       <element xmi:type="uml:Message" href="AnchorsModel.uml#_WHrKoCb3EeihQLPTjNT1Rg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JkoO9CIXEeinxv2N8q8iQw"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JkoO9SIXEeinxv2N8q8iQw" id="left;60"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JkoO9SIXEeinxv2N8q8iQw" id="60"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JkoO9iIXEeinxv2N8q8iQw" id="85"/>
     </edges>
   </notation:Diagram>

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/ExecutionSpecificationFigure.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/ExecutionSpecificationFigure.java
@@ -53,6 +53,10 @@ public class ExecutionSpecificationFigure extends NodeFigure {
 				//
 				// Message anchors
 				//
+				// the side case is deprecated, since issue #376, but still there for compatibility
+				case SIDE:
+					return new ExecutionSpecificationSideAnchor(this,
+							anchorParser.getDistanceFromReference(terminal));
 				case DISTANCE:
 				case FIXED:
 					return new ExecutionSpecificationSideAnchor(this, anchorParser.getDistance(terminal));

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/ExecutionSpecificationFigure.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/ExecutionSpecificationFigure.java
@@ -13,7 +13,6 @@ package org.eclipse.papyrus.uml.diagram.sequence.figure;
 
 import org.eclipse.draw2d.ConnectionAnchor;
 import org.eclipse.draw2d.Graphics;
-import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.draw2d.RectangleFigure;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PrecisionPoint;
@@ -54,9 +53,9 @@ public class ExecutionSpecificationFigure extends NodeFigure {
 				//
 				// Message anchors
 				//
-				case SIDE:
-					return new ExecutionSpecificationSideAnchor(this, anchorParser.getSide(terminal),
-							anchorParser.getDistanceFromReference(terminal));
+				case DISTANCE:
+				case FIXED:
+					return new ExecutionSpecificationSideAnchor(this, anchorParser.getDistance(terminal));
 				case START:
 					return new ExecutionSpecificationStartAnchor(this);
 				case END:
@@ -108,10 +107,10 @@ public class ExecutionSpecificationFigure extends NodeFigure {
 			return new ExecutionSpecificationEndAnchor(this);
 		}
 		if (p.x() <= (rect.width() / 2)) {
-			return new ExecutionSpecificationSideAnchor(this, PositionConstants.LEFT, p.y());
+			return new ExecutionSpecificationSideAnchor(this, p.y());
 		}
 		if (p.x() > (rect.width() / 2)) {
-			return new ExecutionSpecificationSideAnchor(this, PositionConstants.RIGHT, p.y());
+			return new ExecutionSpecificationSideAnchor(this, p.y());
 		}
 
 		return super.createAnchor(p);

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationSideAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationSideAnchor.java
@@ -11,6 +11,8 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.diagram.sequence.figure.anchors;
 
+import static org.eclipse.draw2d.PositionConstants.LEFT;
+
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.draw2d.AbstractConnectionAnchor;
 import org.eclipse.draw2d.IFigure;
@@ -25,11 +27,9 @@ public class ExecutionSpecificationSideAnchor extends AbstractConnectionAnchor i
 
 	private int height;
 
-	public ExecutionSpecificationSideAnchor(IFigure figure, int side, int height) {
+	public ExecutionSpecificationSideAnchor(IFigure figure, int height) {
 		super(figure);
-		Assert.isTrue(side == PositionConstants.LEFT || side == PositionConstants.RIGHT);
-
-		this.side = side;
+		this.side = LEFT;
 		this.height = height;
 	}
 
@@ -39,7 +39,7 @@ public class ExecutionSpecificationSideAnchor extends AbstractConnectionAnchor i
 		getOwner().translateToAbsolute(header);
 
 		Point location = new Point(0, height);
-		if (side == PositionConstants.LEFT) {
+		if (side == LEFT) {
 			location.translate(header.getTopLeft());
 		} else {
 			location.translate(header.getTopRight());
@@ -50,7 +50,8 @@ public class ExecutionSpecificationSideAnchor extends AbstractConnectionAnchor i
 
 	@Override
 	public String getTerminal() {
-		return AnchorParser.getInstance().getTerminal(AnchorKind.SIDE, side, height);
+		// no serialization of side, this is derived at runtime
+		return AnchorParser.getInstance().getTerminal(AnchorKind.DISTANCE, height);
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationSideAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationSideAnchor.java
@@ -19,7 +19,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.anchors.AnchorParser.AnchorKind;
 
-public class ExecutionSpecificationSideAnchor extends AbstractConnectionAnchor implements ISequenceAnchor {
+public class ExecutionSpecificationSideAnchor extends AbstractConnectionAnchor implements IExecutionAnchor {
 
 	private int side;
 
@@ -56,6 +56,15 @@ public class ExecutionSpecificationSideAnchor extends AbstractConnectionAnchor i
 	@Override
 	public String toString() {
 		return String.format("ExecAnchor(%s)", getTerminal()); //$NON-NLS-1$
+	}
+
+	@Override
+	public void setConnectionSide(int side) {
+		Assert.isTrue((side & PositionConstants.LEFT_CENTER_RIGHT) != 0);
+		if (side != this.side) {
+			this.side = side;
+			fireAnchorMoved();
+		}
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/AnchorFactory.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/AnchorFactory.java
@@ -278,17 +278,7 @@ class AnchorFactory {
 			} else if (distance >= layout.getHeight(getAnchorView())) {
 				result = END;
 			} else {
-				String side;
-				boolean isSelfMessage = sourceLifeline == targetLifeline;
-				if (isSelfMessage) {
-					// Self message always received on same side as sent
-					side = isLeftToRight() ? RIGHT : LEFT;
-				} else {
-					// Which direction?
-					side = (isLeftToRight() == isConnectionSource) ? RIGHT : LEFT;
-				}
-
-				result = side + distance;
+				result = Integer.toString(distance);
 			}
 
 			return result;

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/65-moving.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/65-moving.notation
@@ -70,13 +70,13 @@
     <element xmi:type="uml:Message" href="65-moving.uml#_OPil0OKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OPil0uKpEeix5N_q7jP6rA"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OPil0-KpEeix5N_q7jP6rA" id="89"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OPil1OKpEeix5N_q7jP6rA" id="left;77"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OPil1OKpEeix5N_q7jP6rA" id="77"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_Ox2BoOKpEeix5N_q7jP6rA" type="Edge_Message" source="_FTODw2pHEeiIJqtZNCF3Dw" target="_QWOLYIOnEeiaaZTinMWZHw">
     <element xmi:type="uml:Message" href="65-moving.uml#_Ox1akuKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ox2BoeKpEeix5N_q7jP6rA"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ox2BouKpEeix5N_q7jP6rA" id="305"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ox2Bo-KpEeix5N_q7jP6rA" id="left;293"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ox2Bo-KpEeix5N_q7jP6rA" id="293"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_k49CseKpEeix5N_q7jP6rA" type="Edge_Message" source="_QWOLYIOnEeiaaZTinMWZHw" target="_FTODw2pHEeiIJqtZNCF3Dw">
     <element xmi:type="uml:Message" href="65-moving.uml#_k49CsOKpEeix5N_q7jP6rA"/>
@@ -87,20 +87,20 @@
   <edges xmi:type="notation:Connector" xmi:id="_vx2e4uKpEeix5N_q7jP6rA" type="Edge_Message" source="_QWOLYIOnEeiaaZTinMWZHw" target="_vx3F8OKpEeix5N_q7jP6rA">
     <element xmi:type="uml:Message" href="65-moving.uml#_vx2e4eKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vx2e4-KpEeix5N_q7jP6rA"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx2e5OKpEeix5N_q7jP6rA" id="right;173"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx2e5OKpEeix5N_q7jP6rA" id="173"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx2e5eKpEeix5N_q7jP6rA" id="start"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_vx3F9eKpEeix5N_q7jP6rA" type="Edge_Message" source="_vx3F8OKpEeix5N_q7jP6rA" target="_QWOLYIOnEeiaaZTinMWZHw">
     <element xmi:type="uml:Message" href="65-moving.uml#_vx3F9OKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vx3F9uKpEeix5N_q7jP6rA"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx3F9-KpEeix5N_q7jP6rA" id="end"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx3F-OKpEeix5N_q7jP6rA" id="right;242"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx3F-OKpEeix5N_q7jP6rA" id="242"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_lN3PwON6Eeix-PwTlDMrnw" type="Edge_Message" source="_QWOLYIOnEeiaaZTinMWZHw" target="_S7leM-KpEeix5N_q7jP6rA">
     <children xmi:type="notation:DecorationNode" xmi:id="_lN3PweN6Eeix-PwTlDMrnw" type="Edge_Message_Name"/>
     <element xmi:type="uml:Message" href="65-moving.uml#_lN2oseN6Eeix-PwTlDMrnw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lN3PwuN6Eeix-PwTlDMrnw"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lN3Pw-N6Eeix-PwTlDMrnw" id="right;147"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lN3Pw-N6Eeix-PwTlDMrnw" id="147"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lN3PxON6Eeix-PwTlDMrnw" id="159"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_wDtX8ON6Eeix-PwTlDMrnw" type="Edge_Message" source="_F8jUo2pHEeiIJqtZNCF3Dw" target="_FTODw2pHEeiIJqtZNCF3Dw">

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionAnchorsUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionAnchorsUITest.java
@@ -1,0 +1,206 @@
+/*****************************************************************************
+ * Copyright (c) 2018 EclipseSource and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   EclipseSource - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Lifeline;
+import org.eclipse.uml2.uml.Message;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ModelResource("execution-busy.di")
+@Maximized
+public class ExecutionAnchorsUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@Rule
+	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+	@AutoFixture("Lifeline1")
+	private Lifeline lifeline1;
+
+	@AutoFixture
+	private EditPart lifeline1EP;
+
+	@AutoFixture("Lifeline2")
+	private Lifeline lifeline2;
+
+	@AutoFixture
+	private EditPart lifeline2EP;
+
+	@AutoFixture("Lifeline3")
+	private Lifeline lifeline3;
+
+	@AutoFixture
+	private EditPart lifeline3EP;
+
+	@AutoFixture("Lifeline4")
+	private Lifeline lifeline4;
+
+	@AutoFixture
+	private EditPart lifeline4EP;
+
+	@AutoFixture("request")
+	private Message request;
+
+	@AutoFixture
+	private EditPart requestEP;
+
+	@AutoFixture("m2")
+	private Message m2;
+
+	@AutoFixture
+	private EditPart m2EP;
+
+	@AutoFixture("m4")
+	private Message m4;
+
+	@AutoFixture
+	private EditPart m4EP;
+
+	@AutoFixture("reply")
+	private Message reply;
+
+	@AutoFixture
+	private EditPart replyEP;
+
+	@AutoFixture("Execution1")
+	private ExecutionSpecification execution1;
+
+	@AutoFixture
+	private EditPart execution1EP;
+
+	private Point request_source;
+
+	private Point m2_source;
+
+	private Point reply_source;
+
+	private Point lifeline2_header_center;
+
+	private Point lifeline1_header_center;
+
+	private Point request_target;
+
+	private Point m2_target;
+
+	private Point reply_target;
+
+	private Point m4_source;
+
+	private Point m4_target;
+
+	@Before
+	public void findFixtures() {
+		request_source = getSource(requestEP);
+		request_target = getTarget(requestEP);
+
+		m2_source = getSource(m2EP);
+		m2_target = getTarget(m2EP);
+
+		m4_source = getSource(m4EP);
+		m4_target = getTarget(m4EP);
+
+		reply_source = getSource(replyEP);
+		reply_target = getTarget(replyEP);
+
+		lifeline1_header_center = getBounds(lifeline1EP).getCenter();
+		lifeline2_header_center = getBounds(lifeline2EP).getCenter();
+	}
+
+	@After
+	public void checkAfter() {
+		editor.undo();
+		assertEquals(request_source, getSource(requestEP));
+		assertEquals(request_target, getTarget(requestEP));
+
+		assertEquals(request_source, getSource(requestEP));
+		assertEquals(request_target, getTarget(requestEP));
+
+		assertEquals(m2_source, getSource(m2EP));
+		assertEquals(m2_target, getTarget(m2EP));
+
+		assertEquals(m4_source, getSource(m4EP));
+		assertEquals(m4_target, getTarget(m4EP));
+	}
+
+	@Test
+	public void moveLifeline2ToRight() {
+		/* action */
+		// move between Lifeline3 & Lifeline4
+		Point end = getBounds(lifeline3EP).getRight().translate(30, 0);
+		editor.with(editor.allowSemanticReordering(),
+				() -> editor.moveSelection(lifeline2_header_center, end));
+
+		/* check new state */
+		Point new_lifeline2_header_center = getBounds(lifeline2EP).getCenter().getCopy();
+		// Do not depend on good implementation for moving lifeline... (5 picels offset
+		// at the time this test was written)
+		int lifeline2Offset = new_lifeline2_header_center.x() - lifeline2_header_center.x;
+		// Do not depend on good implementation for moving lifeline... (5 picels offset
+		// at the time this test was written)
+
+		Point new_request_target = getTarget(requestEP);
+		// check the anchor has moved on the right place...
+		assertThat(new_request_target, equalTo(request_target.getCopy().translate(lifeline2Offset, 0)));
+
+		Point new_m2_source = getSource(m2EP);
+		// check the anchor has moved on the right place...
+		assertThat(new_m2_source, equalTo(m2_source.getCopy().translate(lifeline2Offset - EXEC_WIDTH, 0)));
+
+		Point new_m4_target = getTarget(m4EP);
+		// check the anchor has moved on the right place...
+		assertThat(new_m4_target, equalTo(m4_target.getCopy().translate(lifeline2Offset, 0)));
+
+		Point new_reply_source = getSource(replyEP);
+		// check the anchor has moved on the right place...
+		assertThat(new_reply_source, equalTo(reply_source.getCopy().translate(lifeline2Offset, 0)));
+	}
+
+	@Test
+	public void moveLifeline1ToRight() {
+		/* action */
+		Point end = getBounds(lifeline2EP).getRight().translate(30, 0);
+		editor.with(editor.allowSemanticReordering(),
+				() -> editor.moveSelection(lifeline1_header_center, end));
+
+		/* check new state */
+		Point new_lifeline1_header_center = getBounds(lifeline1EP).getCenter().getCopy();
+		int lifeline1Offset = new_lifeline1_header_center.x() - lifeline1_header_center.x;
+
+		Point new_request_target = getTarget(requestEP);
+		assertThat(new_request_target, equalTo(request_target.getCopy().translate(EXEC_WIDTH, 0)));
+
+		Point new_m2_source = getSource(m2EP);
+		assertThat(new_m2_source, equalTo(m2_source)); // no move
+
+		Point new_m4_target = getTarget(m4EP);
+		assertThat(new_m4_target, equalTo(m4_target)); // no move
+
+		Point new_reply_source = getSource(replyEP);
+		assertThat(new_reply_source, equalTo(reply_source.getCopy().translate(EXEC_WIDTH, 0)));
+		Point new_reply_target = getTarget(replyEP);
+		assertThat(new_reply_target, equalTo(reply_target.getCopy().translate(lifeline1Offset, 0)));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionMoveUITest.java
@@ -15,95 +15,61 @@ package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isBounded;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.at;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
-import java.util.Iterator;
-
 import org.eclipse.gef.EditPart;
-import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
-import org.eclipse.papyrus.infra.gmfdiag.common.utils.DiagramEditPartsUtil;
-import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.ExecutionSpecificationEditPart;
-import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.LifelineHeaderEditPart;
-import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.MessageEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
-import org.eclipse.uml2.uml.ExecutionSpecification;
-import org.eclipse.uml2.uml.Lifeline;
-import org.eclipse.uml2.uml.Message;
 import org.junit.Test;
 
 /**
  * UI tests for Execution and nested executions move
  */
-@SuppressWarnings("restriction")
 @ModelResource("nested-execution.di")
 @Maximized
 public class ExecutionMoveUITest extends AbstractGraphicalEditPolicyUITest {
 
 	private static final int LIFELINE_1__BODY_X = 155;
-	private static final int LIFELINE_2__BODY_X = 288;
+
 	private static final int LIFELINE_3__BODY_X = 426;
 
 	private static final int NESTED_EXEC_OFFSET = 19;
-	private static final int NESTED_EXEC_HEIGHT = 40;
 
-	private static final int EXEC_WIDTH = 10;
+	private static final int NESTED_EXEC_HEIGHT = 40;
 
 	@Test
 	public void moveSyncMessageEnd() {
 		/* initial state - check message end position */
-		EditPart syncEP = requireMessage("nested-execution::interaction1::sync");
+		EditPart syncEP = findEditPart("nested-execution::interaction1::sync", true);
 		int sync_y = getTargetY(syncEP);
 
-		EditPart replyEP = requireMessage("nested-execution::interaction1::reply");
+		EditPart replyEP = findEditPart("nested-execution::interaction1::reply", true);
 		int reply_y = getSourceY(replyEP);
 
-		EditPart exec1EP = requireExecution("nested-execution::interaction1::exec1");
-		assumeThat(exec1EP, isBounded(LIFELINE_3__BODY_X - EXEC_WIDTH / 2, sync_y, EXEC_WIDTH, reply_y - sync_y));
+		EditPart exec1EP = findEditPart("nested-execution::interaction1::exec1", false);
+		assumeThat(exec1EP,
+				isBounded(LIFELINE_3__BODY_X - EXEC_WIDTH / 2, sync_y, EXEC_WIDTH, reply_y - sync_y));
 
-		EditPart nestedExecEP = requireExecution("nested-execution::interaction1::nestedExec");
+		EditPart nestedExecEP = findEditPart("nested-execution::interaction1::nestedExec", false);
 		assumeThat(nestedExecEP,
-				isBounded(LIFELINE_3__BODY_X, sync_y+NESTED_EXEC_OFFSET, EXEC_WIDTH, NESTED_EXEC_HEIGHT));
+				isBounded(LIFELINE_3__BODY_X, sync_y + NESTED_EXEC_OFFSET, EXEC_WIDTH, NESTED_EXEC_HEIGHT));
 
 		/* move message end on Lifeline1 */
-		editor.with(editor.allowSemanticReordering(), () -> editor
-				.moveSelection(at(LIFELINE_3__BODY_X - EXEC_WIDTH / 2, sync_y), at(LIFELINE_1__BODY_X, sync_y)));
+		editor.with(editor.allowSemanticReordering(),
+				() -> editor.moveSelection(at(LIFELINE_3__BODY_X - EXEC_WIDTH / 2, sync_y),
+						at(LIFELINE_1__BODY_X, sync_y)));
 
 		/*
 		 * check result - execution and nested execution have moved to the right place
 		 */
-		exec1EP = requireExecution("nested-execution::interaction1::exec1");
-		assertThat(exec1EP, isBounded(LIFELINE_1__BODY_X - EXEC_WIDTH / 2, sync_y, EXEC_WIDTH, reply_y - sync_y));
+		exec1EP = findEditPart("nested-execution::interaction1::exec1", false);
+		assertThat(exec1EP,
+				isBounded(LIFELINE_1__BODY_X - EXEC_WIDTH / 2, sync_y, EXEC_WIDTH, reply_y - sync_y));
 
-		nestedExecEP = requireExecution("nested-execution::interaction1::nestedExec");
+		nestedExecEP = findEditPart("nested-execution::interaction1::nestedExec", false);
 		assumeThat(nestedExecEP,
 				isBounded(LIFELINE_1__BODY_X, sync_y + NESTED_EXEC_OFFSET, EXEC_WIDTH, NESTED_EXEC_HEIGHT));
 
 	}
 
-	private MessageEditPart requireMessage(String qualifiedName) {
-		Message message = editor.getElement(qualifiedName, Message.class);
-		Iterator<IGraphicalEditPart> it = DiagramEditPartsUtil
-				.getChildrenByEObject(message, editor.getDiagramEditPart(), true).iterator();
-		if(it.hasNext()) {
-			IGraphicalEditPart ep = it.next();
-			if (MessageEditPart.class.isInstance(ep)) {
-				return MessageEditPart.class.cast(ep);
-			}
-		}
-		fail("impossible to get Message edit part "+qualifiedName);
-		return null;
-	}
-
-	private LifelineHeaderEditPart requireLifeline(String qualifiedName) {
-		Lifeline lifeline = editor.getElement(qualifiedName, Lifeline.class);
-		return (LifelineHeaderEditPart) editor.getDiagramEditPart().findEditPart(editor.getDiagramEditPart(), lifeline);
-	}
-
-	private ExecutionSpecificationEditPart requireExecution(String qualifiedName) {
-		ExecutionSpecification spec = editor.getElement(qualifiedName, ExecutionSpecification.class);
-		return (ExecutionSpecificationEditPart) editor.getDiagramEditPart().findEditPart(editor.getDiagramEditPart(),
-				spec);
-	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-busy.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-busy.notation
@@ -67,19 +67,19 @@
   <edges xmi:type="notation:Connector" xmi:id="_cNxC0MvBEei-2PpXSl-dWw" type="Edge_Message" source="_FtukYMvBEei-2PpXSl-dWw" target="__vCYY8vAEei-2PpXSl-dWw">
     <element xmi:type="uml:Message" href="execution-busy.uml#_cNv0ssvBEei-2PpXSl-dWw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cNxC0cvBEei-2PpXSl-dWw"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cNxC0svBEei-2PpXSl-dWw" id="right;28"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cNxC0svBEei-2PpXSl-dWw" id="28"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cNxC08vBEei-2PpXSl-dWw" id="81"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_ea4aoMvBEei-2PpXSl-dWw" type="Edge_Message" source="_FtukYMvBEei-2PpXSl-dWw" target="_DdgOM8vBEei-2PpXSl-dWw">
     <element xmi:type="uml:Message" href="execution-busy.uml#_ea3zkMvBEei-2PpXSl-dWw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ea4aocvBEei-2PpXSl-dWw"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ea4aosvBEei-2PpXSl-dWw" id="right;53"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ea4aosvBEei-2PpXSl-dWw" id="53"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ea4ao8vBEei-2PpXSl-dWw" id="106"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_fUBCEsvBEei-2PpXSl-dWw" type="Edge_Message" source="_DdgOM8vBEei-2PpXSl-dWw" target="_FtukYMvBEei-2PpXSl-dWw">
     <element xmi:type="uml:Message" href="execution-busy.uml#_fUBCEcvBEei-2PpXSl-dWw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fUBCE8vBEei-2PpXSl-dWw"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fUBCFMvBEei-2PpXSl-dWw" id="131"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fUBCFcvBEei-2PpXSl-dWw" id="right;78"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fUBCFcvBEei-2PpXSl-dWw" id="78"/>
   </edges>
 </notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/kitchen-sink.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/kitchen-sink.notation
@@ -66,14 +66,14 @@
   <edges xmi:type="notation:Connector" xmi:id="_Hy6y48GHEeiBUataQqP5Qw" type="Edge_Message" source="_BRwzAMGHEeiBUataQqP5Qw" target="_qA2RQ8GGEeiBUataQqP5Qw">
     <element xmi:type="uml:Message" href="kitchen-sink.uml#_Hy6y4sGHEeiBUataQqP5Qw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Hy6y5MGHEeiBUataQqP5Qw"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hy6y5cGHEeiBUataQqP5Qw" id="right;35"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hy6y5cGHEeiBUataQqP5Qw" id="35"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hy6y5sGHEeiBUataQqP5Qw" id="204"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_Uhk208GHEeiBUataQqP5Qw" type="Edge_Message" source="_qA2RQ8GGEeiBUataQqP5Qw" target="_NLtcgMGHEeiBUataQqP5Qw">
     <element xmi:type="uml:Message" href="kitchen-sink.uml#_Uhk20sGHEeiBUataQqP5Qw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Uhk21MGHEeiBUataQqP5Qw"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhk21cGHEeiBUataQqP5Qw" id="229"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhk21sGHEeiBUataQqP5Qw" id="left;14"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Uhk21sGHEeiBUataQqP5Qw" id="14"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_VulchcGHEeiBUataQqP5Qw" type="Edge_Message" source="_qA2RQ8GGEeiBUataQqP5Qw" target="_Vulcg8GHEeiBUataQqP5Qw">
     <element xmi:type="uml:Message" href="kitchen-sink.uml#_VulcgsGHEeiBUataQqP5Qw"/>


### PR DESCRIPTION
- anchor now ignores the position on the notation, and only computes its
side  as it is done with start/finish anchors. A better solution may be
to only save height, and migrate all existing test models.
- add tests
