### PR TITLE
Auto-correct lifeline of an executions' reply message

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
@@ -322,8 +322,16 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 		return Optional.empty();
 	}
 
-	private boolean anyDestructionOccurrenceBefore(OptionalInt y) {
-		Optional<MElement<?>> elementBefore = lifeline.elementAt(y.orElse(Integer.MAX_VALUE));
+	private boolean anyDestructionOccurrenceBefore(OptionalInt absoluteY) {
+		int llRelativeY = Integer.MAX_VALUE;
+		if (absoluteY.isPresent()) {
+			int lifelineOffset = layoutHelper().getBottom(lifeline.getDiagramView().get());
+			llRelativeY = absoluteY.getAsInt() - lifelineOffset;
+		}
+		Optional<MElement<?>> elementBefore = lifeline.elementAt(llRelativeY);
+		if (!elementBefore.isPresent()) {
+			return false;
+		}
 		List<MOccurrence<?>> occurrences = lifeline.getOccurrences();
 		int indexOfElementBefore = elementBefore.map(occurrences::indexOf)
 				.orElse(Integer.valueOf(occurrences.size())).intValue();

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
@@ -70,6 +70,8 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 	// The element on the lifeline before which we're inserting our occurrence
 	private final Optional<MElement<? extends Element>> nextOnLifeline;
 
+	private final boolean handleOppositeSendOrReply;
+
 	/**
 	 * Initializes me.
 	 *
@@ -77,6 +79,11 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 	 */
 	public SetCoveredCommand(MOccurrenceImpl<? extends Element> end, MLifeline lifeline,
 			OptionalInt yPosition) {
+		this(end, lifeline, yPosition, true);
+	}
+
+	protected SetCoveredCommand(MOccurrenceImpl<? extends Element> end, MLifeline lifeline,
+			OptionalInt yPosition, boolean handleOppositeSendOrReplyOfExecution) {
 		super(end);
 
 		this.lifeline = lifeline;
@@ -84,6 +91,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 
 		nextOnLifeline = Lifelines.elementAfterAbsolute(lifeline,
 				yPosition.orElseGet(() -> end.getTop().orElse(0)));
+		this.handleOppositeSendOrReply = handleOppositeSendOrReplyOfExecution;
 	}
 
 	protected boolean isChangingLifeline() {
@@ -243,10 +251,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 			Supplier<Shape> newAttachedShape = () -> {
 				// Are we connected to an execution that will be moving with us?
 				// If so, no reattachment will be necessary
-				Optional<MExecution> exec = (end.isFinish() || end.isStart()) //
-						? end.getExecution()
-						: Optional.empty();
-				Optional<Shape> executionShape = exec.flatMap(MExecution::getDiagramView);
+				Optional<Shape> executionShape = getExecution(end).flatMap(MExecution::getDiagramView);
 				if (!executionShape.isPresent()) {
 					// Are we connecting to an execution specification?
 					executionShape = executionShapeAt(lifeline, newYPosition);
@@ -257,11 +262,15 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 			if (end.isSend()) {
 				commandSink.accept(defer(
 						() -> reconnectSource(connector, newAttachedShape.get(), newYPosition).orElse(null)));
-				end.getOtherEnd().flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
+				Optional<MMessageEnd> otherEnd = end.getOtherEnd();
+				otherEnd.flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
+				otherEnd.flatMap(this::handleOppositeSendOrReplyMessage).ifPresent(commandSink);
 			} else if (end.isReceive()) {
 				commandSink.accept(defer(
 						() -> reconnectTarget(connector, newAttachedShape.get(), newYPosition).orElse(null)));
-				end.getOtherEnd().flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
+				Optional<MMessageEnd> otherEnd = end.getOtherEnd();
+				otherEnd.flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
+				otherEnd.flatMap(this::handleOppositeSendOrReplyMessage).ifPresent(commandSink);
 			} // else don't know what to do with it
 		}
 
@@ -273,6 +282,55 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 			// Track this end
 			otherCovered.map(ll -> opposite.setCovered(ll, yPosition)).ifPresent(commandSink);
 		}
+	}
+
+	private Optional<Command> handleOppositeSendOrReplyMessage(MMessageEnd otherEnd) {
+		if (!handleOppositeSendOrReply) {
+			return Optional.empty();
+		}
+
+		Optional<MExecution> execution = getExecution(otherEnd);
+		Optional<MMessage> startMessage = getStartMessage(execution);
+		Optional<MMessage> finishMessage = getFinishMessage(execution);
+		if (!execution.isPresent() || !startMessage.isPresent() || !finishMessage.isPresent()) {
+			return Optional.empty();
+		}
+
+		Optional<MMessageEnd> endToMove = Optional.empty();
+		Optional<OptionalInt> targetY = Optional.empty();
+		if (otherEnd.isStart()) {
+			endToMove = finishMessage.get().getReceive();
+			targetY = endToMove.map(MMessageEnd::getBottom);
+		} else if (otherEnd.isFinish()) {
+			endToMove = startMessage.get().getSend();
+			targetY = endToMove.map(MMessageEnd::getTop);
+		}
+
+		if (endToMove.isPresent() && endToMove.get() instanceof MOccurrenceImpl<?>) {
+			MOccurrenceImpl<?> occurrence = (MOccurrenceImpl<?>)endToMove.get();
+			if (occurrence.getCovered().filter(l -> l != lifeline).isPresent() && occurrence != getTarget()) {
+				OptionalInt y = targetY.orElse(occurrence.getBottom());
+				return Optional.of(new SetCoveredCommand(occurrence, lifeline, y, false));
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	private Optional<MExecution> getExecution(MMessageEnd end) {
+		return (end.isFinish() || end.isStart()) //
+				? end.getExecution()
+				: Optional.empty();
+	}
+
+	private Optional<MMessage> getStartMessage(Optional<MExecution> execution) {
+		return execution.flatMap(MExecution::getStart).filter(MMessageEnd.class::isInstance)
+				.map(MMessageEnd.class::cast).map(MMessageEnd::getOwner);
+	}
+
+	private Optional<MMessage> getFinishMessage(Optional<MExecution> execution) {
+		return execution.flatMap(MExecution::getFinish).filter(MMessageEnd.class::isInstance)
+				.map(MMessageEnd.class::cast).map(MMessageEnd::getOwner);
 	}
 
 	Optional<Command> handleSelfMessageChange(MMessageEnd otherEnd) {


### PR DESCRIPTION
When re-orienting a message that has an end being the start or finish of
an execution, this change also re-orients the opposite accordingly, so
that both eventually start/finish on the same lifeline.

With that, we ensure the validity of the following constraint:
If a reply message finishes the specification, this is, the finish
occurrence specification of the execution specification corresponds with
the send event message occurrence specification of the reply message,
the receive event of the message must be located in the same lifeline
than the send event of the message starting the execution specification,
if any.

Fix #42

Signed-off-by: Philip Langer <planger@eclipsesource.com>