### PR TITLE
Fix #68 Move executions on lifeline

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/DeferredPaddingCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/DeferredPaddingCommand.java
@@ -13,6 +13,7 @@
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.above;
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.below;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.mapToInt;
 
@@ -43,11 +44,13 @@ import org.eclipse.uml2.uml.Element;
  */
 public class DeferredPaddingCommand extends CommandWrapper {
 
+	private static final Comparator<MElement<?>> ORDERING = LogicalModelOrdering.semantically();
+
 	private MElement<? extends Element> referenceElement;
 
 	private MElement<? extends Element> nudgeElement;
 
-	private Comparator<MElement<?>> ordering = LogicalModelOrdering.semantically();
+	private PaddingDirection direction = PaddingDirection.NONE;
 
 	/**
 	 * Not instantiable by clients.
@@ -88,18 +91,33 @@ public class DeferredPaddingCommand extends CommandWrapper {
 			// Have now determined that padding is not required
 			referenceElement = null;
 			nudgeElement = null;
-		} else if ((referenceElement == null) || before(referenceElement, from)) {
+			direction = PaddingDirection.NONE;
+		} else if (referenceElement == null) {
 			referenceElement = from;
 			nudgeElement = to;
-		} else if ((nudgeElement == null) || before(to, nudgeElement)) {
+
+			if (before(from, nudgeElement)) {
+				// Implies downward nudging
+				direction = PaddingDirection.DOWN;
+			} else {
+				direction = PaddingDirection.UP;
+			}
+		} else if (direction.updateReference(referenceElement, from)) {
+			referenceElement = from;
+			nudgeElement = to;
+		} else if (direction.updateNudge(nudgeElement, referenceElement, to)) {
 			// Nudge the closer element
 			nudgeElement = to;
 		}
 		return this;
 	}
 
-	private boolean before(MElement<? extends Element> a, MElement<? extends Element> b) {
-		return (a.getElement() != b.getElement()) && (a.precedes(b) || (ordering.compare(a, b) < 0));
+	private static boolean before(MElement<? extends Element> a, MElement<? extends Element> b) {
+		return (a.getElement() != b.getElement()) && (a.precedes(b) || (ORDERING.compare(a, b) < 0));
+	}
+
+	private static boolean after(MElement<? extends Element> a, MElement<? extends Element> b) {
+		return (a.getElement() != b.getElement()) && (b.precedes(a) || (ORDERING.compare(b, a) < 0));
 	}
 
 	@Override
@@ -122,7 +140,23 @@ public class DeferredPaddingCommand extends CommandWrapper {
 			return IdentityCommand.INSTANCE;
 		}
 
-		Command result = nudgeElement.nudge(nudgeY);
+		Command result;
+		switch (direction) {
+			case DOWN:
+				result = nudgeElement.nudge(nudgeY);
+				break;
+			case UP:
+				// An "upward" nudge doesn't actually nudge anything up because the diagram can
+				// only expand downwards (lifeline heads are fixed). Rather, we ensure space
+				// by nudging down the element that was moved up, but also everything following
+				// it so that the layout is consistent
+				result = referenceElement.nudge(nudgeY);
+				break;
+			default:
+				result = null;
+				break;
+		}
+
 		if (result == null) {
 			// Can't nudge this element
 			result = UnexecutableCommand.INSTANCE;
@@ -132,14 +166,16 @@ public class DeferredPaddingCommand extends CommandWrapper {
 	}
 
 	protected int computeNudgeAmount() {
-		if ((nudgeElement == null) || (referenceElement == null)) {
+		if ((direction == PaddingDirection.NONE) || (nudgeElement == null) || (referenceElement == null)) {
 			return 0;
 		}
 
 		MElement<? extends Element> padFrom = getPaddableElement(referenceElement);
 		MElement<? extends Element> padElement = getPaddableElement(nudgeElement);
 
-		if (padFrom.getElement() == padElement.getElement() || above(padFrom).test(padElement)) {
+		if ((padFrom.getElement() == padElement.getElement())
+				|| ((direction == PaddingDirection.DOWN) && above(padFrom).test(padElement))
+				|| ((direction == PaddingDirection.UP) && below(padFrom).test(padElement))) {
 			// This would happen, for example, when re-targeting a message bringins along an
 			// execution specification that emits a message terminating on the re-targeted
 			// message's new receiving lifeline
@@ -157,7 +193,18 @@ public class DeferredPaddingCommand extends CommandWrapper {
 				view -> constraints.getPadding(RelativePosition.TOP, view));
 
 		int requiredPadding = referencePadding.orElse(0) + nudgeePadding.orElse(0);
-		int gap = nudgeElement.verticalDistance(referenceElement).orElse(0);
+		int gap;
+
+		switch (direction) {
+			case DOWN:
+				gap = nudgeElement.verticalDistance(referenceElement).orElse(0);
+				break;
+			case UP:
+				gap = referenceElement.verticalDistance(nudgeElement).orElse(0);
+				break;
+			default:
+				throw new IllegalStateException("no nudge direction"); //$NON-NLS-1$
+		}
 
 		return Math.max(0, requiredPadding - gap);
 	}
@@ -179,5 +226,40 @@ public class DeferredPaddingCommand extends CommandWrapper {
 				return object;
 			}
 		}.doSwitch(element);
+	}
+
+	//
+	// Nested types
+	//
+
+	/**
+	 * Enumeration of direction in which padding may be applied.
+	 */
+	private static enum PaddingDirection {
+		NONE, DOWN, UP;
+
+		boolean updateReference(MElement<? extends Element> reference, MElement<? extends Element> from) {
+			switch (this) {
+				case DOWN:
+					return before(reference, from);
+				case UP:
+					return after(reference, from);
+				default:
+					return false;
+			}
+		}
+
+		boolean updateNudge(MElement<? extends Element> nudge, MElement<? extends Element> from,
+				MElement<? extends Element> to) {
+			switch (this) {
+				case DOWN:
+					return after(to, from) && before(to, nudge);
+				case UP:
+					return before(to, from) && after(to, nudge);
+				default:
+					return false;
+			}
+		}
+
 	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Lifelines.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Lifelines.java
@@ -12,6 +12,7 @@
 
 package org.eclipse.papyrus.uml.interaction.model.util;
 
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.above;
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.below;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.elseMaybe;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.flatMapToObj;
@@ -69,6 +70,12 @@ public class Lifelines {
 		return elseMaybe(elementAtAbsolute(lifeline, y).flatMap(elem -> lifeline.following(elem)),
 				// Otherwise, the first element on the lifeline (if any and it's below this point)
 				() -> lifeline.following().filter(below(y)));
+	}
+
+	public static Optional<MElement<? extends Element>> elementBeforeAbsolute(MLifeline lifeline, int y) {
+		// Note that the "element at" is often actually above; that's what element-at means
+		return elementAtAbsolute(lifeline, y)
+				.flatMap(elem -> elseMaybe(Optional.of(elem).filter(above(y)), lifeline.preceding(elem)));
 	}
 
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -292,6 +292,18 @@ public class ExecutionSpecificationDragEditPolicyUITest {
 		@AutoFixture
 		private EditPart exec2EP;
 
+		@AutoFixture
+		private Message sync2;
+
+		@AutoFixture
+		private EditPart sync2EP;
+
+		@AutoFixture
+		private Message reply2;
+
+		@AutoFixture
+		private EditPart reply2EP;
+
 		/**
 		 * Initializes me.
 		 */
@@ -326,8 +338,59 @@ public class ExecutionSpecificationDragEditPolicyUITest {
 					runs(isPoint(async2Geom.getFirstPoint()), isPoint(async2Geom.getLastPoint())));
 			assertThat("Async message 3 was changed", async3EP,
 					runs(isPoint(async3Geom.getFirstPoint()), isPoint(async3Geom.getLastPoint())));
-			assertThat("Execution started by sunc message 2 not moved", exec2EP,
+			assertThat("Execution started by sync message 2 not moved", exec2EP,
 					isAt(isPoint(exec2Geom.getLocation())));
+		}
+
+		@Test
+		public void moveExecutionToSpanMessage() {
+			int delta = -75;
+
+			PointList sync2Geom = getPoints(sync2EP);
+			PointList async3Geom = getPoints(async3EP);
+			PointList reply2Geom = getPoints(reply2EP);
+
+			// First, select the execution to activate selection handles
+			Point grabAt = getCenter(exec2EP);
+			editor.select(grabAt);
+
+			Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+			editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+
+			sync2Geom.translate(0, delta);
+			// async3 doesn't move up, but adjusts its receive end to attach to the execution
+			async3Geom.setPoint(async3Geom.getLastPoint().getTranslated(-EXEC_WIDTH / 2, 0), 1);
+			reply2Geom.translate(0, delta);
+
+			assertThat("Request message 2 was not moved", sync2EP,
+					runs(isPoint(sync2Geom.getFirstPoint()), isPoint(sync2Geom.getLastPoint())));
+			assertThat("Reply message 2 was not moved", reply2EP,
+					runs(isPoint(reply2Geom.getFirstPoint()), isPoint(reply2Geom.getLastPoint())));
+			assertThat("Async message 3 not properly attached to execution", async3EP,
+					runs(isPoint(async3Geom.getFirstPoint()), isPoint(async3Geom.getLastPoint())));
+		}
+
+		@Test
+		public void attemptExecutionToSpanMessage() {
+			int delta = -75;
+
+			PointList sync2Geom = getPoints(sync2EP);
+			PointList async3Geom = getPoints(async3EP);
+			PointList reply2Geom = getPoints(reply2EP);
+
+			// First, select the execution to activate selection handles
+			Point grabAt = getCenter(exec2EP);
+			editor.select(grabAt);
+
+			Point dropAt = new Point(grabAt.x(), grabAt.y() + delta);
+			editor.drag(grabAt, dropAt);
+
+			assertThat("Request message 2 was changed", sync2EP,
+					runs(isPoint(sync2Geom.getFirstPoint()), isPoint(sync2Geom.getLastPoint())));
+			assertThat("Reply message 2 was changed", reply2EP,
+					runs(isPoint(reply2Geom.getFirstPoint()), isPoint(reply2Geom.getLastPoint())));
+			assertThat("Async message 3 was changed", async3EP,
+					runs(isPoint(async3Geom.getFirstPoint()), isPoint(async3Geom.getLastPoint())));
 		}
 
 	}


### PR DESCRIPTION
Implement some left-over details of moving executions up and down a lifeline that were not already addressed by #404 for issue #70:

- when moving an execution to encompass existing message ends on the lifeline, they would be bumped out of the way instead of simply attached to the execution where it ended up
- when moving an execution up, padding from the previous interaction fragment of whatever kind on that lifeline wasn't ensured as it was from the next fragment when moving the interaction down

**Note** that ensuring padding is always done by nudging elements down, whether to make room for an element being moved down (such as an execution in our case) or by nudging down the elements that were moved up into proximity to others.  However, there are problems with that nudge implementation that result in some weirdly sloped messages and possibly other layout issues.  Those aren't in scope of this issue at hand; there are other issues covering nudge problems, or possibly new ones to be raised.