### PR TITLE
Fix #411 Execution nesting changes

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationCreationEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationCreationEditPolicy.java
@@ -30,6 +30,7 @@ import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MObject;
+import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
 import org.eclipse.papyrus.uml.interaction.model.util.Optionals;
 import org.eclipse.papyrus.uml.interaction.model.util.SequenceDiagramSwitch;
 import org.eclipse.uml2.uml.Element;
@@ -74,8 +75,12 @@ public class ExecutionSpecificationCreationEditPolicy extends LogicalModelCreati
 							}
 						}
 
-						return execution.insertNestedExecutionAfter(before.orElse(execution), offset,
-								size != null ? size.height : 40, eClass);
+						return execution
+								.insertNestedExecutionAfter(before.orElse(execution), offset,
+										size != null ? size.height
+												: getLayoutConstraints()
+														.getMinimumHeight(ViewTypes.EXECUTION_SPECIFICATION),
+										eClass);
 					}
 
 					@Override

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDropEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDropEditPolicy.java
@@ -1,0 +1,42 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
+
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
+
+import java.util.Optional;
+
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+
+/**
+ * Edit policy for dropping elements onto an execution specification.
+ */
+public class ExecutionSpecificationDropEditPolicy extends LifelineBodyDropEditPolicy {
+
+	/**
+	 * Initializes me.
+	 */
+	public ExecutionSpecificationDropEditPolicy() {
+		super();
+	}
+
+	@Override
+	protected Optional<MLifeline> getHostLifeline() {
+		Optional<ExecutionSpecification> execution = as(Optional.ofNullable(getHostObject()),
+				ExecutionSpecification.class);
+		return as(execution.flatMap(getInteraction()::getElement), MExecution.class)
+				.map(MExecution::getOwner);
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/NoPapyrusEditPolicyProvider.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/NoPapyrusEditPolicyProvider.java
@@ -59,8 +59,8 @@ public class NoPapyrusEditPolicyProvider extends AbstractProvider implements IEd
 				withDrop(LifelineCreationEditPolicy::new, LifelineBodyDropEditPolicy::new));
 		substitute(InteractionCompartmentEditPart.class, EditPolicyRoles.CREATION_ROLE,
 				InteractionCreationEditPolicy::new);
-		substitute(ExecutionSpecificationEditPart.class, EditPolicyRoles.CREATION_ROLE,
-				ExecutionSpecificationCreationEditPolicy::new);
+		substitute(ExecutionSpecificationEditPart.class, EditPolicyRoles.CREATION_ROLE, withDrop(
+				ExecutionSpecificationCreationEditPolicy::new, ExecutionSpecificationDropEditPolicy::new));
 
 		// Diagram assistant edit policies
 		substitute(LifelineBodyEditPart.class, EditPolicyRoles.POPUPBAR_ROLE,
@@ -164,11 +164,13 @@ public class NoPapyrusEditPolicyProvider extends AbstractProvider implements IEd
 					super.setHost(host);
 				}
 
+				@SuppressWarnings("unchecked")
 				@Override
 				protected DropObjectsRequest castToDropObjectsRequest(ChangeBoundsRequest request) {
 					DropObjectsRequest result = super.castToDropObjectsRequest(request);
 
 					PrivateRequestUtils.forwardParameters(request, result);
+					PrivateRequestUtils.setChangeBoundsRequest(result, request);
 
 					return result;
 				}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/PrivateRequestUtils.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/PrivateRequestUtils.java
@@ -17,6 +17,8 @@ import java.util.stream.Stream;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.Request;
+import org.eclipse.gef.requests.ChangeBoundsRequest;
+import org.eclipse.gmf.runtime.diagram.ui.requests.DropObjectsRequest;
 
 /**
  * Utilities for working with private {@link Request}s and/or private details of {@code Request}s.
@@ -32,10 +34,12 @@ public final class PrivateRequestUtils {
 
 	private static final String ALLOW_SEMANTIC_REORDERING_PARAMETER = "__allow_semantic_reordering__"; //$NON-NLS-1$
 
+	private static final String CHANGE_BOUNDS_REQUEST_PARAMETER = "__change_bounds_request__"; //$NON-NLS-1$
+
 	private static final String[] PARAMETERS = { //
 			FORCE_PARAMETER, //
 			ORIGINAL_MOUSE_PARAMETER, ORIGINAL_SOURCE_PARAMETER, ORIGINAL_TARGET_PARAMETER, //
-			ALLOW_SEMANTIC_REORDERING_PARAMETER, //
+			ALLOW_SEMANTIC_REORDERING_PARAMETER, CHANGE_BOUNDS_REQUEST_PARAMETER, //
 	};
 
 	/**
@@ -197,5 +201,28 @@ public final class PrivateRequestUtils {
 		Stream.of(PARAMETERS).filter(p -> hasParameter(fromRequest, p))
 				.filter(p -> !hasParameter(toRequest, p))
 				.forEach(p -> setParameter(toRequest, p, getParameter(fromRequest, p, Object.class, null)));
+	}
+
+	/**
+	 * Records the change-bounds request that triggers a {@code drop}.
+	 * 
+	 * @param drop
+	 *            a drop request
+	 * @param changeBounds
+	 *            the change-bounds request that triggered it
+	 */
+	public static void setChangeBoundsRequest(DropObjectsRequest drop, ChangeBoundsRequest changeBounds) {
+		setParameter(drop, CHANGE_BOUNDS_REQUEST_PARAMETER, changeBounds);
+	}
+
+	/**
+	 * Queries the change-bounds request that triggers a {@code drop}.
+	 * 
+	 * @param drop
+	 *            a drop request
+	 * @return the change-bounds request that triggered it
+	 */
+	public static ChangeBoundsRequest getChangeBoundsRequest(DropObjectsRequest drop) {
+		return getParameter(drop, CHANGE_BOUNDS_REQUEST_PARAMETER, ChangeBoundsRequest.class, null);
 	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/PendingContainmentChangeData.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/PendingContainmentChangeData.java
@@ -1,0 +1,178 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.ifPresentElse;
+
+import com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.uml2.uml.Element;
+
+/**
+ * A framework for {@linkplain DependencyContext context} variables that record logical, semantic, and/or
+ * visual containment changes pending in the model operation currently being computed.
+ * 
+ * @see DependencyContext
+ */
+abstract class PendingContainmentChangeData<P extends MElement<? extends Element>, C extends MElement<? extends Element>> {
+	private final P parent;
+
+	private final List<C> children = Lists.newArrayListWithExpectedSize(1);
+
+	PendingContainmentChangeData(P parent, C child) {
+		super();
+
+		this.parent = parent;
+		addChild(child);
+	}
+
+	private void addChild(C child) {
+		children.add(child);
+	}
+
+	/**
+	 * Queries the parent of the pending {@linkplain #getPendingChild() child element}.
+	 * 
+	 * @return the parent element
+	 */
+	public P getParent() {
+		return parent;
+	}
+
+	/**
+	 * Queries the element that is being assigned a {@linkplain #getParent() new parent}.
+	 * 
+	 * @return the child element
+	 */
+	public C getPendingChild() {
+		return children.get(0);
+	}
+
+	/**
+	 * Queries the elements that are being assigned a {@linkplain #getParent() new parent}.
+	 * 
+	 * @return the child elements
+	 */
+	public List<C> getPendingChildren() {
+		return Collections.unmodifiableList(children);
+	}
+
+	/**
+	 * Query the element that is in process of having the given element set as its new {@code parent}.
+	 * 
+	 * @param parent
+	 *            an element that may or may not be getting a new child
+	 * @return the pending child element
+	 */
+	static <P extends MElement<? extends Element>, C extends MElement<? extends Element>> Optional<C> getPendingChild(
+			Class<? extends PendingContainmentChangeData<P, C>> relationshipType, P parent) {
+
+		return DependencyContext.get().get(parent, relationshipType)
+				.map(PendingContainmentChangeData::getPendingChild);
+	}
+
+	/**
+	 * Query the elements that are in process of having the given element set as their new {@code parent}.
+	 * 
+	 * @param parent
+	 *            an element that may or may not be getting a new child
+	 * @return the pending child elements
+	 */
+	static <P extends MElement<? extends Element>, C extends MElement<? extends Element>> List<C> getPendingChildren(
+			Class<? extends PendingContainmentChangeData<P, C>> relationshipType, P parent) {
+		return DependencyContext.get().get(parent, relationshipType)
+				.map(PendingContainmentChangeData::getPendingChildren).orElse(Collections.emptyList());
+	}
+
+	/**
+	 * Query the element that is in process of being made the parent of a pending {@code child}.
+	 * 
+	 * @param child
+	 *            an element that may or may not be getting a new parent
+	 * @return the pending parent element
+	 */
+	static <P extends MElement<? extends Element>, C extends MElement<? extends Element>> Optional<P> getPendingParent(
+			Class<? extends PendingContainmentChangeData<P, C>> relationshipType, C child) {
+		return getPendingParentData(DependencyContext.get(), relationshipType, child)
+				.map(PendingParentData::getPendingParent);
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes" })
+	private static <P extends MElement<? extends Element>, C extends MElement<? extends Element>> Optional<PendingContainmentChangeData.PendingParentData<P, C>> getPendingParentData(
+			DependencyContext ctx, Class<? extends PendingContainmentChangeData<P, C>> relationshipType,
+			C child) {
+
+		return (Optional)ctx.get(child, PendingParentData.class,
+				data -> data.getRelationshipType() == relationshipType);
+	}
+
+	/**
+	 * Record an element that is in process of having the given element set as its new {@code owner}.
+	 * 
+	 * @param owner
+	 *            an element that is getting a new owned child
+	 * @param pendingChild
+	 *            an element that is getting the new {@code owner}
+	 */
+	static <P extends MElement<? extends Element>, C extends MElement<? extends Element>> void setPendingChild(
+			Class<? extends PendingContainmentChangeData<P, C>> relationshipType, P parent, C pendingChild,
+			BiFunction<P, C, PendingContainmentChangeData<P, C>> factory) {
+
+		DependencyContext ctx = DependencyContext.get();
+
+		@SuppressWarnings({"unchecked", "rawtypes" })
+		Optional<PendingContainmentChangeData<P, C>> childData = (Optional)ctx.get(parent, relationshipType);
+
+		ifPresentElse(childData, cd -> {
+			cd.addChild(pendingChild);
+			ctx.put(pendingChild, new PendingParentData<>(relationshipType, cd));
+		}, () -> {
+			PendingContainmentChangeData<P, C> cd = factory.apply(parent, pendingChild);
+			ctx.put(parent, cd);
+			ctx.put(pendingChild, new PendingParentData<>(relationshipType, cd));
+		});
+	}
+
+	//
+	// Nested types
+	//
+
+	private static final class PendingParentData<P extends MElement<? extends Element>, C extends MElement<? extends Element>> {
+		private final Class<? extends PendingContainmentChangeData<P, C>> relationshipType;
+
+		private final PendingContainmentChangeData<P, C> childData;
+
+		PendingParentData(Class<? extends PendingContainmentChangeData<P, C>> relationshipType,
+				PendingContainmentChangeData<P, C> childData) {
+			super();
+
+			this.relationshipType = relationshipType;
+			this.childData = childData;
+		}
+
+		Class<? extends PendingContainmentChangeData<P, C>> getRelationshipType() {
+			return relationshipType;
+		}
+
+		P getPendingParent() {
+			return childData.getParent();
+		}
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/PendingNestedData.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/PendingNestedData.java
@@ -1,0 +1,83 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+
+/**
+ * A {@linkplain DependencyContext context} variable that records execution nesting change in progress.
+ * 
+ * @see DependencyContext
+ */
+public final class PendingNestedData extends PendingContainmentChangeData<MExecution, MExecution> {
+	private PendingNestedData(MExecution nesting, MExecution nested) {
+		super(nesting, nested);
+	}
+
+	/**
+	 * Query the execution that is in process of having the given element set as its new {@code nesting}
+	 * execution.
+	 * 
+	 * @param nesting
+	 *            an execution that may or may not be getting a new nested execution
+	 * @return the pending nested execution
+	 */
+	public static Optional<MExecution> getPendingChild(MExecution nesting) {
+		return PendingContainmentChangeData.getPendingChild(PendingNestedData.class, nesting);
+	}
+
+	/**
+	 * Query the executions that are in process of having the given execution set as their new
+	 * {@code newsting}.
+	 * 
+	 * @param nesting
+	 *            an execution that may or may not be getting a new nested execution
+	 * @return the pending nested executions
+	 */
+	public static List<MExecution> getPendingNestedExecutions(MExecution nesting) {
+		return PendingContainmentChangeData.getPendingChildren(PendingNestedData.class, nesting);
+	}
+
+	/**
+	 * Query the execution that is in process of being made the nesting of a pending {@code nested} execution.
+	 * 
+	 * @param nested
+	 *            an execution that may or may not be getting a new nesting execution
+	 * @return the pending nesting execution
+	 */
+	public static Optional<MExecution> getPendingNestingExecution(MExecution nested) {
+		return PendingContainmentChangeData.getPendingParent(PendingNestedData.class, nested);
+	}
+
+	/**
+	 * Record an execution that is in process of having the given execution set as its new {@code nesting}
+	 * execution.
+	 * 
+	 * @param nesting
+	 *            an execution that is getting a new nested execution
+	 * @param pendingNested
+	 *            an execution that is getting the new {@code nesting}
+	 */
+	static void setPendingNested(MExecution nesting, MExecution pendingNested) {
+		if (!nesting.getNestedExecutions().stream()
+				.anyMatch(n -> n.getElement() == pendingNested.getElement())) {
+
+			PendingContainmentChangeData.setPendingChild(PendingNestedData.class, nesting, pendingNested,
+					PendingNestedData::new);
+		}
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
@@ -15,6 +15,7 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 import static java.lang.Math.abs;
 import static java.util.Collections.singletonList;
 import static org.eclipse.papyrus.uml.interaction.model.util.Executions.executionShapeAt;
+import static org.eclipse.papyrus.uml.interaction.model.util.Executions.splitsExecution;
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.above;
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.below;
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.equalTo;
@@ -177,6 +178,10 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 			// And re-connect the message view to the new lifeline's head
 			result = chain(result,
 					defer(() -> reconnectTarget(messageView, lifelineHead, createPosition).orElse(null)));
+		} else if ((getTarget() instanceof MExecutionOccurrence)
+				&& getTarget().getExecution().filter(splitsExecution(lifeline)).isPresent()) {
+
+			result = UnexecutableCommand.INSTANCE;
 		} else {
 			// Handle a dependent execution
 			result = dependencies(getTarget()).map(chaining(result)).orElse(result);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetOwnerCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetOwnerCommand.java
@@ -14,7 +14,8 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
 import static java.util.Collections.singletonList;
 import static org.eclipse.papyrus.uml.interaction.internal.model.commands.PendingVerticalExtentData.affectedOccurrences;
-import static org.eclipse.papyrus.uml.interaction.model.util.Executions.getLifelineView;
+import static org.eclipse.papyrus.uml.interaction.model.util.Executions.executionShapeAt;
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.equalTo;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.lessThan;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.map;
@@ -28,7 +29,6 @@ import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.notation.Shape;
-import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
@@ -89,20 +89,14 @@ public class SetOwnerCommand extends ModelCommandWithDependencies<MElementImpl<?
 		return owner.getElement() != newOwner.getElement();
 	}
 
+	protected boolean isChangingNesting() {
+		return (getTarget() instanceof MExecution)
+				&& PendingNestedData.getPendingNestingExecution((MExecution)getTarget()).isPresent();
+	}
+
 	protected boolean isChangingPosition() {
 		return (top.isPresent() && !getTarget().getTop().equals(top))
 				|| (bottom.isPresent() && !getTarget().getBottom().equals(bottom));
-	}
-
-	protected boolean needReparentView(MExecution execution) {
-		// browse the list of parent views until we get to the real lifeline view.
-		// once found, compare to the "new" lifeline owner.
-		// if similar, no need to reparent
-		// this avoids issues in reparenting executions with nested executions
-		Optional<View> parentLifelineView = getLifelineView(execution);
-		return parentLifelineView.isPresent()
-				&& !parentLifelineView.equals(as(newOwner.getDiagramView(), View.class));
-
 	}
 
 	@Override
@@ -142,12 +136,12 @@ public class SetOwnerCommand extends ModelCommandWithDependencies<MElementImpl<?
 			int newTop = top.orElseGet(() -> execution.getTop().getAsInt());
 			int newBottom = bottom.orElseGet(() -> execution.getBottom().getAsInt());
 
-			if (isChangingOwner() && needReparentView(execution)) {
-				// Move the execution shape
-				result = chain(result, diagramHelper().reparentView(executionShape.get(), lifelineView));
-			}
+			if (isChangingPosition() || isChangingOwner() || isChangingNesting()) {
+				// Handle new parent shape (moving to/from nested condition)
+				Optional<Shape> nestingExecution = executionShapeAt(lifeline, newTop, equalTo(execution));
+				Shape newParent = nestingExecution.orElse(lifelineView);
+				result = chain(result, diagramHelper().reparentView(executionShape.get(), newParent));
 
-			if (isChangingPosition() || isChangingOwner()) {
 				// Position it later, as the relative position of the execution may then be different
 				// according to the new lifeline's creation position
 				result = chain(result, layoutHelper().setTop(executionShape.get(), () -> newTop));
@@ -195,6 +189,10 @@ public class SetOwnerCommand extends ModelCommandWithDependencies<MElementImpl<?
 
 		// Note that nested executions will be handled implicitly by either their start or finish.
 		Optional<Command> reattach = affectedOccurrences(execution).map(occ -> {
+			// If our 'execution' is now nesting another, let it know that
+			Optionals.elseMaybe(occ.getStartedExecution(), occ.getFinishedExecution())
+					.ifPresent(nested -> PendingNestedData.setPendingNested(execution, nested));
+
 			OptionalInt where = occ.getTop();
 			return defer(() -> occ.setCovered(lifeline, where));
 		}).reduce(chaining());

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Executions.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Executions.java
@@ -1,8 +1,13 @@
 package org.eclipse.papyrus.uml.interaction.model.util;
 
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.alwaysFalse;
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.equalTo;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.elseMaybe;
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.flatMapToObj;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Predicate;
 
 import org.eclipse.emf.ecore.EObject;
@@ -10,9 +15,11 @@ import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.PendingChildData;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.PendingVerticalExtentData;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
+import org.eclipse.uml2.uml.Element;
 
 public class Executions {
 
@@ -40,21 +47,56 @@ public class Executions {
 	}
 
 	public static Optional<MExecution> executionAt(MLifeline lifeline, int absoluteY) {
-		Predicate<MExecution> spanning = PendingVerticalExtentData.spans(absoluteY);
+		return executionAt(lifeline, absoluteY, alwaysFalse());
+	}
 
-		Optional<MExecution> movingToLifeline = as(PendingChildData.getPendingChild(lifeline),
-				MExecution.class).filter(spanning);
+	public static Optional<MExecution> executionAt(MLifeline lifeline, int absoluteY,
+			Predicate<? super MExecution> excluding) {
 
-		if (movingToLifeline.isPresent()) {
-			// Easy case
-			return movingToLifeline;
-		}
+		Predicate<MExecution> spanning = PendingVerticalExtentData.<MExecution> spans(absoluteY)
+				.and(excluding.negate());
 
-		return lifeline.getExecutions().stream().filter(spanning).max(LogicalModelOrdering.vertically());
+		Optional<MExecution> movingToLifeline = PendingChildData.getPendingChildren(lifeline).stream()
+				.filter(MExecution.class::isInstance).map(MExecution.class::cast).filter(spanning)
+				.max(LogicalModelOrdering.vertically());
+
+		return elseMaybe(movingToLifeline, // Easy case
+				() -> lifeline.getExecutions().stream().filter(spanning)
+						.max(LogicalModelOrdering.vertically()));
 	}
 
 	public static Optional<Shape> executionShapeAt(MLifeline lifeline, int absoluteY) {
 		return executionAt(lifeline, absoluteY).flatMap(MExecution::getDiagramView);
+	}
+
+	public static Optional<Shape> executionShapeAt(MLifeline lifeline, int absoluteY,
+			Predicate<? super MExecution> excluding) {
+		return executionAt(lifeline, absoluteY, excluding).flatMap(MExecution::getDiagramView);
+	}
+
+	/**
+	 * Obtain a predicate that tests whether an {@link MExecution} start or finish splits some execution on a
+	 * given lifeline. An execution is split by another if exactly one end is spanned by the other execution.
+	 * 
+	 * @param onLifeline
+	 *            the lifeline on which to look for split executions
+	 * @return the execution splitting predicate
+	 */
+	public static Predicate<MExecution> splitsExecution(MLifeline onLifeline) {
+		return exec -> {
+			OptionalInt start = PendingVerticalExtentData.getPendingTop(exec);
+			OptionalInt finish = PendingVerticalExtentData.getPendingBottom(exec);
+			Predicate<MElement<? extends Element>> self = equalTo(exec);
+
+			Optional<MExecution> startLandsOn = flatMapToObj(start,
+					top -> executionAt(onLifeline, top, self));
+			Optional<MExecution> finishLandsOn = flatMapToObj(finish,
+					bottom -> executionAt(onLifeline, bottom, self));
+
+			return (startLandsOn.isPresent() != finishLandsOn.isPresent()) //
+					|| (finishLandsOn.isPresent()
+							&& !startLandsOn.filter(equalTo(finishLandsOn.get())).isPresent());
+		};
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/LogicalModelPredicates.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/LogicalModelPredicates.java
@@ -26,11 +26,25 @@ import org.eclipse.uml2.uml.Element;
  */
 public class LogicalModelPredicates {
 
+	private static final Predicate<Object> TRUE = __ -> true;
+
+	private static final Predicate<Object> FALSE = __ -> false;
+
 	/**
 	 * Not instantiable by clients.
 	 */
 	private LogicalModelPredicates() {
 		super();
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T extends MElement<? extends Element>> Predicate<T> alwaysTrue() {
+		return (Predicate<T>)TRUE;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T extends MElement<? extends Element>> Predicate<T> alwaysFalse() {
+		return (Predicate<T>)FALSE;
 	}
 
 	public static Predicate<MElement<? extends Element>> above(int y) {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
@@ -14,6 +14,7 @@ package org.eclipse.papyrus.uml.interaction.model.util;
 
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
@@ -69,6 +70,19 @@ public class Optionals {
 	 */
 	public static OptionalInt map(OptionalInt optional, IntUnaryOperator operator) {
 		return optional.isPresent() ? OptionalInt.of(operator.applyAsInt(optional.getAsInt())) : optional;
+	}
+
+	/**
+	 * Map an {@code optional} int under an optional-integer-valued unary {@code function}.
+	 * 
+	 * @param optional
+	 *            an optional integer value
+	 * @param function
+	 *            a function to apply
+	 * @return the optional {@code function} result
+	 */
+	public static OptionalInt flatMap(OptionalInt optional, IntFunction<OptionalInt> function) {
+		return optional.isPresent() ? function.apply(optional.getAsInt()) : optional;
 	}
 
 	/**
@@ -249,5 +263,24 @@ public class Optionals {
 	 */
 	public static OptionalInt filter(OptionalInt value, IntPredicate predicate) {
 		return (value.isPresent() && predicate.test(value.getAsInt())) ? value : OptionalInt.empty();
+	}
+
+	/**
+	 * An analogue of the {@link Optional#ifPresent(Consumer)} API that includes an {@code else} clause.
+	 * 
+	 * @param optional
+	 *            the optional value to process
+	 * @param ifPresent
+	 *            the present ({@code then}) case
+	 * @param orElse
+	 *            the absent ({@code else}) case
+	 */
+	public static <T> void ifPresentElse(Optional<T> optional, Consumer<? super T> ifPresent,
+			Runnable orElse) {
+		if (optional.isPresent()) {
+			ifPresent.accept(optional.get());
+		} else {
+			orElse.run();
+		}
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -19,6 +19,7 @@ import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GE
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isAt;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isBounded;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.runs;
+import static org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes.LIFELINE_BODY;
 import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.gt;
 import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.gte;
 import static org.hamcrest.CoreMatchers.anything;
@@ -30,6 +31,7 @@ import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture.VisualID;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
@@ -100,12 +102,14 @@ public class ExecutionSpecificationDragEditPolicyUITest {
 		private Lifeline l1;
 
 		@AutoFixture
+		@VisualID(LIFELINE_BODY)
 		private EditPart l1EP;
 
 		@AutoFixture("L2")
 		private Lifeline l2;
 
 		@AutoFixture
+		@VisualID(LIFELINE_BODY)
 		private EditPart l2EP;
 
 		@AutoFixture

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
@@ -69,8 +69,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Integration test cases for use cases in which occurrences are moved from one
- * lifeline to another.
+ * Integration test cases for use cases in which occurrences are moved from one lifeline to another.
  *
  * @author Christian W. Damus
  */
@@ -175,8 +174,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 	public static class MessageNoReply extends MessageNoExecution {
 
 		@ClassRule
-		public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
-				.dontCreateRepliesForSyncCalls();
+		public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().dontCreateRepliesForSyncCalls();
 
 		@Override
 		protected void switchLifeline(VerificationMode mode) {
@@ -291,7 +289,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			super.switchLifeline(mode);
 
 			// Verify additional details of the new visuals
-			EditPart destructionEP = ((ConnectionEditPart) messageEP).getTarget();
+			EditPart destructionEP = ((ConnectionEditPart)messageEP).getTarget();
 			mode.verify(destructionEP, instanceOf(DestructionSpecificationEditPart.class));
 			EditPart newLifelineEP = verifying(mode, getBodyEditPart(getReceiver()),
 					"New lifeline edit-part not found");
@@ -303,7 +301,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			super.undoSwitchLifeline(mode);
 
 			// Verify additional details of the old visuals
-			EditPart destructionEP = ((ConnectionEditPart) messageEP).getTarget();
+			EditPart destructionEP = ((ConnectionEditPart)messageEP).getTarget();
 			mode.verify(destructionEP, instanceOf(DestructionSpecificationEditPart.class));
 			EditPart oldLifelineEP = verifying(mode, getBodyEditPart(getOriginalReceiver()),
 					"Old lifeline edit-part not found");
@@ -311,8 +309,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		}
 
 		/**
-		 * Verify that a destruction cannot be moved to a lifeline that would have
-		 * occurrences following it
+		 * Verify that a destruction cannot be moved to a lifeline that would have occurrences following it
 		 */
 		@Test
 		public void existingOccurrences() {
@@ -331,13 +328,13 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 
 			// Verify that nothing changed
 			assertThat(messageEP, runs(sendX, mesgY, getGrabX(), mesgY));
-			EditPart destructionEP = ((ConnectionEditPart) messageEP).getTarget();
+			EditPart destructionEP = ((ConnectionEditPart)messageEP).getTarget();
 			assertThat(destructionEP, instanceOf(DestructionSpecificationEditPart.class));
 			EditPart oldLifelineEP = asserting(getBodyEditPart(getOriginalReceiver()),
 					"Old lifeline edit-part not found");
 			assertThat(destructionEP.getParent(), is(oldLifelineEP));
 			MDestruction destruction = asserting(
-					as(getInteraction().getElement((Element) destructionEP.getAdapter(EObject.class)),
+					as(getInteraction().getElement((Element)destructionEP.getAdapter(EObject.class)),
 							MDestruction.class),
 					"Not a logical destruction");
 			assertThat(asserting(destruction.getCovered(), "No coverage").getName(), is("Lifeline2"));
@@ -354,12 +351,16 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 
 		@Override
 		int getGrabX() {
-			return super.getGrabX() - (DESTRUCTION_WIDTH / 2);
+			// Note that the message arrow actually penetrates to 1/4 depth; it does not attach
+			// to the bounding box of the X shape
+			return super.getGrabX() - (DESTRUCTION_WIDTH / 4);
 		}
 
 		@Override
 		int getNewRecvX() {
-			return super.getNewRecvX() - (DESTRUCTION_WIDTH / 2);
+			// Note that the message arrow actually penetrates to 1/4 depth; it does not attach
+			// to the bounding box of the X shape
+			return super.getNewRecvX() - (DESTRUCTION_WIDTH / 4);
 		}
 	}
 
@@ -399,8 +400,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		}
 
 		/**
-		 * Verify that a creation cannot be moved to a lifeline that would have
-		 * occurrences preceding it
+		 * Verify that a creation cannot be moved to a lifeline that would have occurrences preceding it
 		 */
 		@Test
 		public void existingOccurrences() {
@@ -428,7 +428,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			assertThat(lifeline2, isBounded(anything(), is(top2), anything(), anything()));
 			assertThat(lifeline3, isBounded(anything(), is(top3), anything(), anything()));
 			MMessage message = assuming(
-					as(getInteraction().getElement((Element) messageEP.getAdapter(EObject.class)),
+					as(getInteraction().getElement((Element)messageEP.getAdapter(EObject.class)),
 							MMessage.class),
 					"Not a logical message");
 			MMessageEnd creation = assuming(message.getReceive(), "No creation end");
@@ -436,8 +436,8 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		}
 
 		/**
-		 * Verify that a create message can be reoriented to a lifeline head with the
-		 * same outcome as the lifeline body.
+		 * Verify that a create message can be reoriented to a lifeline head with the same outcome as the
+		 * lifeline body.
 		 */
 		@Test
 		public void switchToLifelineHead() {
@@ -491,7 +491,9 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		private static final int LIFELINE_4_BODY_X = 596;
 
 		private final int m2Y = 173;
+
 		private final int m3Y = 198;
+
 		private final int m4Y = 223;
 
 		@Override
@@ -514,12 +516,12 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			mode.verify(m4EP, runs(LIFELINE_4_BODY_X, m4Y, execRight, m4Y));
 
 			// And the semantics
-			mode.verify("Wrong coverage of m2 send",
-					asserting(m2.getSend(), "m2 lost its send").getCovered(), is(getReceiver()));
+			mode.verify("Wrong coverage of m2 send", asserting(m2.getSend(), "m2 lost its send").getCovered(),
+					is(getReceiver()));
 			mode.verify("Coverage of m2 receive broken",
 					asserting(m2.getReceive(), "m2 lost its recevive").getCovered(), is(getReceiver()));
-			mode.verify("Wrong coverage of m3 send",
-					asserting(m3.getSend(), "m3 lost its send").getCovered(), is(getReceiver()));
+			mode.verify("Wrong coverage of m3 send", asserting(m3.getSend(), "m3 lost its send").getCovered(),
+					is(getReceiver()));
 			mode.verify("Wrong coverage of m4 receive",
 					asserting(m4.getReceive(), "m4 lost its receive").getCovered(), is(getReceiver()));
 		}
@@ -542,12 +544,12 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			mode.verify(m4EP, runs(LIFELINE_4_BODY_X, m4Y, execRight, m4Y));
 
 			// And the semantics
-			mode.verify("Wrong coverage of m2 send",
-					asserting(m2.getSend(), "m2 lost its send").getCovered(), is(getOriginalReceiver()));
+			mode.verify("Wrong coverage of m2 send", asserting(m2.getSend(), "m2 lost its send").getCovered(),
+					is(getOriginalReceiver()));
 			mode.verify("Coverage of m2 receive broken",
 					asserting(m2.getReceive(), "m2 lost its recevive").getCovered(), is(getReceiver()));
-			mode.verify("Wrong coverage of m3 send",
-					asserting(m3.getSend(), "m3 lost its send").getCovered(), is(getOriginalReceiver()));
+			mode.verify("Wrong coverage of m3 send", asserting(m3.getSend(), "m3 lost its send").getCovered(),
+					is(getOriginalReceiver()));
 			mode.verify("Wrong coverage of m4 receive",
 					asserting(m4.getReceive(), "m4 lost its receive").getCovered(),
 					is(getOriginalReceiver()));
@@ -665,8 +667,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 	EditPart requireEditPart(MElement<? extends Element> element) {
 		View notationView = assuming(as(element.getDiagramView(), View.class),
 				"No notation view for " + element);
-		EditPart result = DiagramEditPartsUtil.getEditPartFromView(notationView,
-				editor.getDiagramEditPart());
+		EditPart result = DiagramEditPartsUtil.getEditPartFromView(notationView, editor.getDiagramEditPart());
 		assumeThat("No edit-part for " + element, result, notNullValue());
 		return result;
 	}
@@ -688,10 +689,10 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 
 		editor.flushDisplayEvents();
 
-		View createdView = (View) create.getViewAndElementDescriptor().getAdapter(View.class);
+		View createdView = (View)create.getViewAndElementDescriptor().getAdapter(View.class);
 		assumeThat("No view created", createdView, notNullValue());
 
-		EditPart result = (EditPart) editor.getDiagramEditPart().getViewer().getEditPartRegistry()
+		EditPart result = (EditPart)editor.getDiagramEditPart().getViewer().getEditPartRegistry()
 				.get(createdView);
 		assumeThat("No edit-part registered for created view", result, notNullValue());
 		return result;
@@ -717,12 +718,12 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 
 	static <T> T verifying(VerificationMode mode, Optional<T> value, String message) {
 		switch (mode) {
-		case ASSERT:
-			return asserting(value, message);
-		case ASSUME:
-			return assuming(value, message);
-		default:
-			return value.orElse(null);
+			case ASSERT:
+				return asserting(value, message);
+			case ASSUME:
+				return assuming(value, message);
+			default:
+				return value.orElse(null);
 		}
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/NestedExecutionMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/NestedExecutionMoveUITest.java
@@ -1,0 +1,186 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.is;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isAt;
+import static org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes.LIFELINE_BODY;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.gt;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.infra.gmfdiag.common.utils.DiagramEditPartsUtil;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture.VisualID;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Integration tests for the moving of nested executions to other lifelines and around the same lifeline.
+ */
+@ModelResource("nested-executions.di")
+@Maximized
+public class NestedExecutionMoveUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@Rule
+	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+	@AutoFixture("Lifeline2")
+	@VisualID(LIFELINE_BODY)
+	private EditPart lifeline2;
+
+	@AutoFixture("Lifeline3")
+	@VisualID(LIFELINE_BODY)
+	private EditPart lifeline3;
+
+	@AutoFixture
+	private Rectangle lifeline3Geom;
+
+	@AutoFixture
+	private EditPart request;
+
+	@AutoFixture
+	private PointList requestGeom;
+
+	@AutoFixture
+	private EditPart exec1;
+
+	@AutoFixture
+	private Rectangle exec1Geom;
+
+	@AutoFixture
+	private EditPart exec2;
+
+	@AutoFixture
+	private Rectangle exec2Geom;
+
+	@AutoFixture
+	private EditPart exec3;
+
+	@AutoFixture
+	private Rectangle exec3Geom;
+
+	@AutoFixture
+	private EditPart exec4;
+
+	@AutoFixture
+	private Rectangle exec4Geom;
+
+	/**
+	 * Initializes me.
+	 */
+	public NestedExecutionMoveUITest() {
+		super();
+	}
+
+	@Test
+	public void moveExecutionToNested() {
+		Point grabAt = exec4Geom.getCenter();
+		Point dropAt = exec3Geom.getLeft().getTranslated(-EXEC_WIDTH, 0);
+
+		editor.select(grabAt);
+		editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+
+		autoFixtures.refresh();
+
+		assertThat("Wrong parent", exec4.getParent(), sameInstance(exec3));
+		assertThat(exec4, isAt(is(exec3Geom.x() + EXEC_WIDTH / 2), gt(exec3Geom.y())));
+	}
+
+	@Test
+	public void retargetRequest() {
+		Point grabAt = requestGeom.getLastPoint();
+		Point dropAt = new Point(lifeline3Geom.getCenter().x(), grabAt.y());
+
+		editor.select(requestGeom.getMidpoint());
+		editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+
+		autoFixtures.refresh();
+
+		assertThat("Wrong parent", exec3.getParent(), sameInstance(exec2));
+		assertThat("Wrong parent", exec2.getParent(), sameInstance(exec1));
+		assertThat("Wrong parent", exec1.getParent(), sameInstance(lifeline3));
+
+		assertThat("Wrong nesting", exec3, isAt(gt(exec2Geom.x()), gt(exec2Geom.y())));
+		assertThat("Wrong nesting", exec2, isAt(gt(exec1Geom.x()), gt(exec1Geom.y())));
+	}
+
+	@Test
+	public void moveNestedExecutionToOtherLifeline() {
+		int previousExec3Y = exec3Geom.y();
+		Point grabAt = exec3Geom.getCenter();
+		Point dropAt = new Point(lifeline3Geom.getCenter().x(), grabAt.y());
+
+		editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+
+		autoFixtures.refresh();
+
+		assertThat("Wrong parent", exec3.getParent(), sameInstance(lifeline3));
+		assertThat("Wrong nesting", exec3,
+				isAt(is(lifeline3Geom.getCenter().x() - (EXEC_WIDTH / 2)), is(previousExec3Y)));
+	}
+
+	@Test
+	public void moveNestedExecutionToSpanOtherExecution() {
+		Point previousExec4Location = exec4Geom.getTopLeft();
+		Point grabAt = exec3Geom.getCenter();
+		Point dropAt = exec4Geom.getBottom(); // Optimal placement for the ratio of their sizes
+
+		editor.with(editor.allowSemanticReordering(), () -> editor.moveSelection(grabAt, dropAt));
+
+		autoFixtures.refresh();
+
+		assertThat("Wrong parent", exec3.getParent(), sameInstance(lifeline2));
+		assertThat("Wrong parent", exec4.getParent(), sameInstance(exec3));
+		assertThat("Wrong nesting", exec4,
+				isAt(gt(previousExec4Location.x()), is(previousExec4Location.y())));
+	}
+
+	@Test
+	public void moveNestedExecutionToSpanExecutionOnOtherLifeline() {
+		// Create a new execution on lifeline3 vertically in the middle-ish of an existing execution
+		// on lifeline3
+		Point newExecAt = new Point(lifeline3Geom.getCenter().x(), exec3Geom.getCenter().y());
+		EditPart newExecEP = createShape(SequenceElementTypes.Behavior_Execution_Shape, newExecAt, null);
+		ExecutionSpecification newExec = (ExecutionSpecification)newExecEP.getAdapter(EObject.class);
+
+		autoFixtures.refresh(); // Account for nudging
+		Point previousNewExecLocation = getBounds(newExecEP).getTopLeft();
+
+		// Grab the middle exec of the existing stack near the bottom where the most nested one isn't
+		Point grabAt = exec2Geom.getBottom().getTranslated(0, -10);
+		// And drop it onto lifeline3 over top of the new exec
+		Point dropAt = new Point(lifeline3Geom.getCenter().x(), grabAt.y());
+
+		editor.with(editor.allowSemanticReordering(), () -> editor.moveSelection(grabAt, dropAt));
+
+		// The edit-parts are re-created by the notation changes
+		autoFixtures.refresh();
+		newExecEP = DiagramEditPartsUtil.getChildByEObject(newExec, editor.getDiagramEditPart(), false);
+
+		assertThat("Wrong parent", newExecEP.getParent(), sameInstance(exec3));
+		assertThat("Wrong nesting", newExecEP,
+				isAt(gt(previousNewExecLocation.x()), is(previousNewExecLocation.y())));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/nested-executions.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/nested-executions.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/nested-executions.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/nested-executions.notation
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_SnR90EppEeiB_O7ig5LXPg" type="LightweightSequenceDiagram" name="seq1" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_SnR90UppEeiB_O7ig5LXPg" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_SnR90kppEeiB_O7ig5LXPg" type="Label_Interaction_Name">
+      <element xmi:type="uml:Interaction" href="nested-executions.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+    </children>
+    <children xmi:type="notation:Compartment" xmi:id="_SnR900ppEeiB_O7ig5LXPg" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_FTODwGpHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_FTODwWpHEeiIJqtZNCF3Dw" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_FTODwmpHEeiIJqtZNCF3Dw" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_FTODw2pHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_FTODxGpHEeiIJqtZNCF3Dw" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="nested-executions.uml#_FMyroGpHEeiIJqtZNCF3Dw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTODxWpHEeiIJqtZNCF3Dw" x="30" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_F8jUoGpHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_F8jUoWpHEeiIJqtZNCF3Dw" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_F8jUompHEeiIJqtZNCF3Dw" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_F8jUo2pHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_xm5G0emtEeiy0sMNphMqbA" type="Shape_Execution_Specification">
+            <children xmi:type="notation:Shape" xmi:id="_zaOFoOmtEeiy0sMNphMqbA" type="Shape_Execution_Specification">
+              <children xmi:type="notation:Shape" xmi:id="_7fim8OmtEeiy0sMNphMqbA" type="Shape_Execution_Specification">
+                <element xmi:type="uml:ActionExecutionSpecification" href="nested-executions.uml#_7edo4OmtEeiy0sMNphMqbA"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7fim8emtEeiy0sMNphMqbA" y="13" width="10" height="101"/>
+              </children>
+              <element xmi:type="uml:ActionExecutionSpecification" href="nested-executions.uml#_zWRZwOmtEeiy0sMNphMqbA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zaOFoemtEeiy0sMNphMqbA" y="26" width="10" height="148"/>
+            </children>
+            <element xmi:type="uml:BehaviorExecutionSpecification" href="nested-executions.uml#_xm5G0OmtEeiy0sMNphMqbA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_xm5G0umtEeiy0sMNphMqbA" x="-4" y="37" width="10" height="210"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_Id3pIOmvEeiy0sMNphMqbA" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="nested-executions.uml#_IU2QAOmvEeiy0sMNphMqbA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Id3pIemvEeiy0sMNphMqbA" x="-4" y="276" width="10" height="40"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_F8jUpGpHEeiIJqtZNCF3Dw" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="nested-executions.uml#_F4rhQGpHEeiIJqtZNCF3Dw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_F8jUpWpHEeiIJqtZNCF3Dw" x="190" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_9hFagMr5EeiHN4fdcelXbQ" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_9hFagcr5EeiHN4fdcelXbQ" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_9hFagsr5EeiHN4fdcelXbQ" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_9hFag8r5EeiHN4fdcelXbQ" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_9hFahMr5EeiHN4fdcelXbQ" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="nested-executions.uml#_9dbCgMr5EeiHN4fdcelXbQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9hFahcr5EeiHN4fdcelXbQ" x="347" y="25" width="100" height="28"/>
+      </children>
+      <element xmi:type="uml:Interaction" href="nested-executions.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+    </children>
+    <element xmi:type="uml:Interaction" href="nested-executions.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SnR91EppEeiB_O7ig5LXPg" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_SnR91UppEeiB_O7ig5LXPg" name="diagram_compatibility_version" stringValue="1.4.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_SnR91kppEeiB_O7ig5LXPg"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_SnR910ppEeiB_O7ig5LXPg" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="nested-executions.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="nested-executions.uml#_R_u1oEppEeiB_O7ig5LXPg"/>
+  <edges xmi:type="notation:Connector" xmi:id="_xm4fwOmtEeiy0sMNphMqbA" type="Edge_Message" source="_FTODw2pHEeiIJqtZNCF3Dw" target="_xm5G0emtEeiy0sMNphMqbA">
+    <children xmi:type="notation:DecorationNode" xmi:id="_xm4fwemtEeiy0sMNphMqbA" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="nested-executions.uml#_xm34sOmtEeiy0sMNphMqbA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xm4fwumtEeiy0sMNphMqbA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xm4fw-mtEeiy0sMNphMqbA" id="37"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xm4fxOmtEeiy0sMNphMqbA" id="start"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_xm68AOmtEeiy0sMNphMqbA" type="Edge_Message" source="_xm5G0emtEeiy0sMNphMqbA" target="_FTODw2pHEeiIJqtZNCF3Dw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_xm68AemtEeiy0sMNphMqbA" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="nested-executions.uml#_xm5t4emtEeiy0sMNphMqbA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_xm68AumtEeiy0sMNphMqbA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xm68A-mtEeiy0sMNphMqbA" id="end"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xm68BOmtEeiy0sMNphMqbA" id="247"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/nested-executions.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/nested-executions.uml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Oy8JgEppEeiB_O7ig5LXPg" name="lightweight">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_O45nkEppEeiB_O7ig5LXPg">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_R_u1oEppEeiB_O7ig5LXPg" name="DoIt">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_FMyroGpHEeiIJqtZNCF3Dw" name="Lifeline1" coveredBy="_xm3RoOmtEeiy0sMNphMqbA _xm5t4OmtEeiy0sMNphMqbA"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_F4rhQGpHEeiIJqtZNCF3Dw" name="Lifeline2" coveredBy="_xm3RoemtEeiy0sMNphMqbA _xm5G0OmtEeiy0sMNphMqbA _xm5G0-mtEeiy0sMNphMqbA _zWRZwemtEeiy0sMNphMqbA _zWRZwOmtEeiy0sMNphMqbA _zWSA0OmtEeiy0sMNphMqbA _7ee3AOmtEeiy0sMNphMqbA _7eeP8OmtEeiy0sMNphMqbA _7edo4OmtEeiy0sMNphMqbA _IVIj4OmvEeiy0sMNphMqbA _IU2QAOmvEeiy0sMNphMqbA _IV9DQOmvEeiy0sMNphMqbA"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_9dbCgMr5EeiHN4fdcelXbQ" name="Lifeline3"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_xm3RoOmtEeiy0sMNphMqbA" name="request_send" covered="_FMyroGpHEeiIJqtZNCF3Dw" message="_xm34sOmtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_xm3RoemtEeiy0sMNphMqbA" name="request_recv" covered="_F4rhQGpHEeiIJqtZNCF3Dw" message="_xm34sOmtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_xm5G0OmtEeiy0sMNphMqbA" name="exec1" covered="_F4rhQGpHEeiIJqtZNCF3Dw" finish="_xm5G0-mtEeiy0sMNphMqbA" start="_xm3RoemtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_zWRZwemtEeiy0sMNphMqbA" name="exec2_start" covered="_F4rhQGpHEeiIJqtZNCF3Dw" execution="_zWRZwOmtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_zWRZwOmtEeiy0sMNphMqbA" name="exec2" covered="_F4rhQGpHEeiIJqtZNCF3Dw" finish="_zWSA0OmtEeiy0sMNphMqbA" start="_zWRZwemtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_7eeP8OmtEeiy0sMNphMqbA" name="exec3_start" covered="_F4rhQGpHEeiIJqtZNCF3Dw" execution="_7edo4OmtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_7edo4OmtEeiy0sMNphMqbA" name="exec3" covered="_F4rhQGpHEeiIJqtZNCF3Dw" finish="_7ee3AOmtEeiy0sMNphMqbA" start="_7eeP8OmtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_7ee3AOmtEeiy0sMNphMqbA" name="exec3_finish" covered="_F4rhQGpHEeiIJqtZNCF3Dw" execution="_7edo4OmtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_zWSA0OmtEeiy0sMNphMqbA" name="exec2_finish" covered="_F4rhQGpHEeiIJqtZNCF3Dw" execution="_zWRZwOmtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_xm5G0-mtEeiy0sMNphMqbA" name="reply_send" covered="_F4rhQGpHEeiIJqtZNCF3Dw" message="_xm5t4emtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_xm5t4OmtEeiy0sMNphMqbA" name="reply_recv" covered="_FMyroGpHEeiIJqtZNCF3Dw" message="_xm5t4emtEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_IVIj4OmvEeiy0sMNphMqbA" name="exec4_start" covered="_F4rhQGpHEeiIJqtZNCF3Dw" execution="_IU2QAOmvEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_IU2QAOmvEeiy0sMNphMqbA" name="exec4" covered="_F4rhQGpHEeiIJqtZNCF3Dw" finish="_IV9DQOmvEeiy0sMNphMqbA" start="_IVIj4OmvEeiy0sMNphMqbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_IV9DQOmvEeiy0sMNphMqbA" name="exec4_finish" covered="_F4rhQGpHEeiIJqtZNCF3Dw" execution="_IU2QAOmvEeiy0sMNphMqbA"/>
+    <message xmi:type="uml:Message" xmi:id="_xm34sOmtEeiy0sMNphMqbA" name="request" receiveEvent="_xm3RoemtEeiy0sMNphMqbA" sendEvent="_xm3RoOmtEeiy0sMNphMqbA"/>
+    <message xmi:type="uml:Message" xmi:id="_xm5t4emtEeiy0sMNphMqbA" name="reply" messageSort="reply" receiveEvent="_xm5t4OmtEeiy0sMNphMqbA" sendEvent="_xm5G0-mtEeiy0sMNphMqbA"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixture.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixture.java
@@ -18,6 +18,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import org.eclipse.gef.EditPart;
+
 /**
  * Annotation for fields that represent fixtures in the contextual model or editor, usually an
  * {@link EditorFixture}.
@@ -27,4 +29,19 @@ import java.lang.annotation.Target;
 public @interface AutoFixture {
 	/** An optional element name to search for, which may be qualified or not. */
 	String value() default "";
+
+	//
+	// Nested types
+	//
+
+	/**
+	 * Annotation for {@link AutoFixture @AutoFixture} fields of {@link EditPart} kind to specify the visual
+	 * ID of a child of the top edit-part to resolve as the fixture.
+	 */
+	@Retention(RUNTIME)
+	@Target(FIELD)
+	public @interface VisualID {
+		/** The edit-part visual ID to resolve. */
+		String value();
+	}
 }

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/util/tests/LogicalModelPredicatesTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/util/tests/LogicalModelPredicatesTest.java
@@ -14,7 +14,10 @@ package org.eclipse.papyrus.uml.interaction.model.util.tests;
 
 import static org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage.Literals.MELEMENT__NAME;
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.above;
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.alwaysFalse;
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.alwaysTrue;
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.below;
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.equalTo;
 import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.where;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,6 +26,7 @@ import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.Element;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -73,5 +77,26 @@ public class LogicalModelPredicatesTest {
 		MElement<?> replySend = model.getElement(QN, "reply-send");
 		assertThat(where(MELEMENT__NAME, "request-recv").test(requestRecv), is(true));
 		assertThat(where(MELEMENT__NAME, "request-recv").test(replySend), is(false));
+	}
+
+	@Test
+	public void alwaysTrue_() {
+		assertThat(alwaysTrue().test(model.getMInteraction()), is(true));
+		assertThat(alwaysTrue().test(null), is(true));
+	}
+
+	@Test
+	public void alwaysFalse_() {
+		assertThat(alwaysFalse().test(model.getMInteraction()), is(false));
+		assertThat(alwaysFalse().test(null), is(false));
+	}
+
+	@Test
+	public void equalTo_MElement() {
+		MElement<? extends Element> m = model.getMInteraction();
+		MElement<? extends Element> l = model.getMInteraction().getLifelines().get(0);
+
+		assertThat(equalTo(m).test(m), is(true));
+		assertThat(equalTo(m).test(l), is(false));
 	}
 }


### PR DESCRIPTION
Fix a variety of edit scenarios involving execution nesting, including:

- don't allow partial overlap of execution specifications.  Nesting must be complete or not at all
- ensure that executions dropped onto other executions result in proper nesting, whether the
  execution dropped is smaller than (nested within) or larger than (nesting without) the execution
  on which it is dropped
- the previous item applies equally to executions dropped onto executions on other lifelines as
   on the same lifeline

This also includes some incidental changes unrelated to Issue #411:
- issue #422 (fixing it was required for proper recalculation of executions in other drag/drop scenarios)
- JUnit tests that have been skipping on assumption violations since the merge of changes to the anchoring of delete messages (I worried that it was a regression introduced by changes in this PR, but that turned out not the case)