### PR TITLE
Issue #364 - Anchor position when inserting messages with nudging

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertMessageCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertMessageCommand.java
@@ -12,7 +12,6 @@
 
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
-import static java.lang.Integer.MAX_VALUE;
 import static org.eclipse.papyrus.uml.interaction.graph.util.CrossReferenceUtil.invertSingle;
 import static org.eclipse.papyrus.uml.interaction.graph.util.Suppliers.compose;
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelOrdering.vertically;
@@ -65,6 +64,7 @@ import org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.RelativeP
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.SemanticHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
+import org.eclipse.papyrus.uml.interaction.model.util.Executions;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.Interaction;
@@ -291,15 +291,7 @@ public class InsertMessageCommand extends ModelCommand.Creation<MLifelineImpl, M
 		int absoluteSendY = absoluteSendYReference().getAsInt();
 		int absoluteRecvY = absoluteReceiveYReference().getAsInt();
 
-		// Send: Is there actually an execution occurrence here?
-		int llTopSend = layoutHelper().getBottom(getTarget().getDiagramView().get());
-		int whereSend = beforeSend == getTarget() ? sendOffset
-				// For executions also the top to allow for messages to anchor within it
-				: beforeSend.getTop().orElse(llTopSend) - llTopSend + sendOffset;
-		Optional<MExecution> sendingExec = getTarget().elementAt(whereSend).flatMap(this::getExecution)
-				.filter(exec -> //
-		((exec.getBottom().orElse(-1) - llTopSend) >= whereSend) //
-				&& ((exec.getTop().orElse(MAX_VALUE) - llTopSend) <= whereSend));
+		Optional<MExecution> sendingExec = Executions.executionAt(getTarget(), absoluteSendY);
 		Vertex sender = sendingExec.map(this::vertex).orElseGet(this::vertex);
 		if (sender == null || sender.getDiagramView() == null) {
 			return UnexecutableCommand.INSTANCE;
@@ -319,9 +311,11 @@ public class InsertMessageCommand extends ModelCommand.Creation<MLifelineImpl, M
 				receivingExec = Optional.empty();
 				break;
 			default:
-				receivingExec = this.receiver.elementAt(whereRecv).flatMap(this::getExecution).filter(exec -> //
-				((exec.getBottom().orElse(-1) - llTopRecv) >= whereRecv) //
-						&& ((exec.getTop().orElse(MAX_VALUE) - llTopRecv) <= whereRecv));
+				receivingExec = Executions.executionAt(receiver, absoluteRecvY);
+
+				// this.receiver.elementAt(whereRecv).flatMap(this::getExecution).filter(exec -> //
+				// ((exec.getBottom().orElse(-1) - llTopRecv) >= whereRecv) //
+				// && ((exec.getTop().orElse(MAX_VALUE) - llTopRecv) <= whereRecv));
 				break;
 		}
 		@SuppressWarnings("hiding")

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Executions.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Executions.java
@@ -39,7 +39,7 @@ public class Executions {
 		return parentLifelineView(as(view.map(EObject::eContainer), View.class));
 	}
 
-	public static Optional<Shape> executionShapeAt(MLifeline lifeline, int absoluteY) {
+	public static Optional<MExecution> executionAt(MLifeline lifeline, int absoluteY) {
 		Predicate<MExecution> spanning = PendingVerticalExtentData.spans(absoluteY);
 
 		Optional<MExecution> movingToLifeline = as(PendingChildData.getPendingChild(lifeline),
@@ -47,11 +47,14 @@ public class Executions {
 
 		if (movingToLifeline.isPresent()) {
 			// Easy case
-			return movingToLifeline.flatMap(MExecution::getDiagramView);
+			return movingToLifeline;
 		}
 
-		return lifeline.getExecutions().stream().filter(spanning).max(LogicalModelOrdering.vertically())
-				.flatMap(MExecution::getDiagramView);
+		return lifeline.getExecutions().stream().filter(spanning).max(LogicalModelOrdering.vertically());
+	}
+
+	public static Optional<Shape> executionShapeAt(MLifeline lifeline, int absoluteY) {
+		return executionAt(lifeline, absoluteY).flatMap(MExecution::getDiagramView);
 	}
 
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionAnchorsUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionAnchorsUITest.java
@@ -11,12 +11,16 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
 
+import static org.eclipse.papyrus.uml.diagram.sequence.figure.magnets.IMagnetManager.MODIFIER_NO_SNAPPING;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.MessageEditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
@@ -203,4 +207,32 @@ public class ExecutionAnchorsUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat(new_reply_target, equalTo(reply_target.getCopy().translate(lifeline1Offset, 0)));
 	}
 
+	@Test
+	public void checkAnchorOnNudge() {
+		final int OFFSET = 25; // ensure no padding (20 above, 5 below)
+		// message will be created below m4, in inverse direction (from exec1 to lifeline 4)
+		Point mouseStart = m4_target.getCopy().translate(-2, OFFSET);
+		Point mouseEnd = m4_source.getCopy().translate(0, OFFSET);
+
+		MessageEditPart newMessage = (MessageEditPart)editor.with(editor.modifierKey(MODIFIER_NO_SNAPPING),
+				() -> createConnection(SequenceElementTypes.Async_Message_Edge, mouseStart, mouseEnd));
+
+		assertThat(getSource(newMessage), isPoint(m4_target.getCopy().translate(0, OFFSET)));
+		assertThat(getTarget(newMessage), isPoint(mouseEnd));
+	}
+
+	@Test
+	public void checkAnchorOnNudgeWithPadding() {
+		final int OFFSET = 20; // ensure no padding (20 above, 5 below)
+		// message will be created below m4, in inverse direction (from exec1 to lifeline 4)
+		Point mouseStart = m4_target.getCopy().translate(-2, OFFSET);
+		Point mouseEnd = m4_source.getCopy().translate(0, OFFSET);
+
+		MessageEditPart newMessage = (MessageEditPart)editor.with(editor.modifierKey(MODIFIER_NO_SNAPPING),
+				() -> createConnection(SequenceElementTypes.Async_Message_Edge, mouseStart, mouseEnd));
+
+		// Element was adding a bit below due to padding
+		assertThat(getSource(newMessage), isPoint(m4_target.getCopy().translate(0, 25)));
+		assertThat(getTarget(newMessage), isPoint(mouseEnd.getCopy().translate(0, 5))); // offest from padding
+	}
 }


### PR DESCRIPTION
note: Based on branch for anchor positions fixes. The PR #405 should be reviewed first.

This modifies the computation of the potential execution spanning over the lifeline. So this should be compliant with nested executions, and this should also  fix the wrong anchor creation when inserting a message on the lifeline.

