### PR TITLE
Fix #385 Too much padding on create message

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
@@ -93,7 +93,7 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 	@Override
 	public Command getCommand(Request request) {
 		// Ensure padding, if required
-		return withPadding(() -> super.getCommand(request));
+		return withPadding(request, () -> super.getCommand(request));
 	}
 
 	@Override
@@ -293,9 +293,6 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 												execType)))
 								.map(cmd -> injectViewInto(request.getConnectionViewDescriptor(), cmd))
 								.collect(Collectors.toList()));
-					} else {
-						result = injectViewInto(request.getConnectionViewDescriptor(), sender
-								.insertMessageAfter(startBefore, startOffset, receiver, start.sort, null));
 					}
 
 					result = injectViewInto(request.getConnectionViewDescriptor(),

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDragEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDragEditPolicy.java
@@ -73,7 +73,7 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 	@Override
 	public Command getCommand(Request request) {
 		// Ensure padding, if required
-		return withPadding(() -> super.getCommand(request));
+		return withPadding(request, () -> super.getCommand(request));
 	}
 
 	protected MExecution getExecution() {

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ISequenceEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ISequenceEditPolicy.java
@@ -29,10 +29,13 @@ import org.eclipse.emf.workspace.EMFCommandOperation;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.CompoundCommand;
 import org.eclipse.gef.commands.UnexecutableCommand;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.requests.CreateUnspecifiedTypeConnectionRequest;
+import org.eclipse.gmf.runtime.diagram.ui.requests.CreateUnspecifiedTypeRequest;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.commands.wrappers.OperationToGEFCommandWrapper;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.magnets.IMagnetManager;
@@ -179,12 +182,21 @@ public interface ISequenceEditPolicy extends EditPolicy {
 	/**
 	 * Wrap a supplied command with padding.
 	 * 
+	 * @param request
+	 *            the request to be satisfied by the supplied command
 	 * @param commandSupplier
 	 *            the supplier of a command
 	 * @return a compound of the supplied command and a padding command calculated incrementally during
 	 *         construction of the supplied command, or {@code null} if the no command was supplied
 	 */
-	default Command withPadding(Supplier<? extends Command> commandSupplier) {
+	default Command withPadding(Request request, Supplier<? extends Command> commandSupplier) {
+		if ((request instanceof CreateUnspecifiedTypeRequest)
+				|| (request instanceof CreateUnspecifiedTypeConnectionRequest)) {
+			// We will come back to compute the entire command again once the specific type
+			// to create has been selected (the first round is to determine viable types)
+			return commandSupplier.get();
+		}
+
 		List<Command> result = new ArrayList<>(2);
 
 		// Get the current interaction instance (we would recompute a new one later, otherwise)

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MLifelineImpl.java
@@ -403,7 +403,8 @@ public class MLifelineImpl extends MElementImpl<Lifeline> implements MLifeline {
 	public CreationCommand<Message> insertMessageAfter(MElement<?> before, int offset, MLifeline receiver,
 			MessageSort sort, NamedElement signature) {
 
-		return new InsertMessageCommand(this, before, offset, receiver, sort, signature);
+		return createWithPadding(InsertMessageCommand.class,
+				() -> new InsertMessageCommand(this, before, offset, receiver, sort, signature));
 	}
 
 	/**
@@ -543,7 +544,8 @@ public class MLifelineImpl extends MElementImpl<Lifeline> implements MLifeline {
 	 */
 	@Override
 	public Command makeCreatedAt(OptionalInt yPosition) {
-		return new SetLifelineCreationCommand(this, yPosition);
+		return withPadding(SetLifelineCreationCommand.class,
+				() -> new SetLifelineCreationCommand(this, yPosition));
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/DeferredPaddingCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/DeferredPaddingCommand.java
@@ -143,14 +143,14 @@ public class DeferredPaddingCommand extends CommandWrapper {
 		Command result;
 		switch (direction) {
 			case DOWN:
-				result = nudgeElement.nudge(nudgeY);
+				result = getPaddableElement(nudgeElement).nudge(nudgeY);
 				break;
 			case UP:
 				// An "upward" nudge doesn't actually nudge anything up because the diagram can
 				// only expand downwards (lifeline heads are fixed). Rather, we ensure space
 				// by nudging down the element that was moved up, but also everything following
 				// it so that the layout is consistent
-				result = referenceElement.nudge(nudgeY);
+				result = getPaddableElement(referenceElement).nudge(nudgeY);
 				break;
 			default:
 				result = null;

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertMessageCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertMessageCommand.java
@@ -15,7 +15,6 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 import static java.lang.Integer.MAX_VALUE;
 import static org.eclipse.papyrus.uml.interaction.graph.util.CrossReferenceUtil.invertSingle;
 import static org.eclipse.papyrus.uml.interaction.graph.util.Suppliers.compose;
-import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelOrdering.vertically;
 import static org.eclipse.uml2.uml.MessageSort.REPLY_LITERAL;
 import static org.eclipse.uml2.uml.UMLPackage.Literals.ACTION_EXECUTION_SPECIFICATION;
 import static org.eclipse.uml2.uml.UMLPackage.Literals.EXECUTION_SPECIFICATION__FINISH;
@@ -26,7 +25,6 @@ import static org.eclipse.uml2.uml.UMLPackage.Literals.LIFELINE__COVERED_BY;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -82,7 +80,7 @@ import org.eclipse.uml2.uml.Signal;
  *
  * @author Christian W. Damus
  */
-public class InsertMessageCommand extends ModelCommand.Creation<MLifelineImpl, Message> {
+public class InsertMessageCommand extends ModelCommandWithDependencies.Creation<MLifelineImpl, Message> {
 
 	private final MElement<?> beforeSend;
 
@@ -284,7 +282,7 @@ public class InsertMessageCommand extends ModelCommand.Creation<MLifelineImpl, M
 	}
 
 	@Override
-	protected Command createCommand() {
+	protected Command doCreateCommand() {
 		if (!absoluteSendYReference().isPresent() || !absoluteReceiveYReference().isPresent()) {
 			return UnexecutableCommand.INSTANCE;
 		}
@@ -298,8 +296,8 @@ public class InsertMessageCommand extends ModelCommand.Creation<MLifelineImpl, M
 				: beforeSend.getTop().orElse(llTopSend) - llTopSend + sendOffset;
 		Optional<MExecution> sendingExec = getTarget().elementAt(whereSend).flatMap(this::getExecution)
 				.filter(exec -> //
-		((exec.getBottom().orElse(-1) - llTopSend) >= whereSend) //
-				&& ((exec.getTop().orElse(MAX_VALUE) - llTopSend) <= whereSend));
+				((exec.getBottom().orElse(-1) - llTopSend) >= whereSend) //
+						&& ((exec.getTop().orElse(MAX_VALUE) - llTopSend) <= whereSend));
 		Vertex sender = sendingExec.map(this::vertex).orElseGet(this::vertex);
 		if (sender == null || sender.getDiagramView() == null) {
 			return UnexecutableCommand.INSTANCE;
@@ -489,45 +487,9 @@ public class InsertMessageCommand extends ModelCommand.Creation<MLifelineImpl, M
 
 		switch (sort) {
 			case CREATE_MESSAGE_LITERAL:
-				List<Command> commands = new ArrayList<>(3);
-
-				View receiverShape = this.receiver.getDiagramView().orElse(null);
-				Shape receivingLifelineBodyShape = diagramHelper().getLifelineBodyShape(receiverShape);
-				int receiverBodyTop = layoutHelper().getTop(receivingLifelineBodyShape);
-				int receiverLifelineTop = this.receiver.getTop().orElse(0);
-				/* first make room to move created lifeline down by nudging all required elements down */
-				List<MElement<? extends Element>> elementsToNudge = new ArrayList<>();
-
-				int movedReceiverlifelineTop = absoluteRecvY - ((receiverBodyTop - receiverLifelineTop) / 2);
-				int receiverDeltaY = movedReceiverlifelineTop - receiverLifelineTop + additionalOffsetRecv;
-				int receiverDeltaYFinal = receiverDeltaY;
-
-				/* collect elements below */
-				findElementsBelow(absoluteRecvY, elementsToNudge,
-						getTarget().getInteraction().getMessages().stream(), true);
-				findElementsBelow(absoluteRecvY, elementsToNudge,
-						getTarget().getInteraction().getLifelines().stream()//
-								.filter(m -> m.getTop().orElse(0) < absoluteRecvY)//
-								.flatMap(l -> l.getExecutions().stream()),
-						true);
-				Collections.sort(elementsToNudge, vertically().reversed());
-				List<Command> nudgeCommands = new ArrayList<>(elementsToNudge.size());
-				for (int i = 0; i < elementsToNudge.size(); i++) {
-					MElement<? extends Element> element = elementsToNudge.get(i);
-					nudgeCommands.add(Create.nudgeCommand(getGraph(), getEditingDomain(), receiverDeltaYFinal,
-							0, element));
-				}
-
-				if (!nudgeCommands.isEmpty()) {
-					commands.add(CompoundModelCommand.compose(getEditingDomain(), nudgeCommands));
-				}
-
-				/* finally move lifeline */
-				commands.add(Create.nudgeCommand(getGraph(), getEditingDomain(), receiverDeltaYFinal, 0,
-						this.receiver));
-
-				/* build final command */
-				result = CompoundModelCommand.compose(getEditingDomain(), commands).chain(result);
+				// Chain in the reverse order to ensure that the message connector finds the
+				// new lifeline head location
+				result = chain(this.receiver.makeCreatedAt(OptionalInt.of(recvYPosition)), result);
 				break;
 
 			case DELETE_MESSAGE_LITERAL:

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
@@ -87,6 +87,9 @@ public class DefaultLayoutHelper implements LayoutHelper {
 
 	static final int DEFAULT_RIGHT = DEFAULT_LEFT + DEFAULT_WIDTH;
 
+	// Identity anchors don't have a default semantics in GMF as the x/y position of a shape has
+	static final int DEFAULT_ANCHOR_Y = Integer.MIN_VALUE;
+
 	public static final Pattern IDENTITY_ANCHOR_PATTERN = Pattern
 			.compile("(left;|right;|west;|east;)?(-?\\d+)"); //$NON-NLS-1$
 
@@ -153,7 +156,7 @@ public class DefaultLayoutHelper implements LayoutHelper {
 				// But anchor position is relative to the attached shape
 				int bottom = getYPosition(anchor, anchoredShape(anchor));
 
-				if (bottom == DEFAULT_BOTTOM) {
+				if (bottom == DEFAULT_ANCHOR_Y) {
 					result = OptionalInt.empty();
 				} else {
 					result = OptionalInt.of(bottom);
@@ -293,7 +296,7 @@ public class DefaultLayoutHelper implements LayoutHelper {
 
 			@Override
 			public Object caseIdentityAnchor(IdentityAnchor anchor) {
-				int result = DEFAULT_TOP;
+				int result = DEFAULT_ANCHOR_Y;
 				String id = anchor.getId();
 
 				if (id != null) {
@@ -310,7 +313,6 @@ public class DefaultLayoutHelper implements LayoutHelper {
 								// It's the finish anchor
 								LayoutConstraint layout = anchoredShape(anchor).getLayoutConstraint();
 								if (layout instanceof Size) {
-									// Yes, this too could be DEFAULT_BOTTOM!
 									result = ((Size)layout).getHeight();
 								}
 							}
@@ -372,7 +374,7 @@ public class DefaultLayoutHelper implements LayoutHelper {
 				// But anchor position is relative to the attached shape
 				int bottom = getYPosition(anchor, anchoredShape(anchor));
 
-				if (bottom == DEFAULT_BOTTOM) {
+				if (bottom == DEFAULT_ANCHOR_Y) {
 					result = OptionalInt.empty();
 				} else {
 					result = OptionalInt.of(bottom);
@@ -453,7 +455,7 @@ public class DefaultLayoutHelper implements LayoutHelper {
 			return DEFAULT_BOTTOM;
 		} else {
 			int result = getBottomFunction().applyAsInt(anchor);
-			if (result != DEFAULT_BOTTOM) {
+			if (result != DEFAULT_ANCHOR_Y) {
 				result = relativeTop + result;
 			}
 			return result;
@@ -575,7 +577,7 @@ public class DefaultLayoutHelper implements LayoutHelper {
 
 			@Override
 			public Object caseIdentityAnchor(IdentityAnchor anchor) {
-				int result = DEFAULT_BOTTOM;
+				int result = DEFAULT_ANCHOR_Y;
 				String id = anchor.getId();
 
 				if (id != null) {
@@ -592,7 +594,6 @@ public class DefaultLayoutHelper implements LayoutHelper {
 								// It's the finish anchor
 								LayoutConstraint layout = anchoredShape(anchor).getLayoutConstraint();
 								if (layout instanceof Size) {
-									// Yes, this too could be DEFAULT_BOTTOM!
 									result = ((Size)layout).getHeight();
 								}
 							}
@@ -722,7 +723,15 @@ public class DefaultLayoutHelper implements LayoutHelper {
 
 		View view = v.getDiagramView();
 		if (view instanceof Shape) {
-			result = setTop((Shape)view, yPosition);
+			int newTop = yPosition;
+
+			if (v.getInteractionElement() instanceof DestructionOccurrenceSpecification) {
+				// Special case: we actually want to locate the centre of the X shape
+				int height = getHeight((Shape)view);
+				newTop = newTop - (height / 2);
+			}
+
+			result = setTop((Shape)view, newTop);
 		} else if (view instanceof Edge) {
 			Edge edge = (Edge)view;
 			// All edges in a sequence diagram slope down if they are not horizontal
@@ -844,7 +853,15 @@ public class DefaultLayoutHelper implements LayoutHelper {
 
 		View view = v.getDiagramView();
 		if (view instanceof Shape) {
-			result = setBottom((Shape)view, yPosition);
+			int newBottom = yPosition;
+
+			if (v.getInteractionElement() instanceof DestructionOccurrenceSpecification) {
+				// Special case: we actually want to locate the centre of the X shape
+				int height = getHeight((Shape)view);
+				newBottom = newBottom + (height / 2);
+			}
+
+			result = setBottom((Shape)view, newBottom);
 		} else if (view instanceof Edge) {
 			Edge edge = (Edge)view;
 			// All edges in a sequence diagram slope down if they are not horizontal

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTest.java
@@ -108,8 +108,11 @@ public class CreateMessageTest {
 		int nudgedLifeline2Top = model.getLifelineBodyTop(interaction().getLifelines().get(0)) + 25 //
 				- (lifeline2Header / 2);
 		assertEquals(nudgedLifeline2Top, interaction().getLifelines().get(1).getTop().getAsInt());
+		int nudgedLifeline2Bottom = interaction().getLifelines().get(1).getBottom().getAsInt();
 
-		int delta = nudgedLifeline2Top - lifeline2Top;
+		// Message padding is 20 and lifeline head padding is 5
+		final int padding = 25;
+		final int delta = padding - (message1Top - nudgedLifeline2Bottom);
 		assertEquals(message1Top + delta, interaction().getMessages().get(0).getTop().getAsInt());
 		assertEquals(message2Top + delta, interaction().getMessages().get(1).getTop().getAsInt());
 		assertEquals(execution1Top + delta,
@@ -159,14 +162,22 @@ public class CreateMessageTest {
 		int nudgedLifeline3Top = interaction().getMessages().get(3).getTop().getAsInt()
 				- (lifeline3Header / 2);
 		assertEquals(nudgedLifeline3Top, interaction().getLifelines().get(2).getTop().getAsInt());
+		int nudgedLifeline2Bottom = interaction().getLifelines().get(1).getBottom().getAsInt();
+		int nudgedLifeline3Bottom = interaction().getLifelines().get(2).getBottom().getAsInt();
 
-		int delta = nudgedLifeline3Top - lifeline3Top;
+		// Message padding is 20 and lifeline head padding is 5
+		final int msgPadding = 25;
+		int delta = msgPadding - (message1Top - nudgedLifeline2Bottom);
 		assertEquals(message1Top + delta, interaction().getMessages().get(0).getTop().getAsInt());
 		assertEquals(message2Top + delta, interaction().getMessages().get(1).getTop().getAsInt());
 		assertEquals(execution1Top + delta,
 				interaction().getLifelines().get(0).getExecutionOccurrences().get(0).getTop().getAsInt());
 		assertEquals(execution2Top + delta,
 				interaction().getLifelines().get(1).getExecutionOccurrences().get(0).getTop().getAsInt());
+
+		// Execution padding is 5 and lifeline head padding is 5
+		final int execPadding = 10;
+		delta = execPadding - (execution3Top - nudgedLifeline3Bottom);
 		assertEquals(execution3Top + delta,
 				interaction().getLifelines().get(2).getExecutionOccurrences().get(0).getTop().getAsInt());
 	}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTestB.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTestB.java
@@ -102,10 +102,11 @@ public class CreateMessageTestB {
 		int nudgedLifeline2Top = interaction().getMessages().get(5).getTop().getAsInt()
 				- (lifeline2Header / 2);
 		assertEquals(nudgedLifeline2Top, interaction().getLifelines().get(1).getTop().getAsInt());
+		int nudgedLifeline2Bottom = interaction().getLifelines().get(1).getBottom().getAsInt();
 
-		int delta = nudgedLifeline2Top - lifeline2Top;
-		// Accounti for padding between the new create message and M1
-		int deltaPad = delta + 10;
+		// Message padding is 20 and lifeline head padding is 5
+		final int padding = 25;
+		final int delta = padding - (message1Top - nudgedLifeline2Bottom);
 		assertEquals(lifeline3Top + delta, interaction().getLifelines().get(2).getTop().getAsInt());
 		assertEquals(message1Top + delta, interaction().getMessages().get(0).getTop().getAsInt());
 		assertEquals(message2Top + delta, interaction().getMessages().get(4).getTop().getAsInt());
@@ -115,8 +116,8 @@ public class CreateMessageTestB {
 		assertEquals(message1Top + delta, interaction().getMessages().get(0).getBottom().getAsInt());
 		assertEquals(message2Top + delta, interaction().getMessages().get(4).getBottom().getAsInt());
 		assertEquals(message3Top + delta, interaction().getMessages().get(1).getBottom().getAsInt());
-		assertEquals(message4Top + deltaPad, interaction().getMessages().get(2).getBottom().getAsInt());
-		assertEquals(message5Top + deltaPad, interaction().getMessages().get(3).getBottom().getAsInt());
+		assertEquals(message4Top + delta, interaction().getMessages().get(2).getBottom().getAsInt());
+		assertEquals(message5Top + delta, interaction().getMessages().get(3).getBottom().getAsInt());
 	}
 
 	@Test
@@ -151,14 +152,13 @@ public class CreateMessageTestB {
 				- (lifeline4Header / 2);
 		assertEquals(nudgedLifeline4Top, interaction().getLifelines().get(3).getTop().getAsInt());
 
-		int delta = nudgedLifeline4Top - lifeline2Top;
-		assertEquals(lifeline4Top + delta, interaction().getLifelines().get(3).getTop().getAsInt());
-		assertEquals(message3Top + delta, interaction().getMessages().get(1).getTop().getAsInt());
-		assertEquals(message4Top + delta, interaction().getMessages().get(2).getTop().getAsInt());
-		assertEquals(message5Top + delta, interaction().getMessages().get(3).getTop().getAsInt());
-		assertEquals(message3Top + delta, interaction().getMessages().get(1).getBottom().getAsInt());
-		assertEquals(message4Top + delta, interaction().getMessages().get(2).getBottom().getAsInt());
-		assertEquals(message5Top + delta, interaction().getMessages().get(3).getBottom().getAsInt());
+		// Nothing needs to move because lifeline4 is not covered by anything
+		assertEquals(message3Top, interaction().getMessages().get(1).getTop().getAsInt());
+		assertEquals(message4Top, interaction().getMessages().get(2).getTop().getAsInt());
+		assertEquals(message5Top, interaction().getMessages().get(3).getTop().getAsInt());
+		assertEquals(message3Top, interaction().getMessages().get(1).getBottom().getAsInt());
+		assertEquals(message4Top, interaction().getMessages().get(2).getBottom().getAsInt());
+		assertEquals(message5Top, interaction().getMessages().get(3).getBottom().getAsInt());
 	}
 
 }

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTesting.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTesting.notation
@@ -51,11 +51,11 @@
     <owner xmi:type="uml:Interaction" href="CreateMessageTesting.uml#_oM9woGKCEeiIbNyTKulhvg"/>
   </styles>
   <element xmi:type="uml:Interaction" href="CreateMessageTesting.uml#_oM9woGKCEeiIbNyTKulhvg"/>
-  <edges xmi:type="notation:Connector" xmi:id="_JUg94GMTEei-baqYVSEfiQ" type="Edge_Message" source="_9sGg02KEEeiIbNyTKulhvg" target="_csgd02KFEeiIbNyTKulhvg">
+  <edges xmi:type="notation:Connector" xmi:id="_JUg94GMTEei-baqYVSEfiQ" type="Edge_Message" source="_9sGg02KEEeiIbNyTKulhvg" target="_F3xsUGKGEeiIbNyTKulhvg">
     <element xmi:type="uml:Message" href="CreateMessageTesting.uml#_JUgW0mMTEei-baqYVSEfiQ"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JUg94WMTEei-baqYVSEfiQ"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUg94mMTEei-baqYVSEfiQ" id="50"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUg942MTEei-baqYVSEfiQ" id="50"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JUg942MTEei-baqYVSEfiQ" id="start"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_M2nxsGMeEei-baqYVSEfiQ" type="Edge_Message" source="_9sGg02KEEeiIbNyTKulhvg" target="_csgd02KFEeiIbNyTKulhvg">
     <element xmi:type="uml:Message" href="CreateMessageTesting.uml#_M2nKomMeEei-baqYVSEfiQ"/>


### PR DESCRIPTION
Re-use the command employed in re-targeting create messages for the initial create message scenario, too.  Also reuse the common deferred padding mechanism for the padding from the new lifeline head location.

In order to make the latter work, it is necessary also to fix a latent problem in which the duplicate calculation of commands
for the “unspecified type” create requests is trips up the dependency context’s tracking of unique command instances.
Also various problems in the handling of destruction occurrences in nudging.
