### PR TITLE
Issue #26 Excess nudging

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.UnexecutableCommand;
@@ -43,6 +44,7 @@ import org.eclipse.gef.editpolicies.FeedbackHelper;
 import org.eclipse.gef.requests.CreateConnectionRequest;
 import org.eclipse.gef.requests.ReconnectRequest;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.ConnectionEditPart;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editpolicies.GraphicalNodeEditPolicy;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateConnectionViewRequest;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
@@ -246,10 +248,11 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 										anchorDesc.offset, start.sort, null,
 										new ExecutionCreationCommandParameter(true, shouldCreateReply(),
 												execType)))
-								.map(cmd -> injectViewInto(request.getConnectionViewDescriptor(), cmd))
+								.map(cmd -> injectViewInto(getEditingDomain(),
+										request.getConnectionViewDescriptor(), cmd))
 								.collect(Collectors.toList()));
 					} else {
-						result = injectViewInto(request.getConnectionViewDescriptor(),
+						result = injectViewInto(getEditingDomain(), request.getConnectionViewDescriptor(),
 								sender.insertMessageAfter(startBefore, startOffset, receiver,
 										anchorDesc.elementBefore.orElse(receiver), anchorDesc.offset,
 										start.sort, null));
@@ -291,17 +294,22 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 										receiver, start.sort, null,
 										new ExecutionCreationCommandParameter(true, shouldCreateReply(),
 												execType)))
-								.map(cmd -> injectViewInto(request.getConnectionViewDescriptor(), cmd))
+								.map(cmd -> injectViewInto(getEditingDomain(),
+										request.getConnectionViewDescriptor(), cmd))
 								.collect(Collectors.toList()));
 					}
 
-					result = injectViewInto(request.getConnectionViewDescriptor(),
+					result = injectViewInto(getEditingDomain(), request.getConnectionViewDescriptor(),
 							sender.insertMessageAfter(startBefore, startOffset, receiver, start.sort, null));
 				}
 
 				return wrap(result);
 			}
 		}.doSwitch(request);
+	}
+
+	protected TransactionalEditingDomain getEditingDomain() {
+		return ((IGraphicalEditPart)getHost()).getEditingDomain();
 	}
 
 	protected Stream<EClass> getAvailableExecutionTypes() {

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LogicalModelCreationEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LogicalModelCreationEditPolicy.java
@@ -19,9 +19,11 @@ import java.util.Optional;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.gef.commands.UnexecutableCommand;
 import org.eclipse.gmf.runtime.diagram.core.util.ViewUtil;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editpolicies.CreationEditPolicy;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateViewAndElementRequest;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateViewRequest;
@@ -60,8 +62,13 @@ public abstract class LogicalModelCreationEditPolicy extends CreationEditPolicy 
 				(IElementType)request.getViewAndElementDescriptor().getCreateElementRequestAdapter()
 						.getAdapter(IElementType.class));
 
-		return result.map(cmd -> injectViewInto(request.getViewAndElementDescriptor(), cmd)).map(this::wrap) //
-				.orElse(UnexecutableCommand.INSTANCE);
+		return result
+				.map(cmd -> injectViewInto(getEditingDomain(), request.getViewAndElementDescriptor(), cmd))
+				.map(this::wrap).orElse(UnexecutableCommand.INSTANCE);
+	}
+
+	protected TransactionalEditingDomain getEditingDomain() {
+		return ((IGraphicalEditPart)getHost()).getEditingDomain();
 	}
 
 	protected abstract Optional<org.eclipse.emf.common.command.Command> getCreationCommand(

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/util/CommandUtil.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/util/CommandUtil.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.common.command.CompoundCommand;
 import org.eclipse.emf.common.util.AbstractTreeIterator;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateViewRequest.ViewDescriptor;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
@@ -41,6 +42,8 @@ public class CommandUtil {
 	/**
 	 * Wrap a creation command to inject the first view that it creates into the given descriptor.
 	 * 
+	 * @param editingDomain
+	 *            the contextual editing domain
 	 * @param viewDescriptor
 	 *            a view descriptor
 	 * @param creationCommand
@@ -48,10 +51,12 @@ public class CommandUtil {
 	 * @return the wrapper, which may just be the original creation command if the view creation cannot be
 	 *         found
 	 */
-	public static Command injectViewInto(ViewDescriptor viewDescriptor, Command creationCommand) {
+	public static Command injectViewInto(EditingDomain editingDomain, ViewDescriptor viewDescriptor,
+			Command creationCommand) {
+
 		if (creationCommand instanceof CreationCommand<?>) {
 			// Need to maintain the specific protocol
-			return injectViewInto(viewDescriptor, (CreationCommand<?>)creationCommand);
+			return injectViewInto(editingDomain, viewDescriptor, (CreationCommand<?>)creationCommand);
 		}
 
 		// Spelunk in the creation command for the view creation
@@ -98,6 +103,8 @@ public class CommandUtil {
 	/**
 	 * Wrap a creation command to inject the first view that it creates into the given descriptor.
 	 * 
+	 * @param editingDomain
+	 *            the contextual editing domain
 	 * @param viewDescriptor
 	 *            a view descriptor
 	 * @param creationCommand
@@ -105,8 +112,8 @@ public class CommandUtil {
 	 * @return the wrapper, which may just be the original creation command if the view creation cannot be
 	 *         found
 	 */
-	public static <T extends EObject> CreationCommand<T> injectViewInto(ViewDescriptor viewDescriptor,
-			CreationCommand<T> creationCommand) {
+	public static <T extends EObject> CreationCommand<T> injectViewInto(EditingDomain editingDomain,
+			ViewDescriptor viewDescriptor, CreationCommand<T> creationCommand) {
 
 		// Spelunk in the creation command for the view creation
 		CreationCommand<? extends View> viewCreation = getViewCreation(viewDescriptor, creationCommand);
@@ -114,7 +121,7 @@ public class CommandUtil {
 
 		if (viewCreation != null) {
 			Supplier<? extends View> viewSupplier = viewCreation;
-			result = creationCommand.andThen(__ -> viewDescriptor.setView(viewSupplier.get()));
+			result = creationCommand.andThen(editingDomain, __ -> viewDescriptor.setView(viewSupplier.get()));
 		}
 
 		return result;

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Graph.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Graph.java
@@ -75,9 +75,11 @@ public interface Graph {
 	 * @see #interactionOrdering()
 	 */
 	default Stream<Vertex> vertices() {
-		return Stream.concat(Stream.of(initial()),
+		Predicate<Vertex> filter = Vertex::exists;
+
+		return Stream.concat(Stream.of(initial()).filter(filter),
 				// Always the interaction first, and the rest sorted after
-				initial().successors().sorted(interactionOrdering()));
+				initial().successors().filter(filter).sorted(interactionOrdering()));
 	}
 
 	/**
@@ -90,6 +92,8 @@ public interface Graph {
 	 */
 	default Stream<Vertex> vertices(EClass type) {
 		Predicate<Vertex> typeFilter = v -> type.isInstance(v.getInteractionElement());
+		typeFilter = typeFilter.and(Vertex::exists);
+
 		return Stream.concat(Stream.of(initial()).filter(typeFilter),
 				// Always the interaction first, and the rest sorted after
 				initial().successors().filter(typeFilter).sorted(interactionOrdering()));

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Visitable.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Visitable.java
@@ -99,4 +99,13 @@ public interface Visitable<T extends Visitable<T>> {
 	default Optional<Group<T>> group(GroupKind kind) {
 		return groups().filter(kind.predicate()).findAny();
 	}
+
+	/**
+	 * Query whether this element still properly exists in the {@linkplain #graph() graph}. It may not exist
+	 * if, for example, the model element that it represents has since been deleted.
+	 * 
+	 * @return whether this element exists
+	 */
+	boolean exists();
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/internal/graph/EdgeImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/internal/graph/EdgeImpl.java
@@ -97,6 +97,11 @@ public class EdgeImpl extends TaggableImpl<EdgeImpl> implements Edge {
 	}
 
 	@Override
+	public boolean exists() {
+		return from.exists() && to.exists();
+	}
+
+	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/internal/graph/VertexImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/internal/graph/VertexImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.papyrus.uml.interaction.internal.graph;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.emf.ecore.util.EcoreUtil.isAncestor;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -126,6 +127,13 @@ public class VertexImpl extends TaggableImpl<VertexImpl> implements Vertex {
 	@Override
 	public Stream<Group<Vertex>> groups() {
 		return immediatePredecessors().filter(Group.class::isInstance).map(Group.class::cast);
+	}
+
+	@Override
+	public boolean exists() {
+		Element interaction = graph.initial().getInteractionElement();
+		Element element = getInteractionElement();
+		return (interaction != null) && (element != null) && isAncestor(interaction, element);
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
@@ -45,6 +45,11 @@
         </eGenericType>
       </eParameters>
     </eOperations>
+    <eOperations name="exists" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Query whether I exist.  A logical model element exists if and only if it is itself contained within an {@link MInteraction} and its underlying UML model {@link #getElement() element} is contained in that logical model's UML interaction."/>
+      </eAnnotations>
+    </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="interaction" lowerBound="1"
         eType="#//MInteraction" changeable="false" volatile="true" transient="true"
         derived="true" resolveProxies="false"/>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
@@ -46,6 +46,7 @@
       <genOperations ecoreOperation="seqd.ecore#//MElement/precedes">
         <genParameters ecoreParameter="seqd.ecore#//MElement/precedes/other"/>
       </genOperations>
+      <genOperations ecoreOperation="seqd.ecore#//MElement/exists"/>
     </genClasses>
     <genClasses ecoreClass="seqd.ecore#//MInteraction">
       <genFeatures property="None" children="true" createChild="false" ecoreFeature="ecore:EReference seqd.ecore#//MInteraction/lifelines"/>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
@@ -186,13 +186,21 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MELEMENT___PRECEDES__MELEMENT = 6;
 
 	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MELEMENT___EXISTS = 7;
+
+	/**
 	 * The number of operations of the '<em>MElement</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
 	 * @generated
 	 * @ordered
 	 */
-	int MELEMENT_OPERATION_COUNT = 7;
+	int MELEMENT_OPERATION_COUNT = 8;
 
 	/**
 	 * The meta object id for the
@@ -323,6 +331,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MINTERACTION___PRECEDES__MELEMENT = MELEMENT___PRECEDES__MELEMENT;
+
+	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MINTERACTION___EXISTS = MELEMENT___EXISTS;
 
 	/**
 	 * The operation id for the '<em>Get Diagram View</em>' operation. <!-- begin-user-doc --> <!--
@@ -577,6 +593,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MLIFELINE___PRECEDES__MELEMENT = MELEMENT___PRECEDES__MELEMENT;
+
+	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MLIFELINE___EXISTS = MELEMENT___EXISTS;
 
 	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -880,6 +904,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MEXECUTION___PRECEDES__MELEMENT = MELEMENT___PRECEDES__MELEMENT;
 
 	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION___EXISTS = MELEMENT___EXISTS;
+
+	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -1141,6 +1173,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MOCCURRENCE___PRECEDES__MELEMENT = MELEMENT___PRECEDES__MELEMENT;
 
 	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MOCCURRENCE___EXISTS = MELEMENT___EXISTS;
+
+	/**
 	 * The operation id for the '<em>Set Covered</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
@@ -1314,6 +1354,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MEXECUTION_OCCURRENCE___PRECEDES__MELEMENT = MOCCURRENCE___PRECEDES__MELEMENT;
+
+	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION_OCCURRENCE___EXISTS = MOCCURRENCE___EXISTS;
 
 	/**
 	 * The operation id for the '<em>Set Covered</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc
@@ -1542,6 +1590,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MMESSAGE_END___PRECEDES__MELEMENT = MOCCURRENCE___PRECEDES__MELEMENT;
 
 	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MMESSAGE_END___EXISTS = MOCCURRENCE___EXISTS;
+
+	/**
 	 * The operation id for the '<em>Set Covered</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc
 	 * -->
 	 * 
@@ -1740,6 +1796,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MMESSAGE___PRECEDES__MELEMENT = MELEMENT___PRECEDES__MELEMENT;
+
+	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MMESSAGE___EXISTS = MELEMENT___EXISTS;
 
 	/**
 	 * The operation id for the '<em>Get Owner</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1957,6 +2021,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MDESTRUCTION___PRECEDES__MELEMENT = MMESSAGE_END___PRECEDES__MELEMENT;
+
+	/**
+	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MDESTRUCTION___EXISTS = MMESSAGE_END___EXISTS;
 
 	/**
 	 * The operation id for the '<em>Set Covered</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc
@@ -2192,6 +2264,16 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 */
 	EOperation getMElement__Precedes__MElement();
+
+	/**
+	 * Returns the meta object for the '{@link org.eclipse.papyrus.uml.interaction.model.MElement#exists()
+	 * <em>Exists</em>}' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the '<em>Exists</em>' operation.
+	 * @see org.eclipse.papyrus.uml.interaction.model.MElement#exists()
+	 * @generated
+	 */
+	EOperation getMElement__Exists();
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.papyrus.uml.interaction.model.MInteraction
@@ -3319,6 +3401,14 @@ public interface SequenceDiagramPackage extends EPackage {
 		 * @generated
 		 */
 		EOperation MELEMENT___PRECEDES__MELEMENT = eINSTANCE.getMElement__Precedes__MElement();
+
+		/**
+		 * The meta object literal for the '<em><b>Exists</b></em>' operation. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
+		 * @generated
+		 */
+		EOperation MELEMENT___EXISTS = eINSTANCE.getMElement__Exists();
 
 		/**
 		 * The meta object literal for the

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MContainmentList.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MContainmentList.java
@@ -13,7 +13,10 @@
 package org.eclipse.papyrus.uml.interaction.internal.model.impl;
 
 import java.util.Collection;
+import java.util.List;
 
+import org.eclipse.emf.common.util.DelegatingEList;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 
@@ -85,5 +88,72 @@ class MContainmentList<E> extends EObjectContainmentEList<E> {
 	@Override
 	public E move(int targetIndex, int sourceIndex) {
 		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Obtain a mutable view of this list to support internal mutation operations.
+	 * 
+	 * @return a mutable view of me
+	 */
+	@SuppressWarnings("serial")
+	public EList<E> mutableList() {
+		return new DelegatingEList<E>() {
+
+			@Override
+			protected List<E> delegateList() {
+				return MContainmentList.this;
+			}
+
+			@Override
+			public boolean add(E object) {
+				return MContainmentList.super.add(object);
+			}
+
+			@Override
+			public void add(int index, E object) {
+				MContainmentList.super.add(index, object);
+			}
+
+			@Override
+			public boolean addAll(Collection<? extends E> collection) {
+				return MContainmentList.super.addAll(collection);
+			}
+
+			@Override
+			public boolean addAll(int index, Collection<? extends E> collection) {
+				return MContainmentList.super.addAll(index, collection);
+			}
+
+			@Override
+			public E remove(int index) {
+				return MContainmentList.super.remove(index);
+			}
+
+			@Override
+			public boolean remove(Object object) {
+				return MContainmentList.super.remove(object);
+			}
+
+			@Override
+			public boolean removeAll(Collection<?> collection) {
+				return MContainmentList.super.removeAll(collection);
+			}
+
+			@Override
+			public E set(int index, E object) {
+				return MContainmentList.super.set(index, object);
+			}
+
+			@Override
+			public void move(int index, E object) {
+				MContainmentList.super.move(index, object);
+			}
+
+			@Override
+			public E move(int targetIndex, int sourceIndex) {
+				return MContainmentList.super.move(targetIndex, sourceIndex);
+			}
+
+		};
 	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionImpl.java
@@ -272,7 +272,8 @@ public class MExecutionImpl extends MElementImpl<ExecutionSpecification> impleme
 	// Create the logical model for my new start/finish occurrence
 	private CreationCommand<ExecutionOccurrenceSpecification> wrap(
 			CreationCommand<ExecutionOccurrenceSpecification> create) {
-		return (create == null) ? null : create.andThen(this::create);
+
+		return (create == null) ? null : create.andThen(getEditingDomain(), this::create);
 	}
 
 	private void create(ExecutionOccurrenceSpecification occurrence) {
@@ -365,7 +366,8 @@ public class MExecutionImpl extends MElementImpl<ExecutionSpecification> impleme
 	 */
 	@Override
 	public Command remove() {
-		return new RemoveExecutionCommand(this, true);
+		return this.removeLogicalElement(RemoveExecutionCommand.class,
+				() -> new RemoveExecutionCommand(this, true));
 	}
 
 } // MExecutionImpl

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionOccurrenceImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MExecutionOccurrenceImpl.java
@@ -93,7 +93,8 @@ public class MExecutionOccurrenceImpl extends MOccurrenceImpl<ExecutionOccurrenc
 
 	@Override
 	public Command remove() {
-		return new RemoveExecutionOccurrenceCommand(this);
+		return this.removeLogicalElement(RemoveExecutionOccurrenceCommand.class,
+				() -> new RemoveExecutionOccurrenceCommand(this));
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MMessageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MMessageImpl.java
@@ -447,7 +447,8 @@ public class MMessageImpl extends MElementImpl<Message> implements MMessage {
 	 */
 	@Override
 	public Command remove() {
-		return new RemoveMessageCommand(this, true);
+		return this.removeLogicalElement(RemoveMessageCommand.class,
+				() -> new RemoveMessageCommand(this, true));
 	}
 
 } // MMessageImpl

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
@@ -362,6 +362,16 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
+	public EOperation getMElement__Exists() {
+		return mElementEClass.getEOperations().get(7);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
 	public EClass getMInteraction() {
 		return mInteractionEClass;
 	}
@@ -1269,6 +1279,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		createEOperation(mElementEClass, MELEMENT___NUDGE__INT);
 		createEOperation(mElementEClass, MELEMENT___REMOVE);
 		createEOperation(mElementEClass, MELEMENT___PRECEDES__MELEMENT);
+		createEOperation(mElementEClass, MELEMENT___EXISTS);
 
 		mInteractionEClass = createEClass(MINTERACTION);
 		createEReference(mInteractionEClass, MINTERACTION__LIFELINES);
@@ -1516,6 +1527,9 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		g2 = createEGenericType();
 		g1.getETypeArguments().add(g2);
 		addEParameter(op, g1, "other", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		initEOperation(getMElement__Exists(), ecorePackage.getEBoolean(), "exists", 1, 1, IS_UNIQUE, //$NON-NLS-1$
+				IS_ORDERED);
 
 		initEClass(mInteractionEClass, MInteraction.class, "MInteraction", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
 				IS_GENERATED_INSTANCE_CLASS);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
@@ -183,4 +183,15 @@ public interface MElement<T extends Element> extends MObject {
 	 */
 	boolean precedes(MElement<?> other);
 
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc --> <!-- begin-model-doc --> Query whether I exist. A logical
+	 * model element exists if and only if it is itself contained within an {@link MInteraction} and its
+	 * underlying UML model {@link #getElement() element} is contained in that logical model's UML
+	 * interaction. <!-- end-model-doc -->
+	 * 
+	 * @model required="true"
+	 * @generated
+	 */
+	boolean exists();
+
 } // MElement

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeOnRemovalCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeOnRemovalCommand.java
@@ -63,7 +63,7 @@ public class NudgeOnRemovalCommand extends ModelCommand<MInteractionImpl> {
 	 *            the elements which will be removed
 	 */
 	public NudgeOnRemovalCommand(EditingDomain editingDomain, MInteractionImpl interaction,
-			Collection<Element> elementsToRemove) {
+			Collection<? extends Element> elementsToRemove) {
 		super(interaction);
 
 		this.interaction = interaction;
@@ -90,7 +90,9 @@ public class NudgeOnRemovalCommand extends ModelCommand<MInteractionImpl> {
 	 * @param elementsToRemove
 	 *            the removed {@link Element elements}
 	 */
-	private Set<MElement<? extends Element>> getRemovedMElements(Collection<Element> elementsToRemove) {
+	private Set<MElement<? extends Element>> getRemovedMElements(
+			Collection<? extends Element> elementsToRemove) {
+
 		return elementsToRemove.stream()//
 				.map(interaction::getElement)//
 				.filter(Optional::isPresent)//

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionCommand.java
@@ -131,4 +131,9 @@ public class RemoveExecutionCommand extends ModelCommand<MExecutionImpl> impleme
 		return delegate.getElementsToRemove();
 	}
 
+	@Override
+	public RemovalCommand<Element> chain(Command next) {
+		return andThen(getTarget().getEditingDomain(), next);
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionOccurrenceCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveExecutionOccurrenceCommand.java
@@ -12,14 +12,19 @@
 
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.edit.command.DeleteCommand;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MExecutionOccurrenceImpl;
+import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommand;
+import org.eclipse.uml2.uml.Element;
 
 /**
  * A command to remove an execution occurrence.
  */
-public class RemoveExecutionOccurrenceCommand extends ModelCommand<MExecutionOccurrenceImpl> {
+public class RemoveExecutionOccurrenceCommand extends ModelCommand<MExecutionOccurrenceImpl> implements RemovalCommand<Element> {
 
 	/**
 	 * Initializes me.
@@ -36,4 +41,15 @@ public class RemoveExecutionOccurrenceCommand extends ModelCommand<MExecutionOcc
 		// Execution occurrences don't have any notation to worry about
 		return DeleteCommand.create(getEditingDomain(), getTarget().getElement());
 	}
+
+	@Override
+	public Collection<Element> getElementsToRemove() {
+		return Collections.singleton(getTarget().getElement());
+	}
+
+	@Override
+	public RemovalCommand<Element> chain(Command next) {
+		return andThen(getTarget().getEditingDomain(), next);
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveLifelineCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveLifelineCommand.java
@@ -115,4 +115,10 @@ public class RemoveLifelineCommand extends ModelCommand<MLifelineImpl> implement
 		}
 		return delegate.getElementsToRemove();
 	}
+
+	@Override
+	public RemovalCommand<Element> chain(Command next) {
+		return andThen(getTarget().getEditingDomain(), next);
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveMessageCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RemoveMessageCommand.java
@@ -134,4 +134,9 @@ public class RemoveMessageCommand extends ModelCommand<MMessageImpl> implements 
 		return delegate.getElementsToRemove();
 	}
 
+	@Override
+	public RemovalCommand<Element> chain(Command next) {
+		return andThen(getTarget().getEditingDomain(), next);
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
@@ -282,13 +282,11 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 						() -> reconnectSource(connector, newAttachedShape.get(), newYPosition).orElse(null)));
 				Optional<MMessageEnd> otherEnd = end.getOtherEnd();
 				otherEnd.flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
-				otherEnd.flatMap(this::handleOppositeSendOrReplyMessage).ifPresent(commandSink);
 			} else if (end.isReceive()) {
 				commandSink.accept(defer(
 						() -> reconnectTarget(connector, newAttachedShape.get(), newYPosition).orElse(null)));
 				Optional<MMessageEnd> otherEnd = end.getOtherEnd();
 				otherEnd.flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
-				otherEnd.flatMap(this::handleOppositeSendOrReplyMessage).ifPresent(commandSink);
 			} // else don't know what to do with it
 		}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
@@ -282,11 +282,13 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 						() -> reconnectSource(connector, newAttachedShape.get(), newYPosition).orElse(null)));
 				Optional<MMessageEnd> otherEnd = end.getOtherEnd();
 				otherEnd.flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
+				otherEnd.flatMap(this::handleOppositeSendOrReplyMessage).ifPresent(commandSink);
 			} else if (end.isReceive()) {
 				commandSink.accept(defer(
 						() -> reconnectTarget(connector, newAttachedShape.get(), newYPosition).orElse(null)));
 				Optional<MMessageEnd> otherEnd = end.getOtherEnd();
 				otherEnd.flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
+				otherEnd.flatMap(this::handleOppositeSendOrReplyMessage).ifPresent(commandSink);
 			} // else don't know what to do with it
 		}
 
@@ -351,7 +353,8 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 
 		if (endToMove.isPresent() && endToMove.get() instanceof MOccurrenceImpl<?>) {
 			MOccurrenceImpl<?> occurrence = (MOccurrenceImpl<?>)endToMove.get();
-			if (occurrence.getCovered().filter(l -> l != lifeline).isPresent() && occurrence != getTarget()) {
+			if (occurrence.getCovered().filter(equalTo(lifeline).negate()).isPresent()
+					&& !equalTo(occurrence).test(getTarget())) {
 				OptionalInt y = targetY.orElse(occurrence.getBottom());
 				if (anyDestructionOccurrenceBefore(y)) {
 					return Optional.of(UnexecutableCommand.INSTANCE);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/impl/InteractionModelBuilder.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/impl/InteractionModelBuilder.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.papyrus.uml.interaction.graph.Graph;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.uml2.uml.DestructionOccurrenceSpecification;
 import org.eclipse.uml2.uml.Element;
@@ -135,6 +136,22 @@ public class InteractionModelBuilder {
 			}
 
 			@Override
+			public MInteraction caseExecutionSpecification(ExecutionSpecification object) {
+				doSwitch(object.getStart());
+				doSwitch(object.getFinish());
+
+				return super.caseExecutionSpecification(object);
+			}
+
+			@Override
+			public MInteraction caseMessage(Message object) {
+				// A new message
+				messageBuilder(logicalModel).accept(object);
+
+				return super.caseMessage(object);
+			}
+
+			@Override
 			public MInteraction defaultCase(EObject object) {
 				return logicalModel;
 			}
@@ -142,6 +159,10 @@ public class InteractionModelBuilder {
 		};
 
 		return modelUpdater.doSwitch(newElement);
+	}
+
+	public static MInteraction add(MElement<? extends Element> context, Element newElement) {
+		return getInstance(context.getInteraction()).add(context.getElement(), newElement);
 	}
 
 	void build(MInteractionImpl interaction, Interaction uml) {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/ElementRemovalCommandImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/ElementRemovalCommandImpl.java
@@ -70,8 +70,8 @@ public class ElementRemovalCommandImpl extends CommandWrapper implements Removal
 	}
 
 	@Override
-	public Command chain(Command next) {
-		return CompoundModelCommand.compose(domain, this, next);
+	public RemovalCommand<Element> chain(Command next) {
+		return andThen(domain, next);
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/ExecutionCreationCommandParameter.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/ExecutionCreationCommandParameter.java
@@ -11,9 +11,17 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.interaction.model.spi;
 
+import static org.eclipse.papyrus.uml.interaction.graph.util.CrossReferenceUtil.invertSingle;
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
 import static org.eclipse.uml2.uml.UMLPackage.Literals.ACTION_EXECUTION_SPECIFICATION;
 
+import java.util.Optional;
+
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Message;
+import org.eclipse.uml2.uml.MessageEnd;
+import org.eclipse.uml2.uml.UMLPackage;
 
 public class ExecutionCreationCommandParameter {
 
@@ -47,4 +55,29 @@ public class ExecutionCreationCommandParameter {
 		return executionType;
 	}
 
+	public Optional<ExecutionSpecification> getExecution(Message request) {
+		Optional<ExecutionSpecification> result;
+
+		if (!isCreateExecution()) {
+			result = Optional.empty();
+		} else {
+			result = invertSingle(request.getReceiveEvent(),
+					UMLPackage.Literals.EXECUTION_SPECIFICATION__START, ExecutionSpecification.class);
+		}
+
+		return result;
+	}
+
+	public Optional<Message> getReply(Message request) {
+		Optional<Message> result;
+
+		if (!isCreateReply()) {
+			result = Optional.empty();
+		} else {
+			result = as(getExecution(request).map(ExecutionSpecification::getFinish), MessageEnd.class)
+					.map(MessageEnd::getMessage);
+		}
+
+		return result;
+	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/RemovalCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/spi/RemovalCommand.java
@@ -12,11 +12,17 @@
 
 package org.eclipse.papyrus.uml.interaction.model.spi;
 
+import static org.eclipse.papyrus.uml.interaction.internal.model.commands.CompoundModelCommand.compose;
+
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Supplier;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CommandWrapper;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.edit.domain.EditingDomain;
 
 /**
  * Command which is supposed to delete model element. It offers methods to access the elements marked for
@@ -33,5 +39,60 @@ public interface RemovalCommand<T extends EObject> extends Command, Supplier<Col
 	default Collection<T> get() {
 		return getElementsToRemove();
 	}
+
+	/**
+	 * Obtain a view of myself that, after I am executed, follows up with the {@code next} command and returns
+	 * my own result as its removal result.
+	 * 
+	 * @param domain
+	 *            the contextual editing domain
+	 * @param next
+	 *            the next command to execute
+	 * @return myself, with follow-up
+	 */
+	default RemovalCommand<T> andThen(EditingDomain domain, Command next) {
+		class AndThen extends CommandWrapper implements RemovalCommand<T> {
+			// Anticipate a small number of follow-ups
+			private final List<Command> toCompose = new ArrayList<>(3);
+
+			AndThen(Command followUp) {
+				super();
+
+				toCompose.add(followUp);
+			}
+
+			@Override
+			protected Command createCommand() {
+				Command result = compose(domain, RemovalCommand.this, toCompose.get(0));
+				for (int i = 1; i < toCompose.size(); i++) {
+					result = result.chain(toCompose.get(i));
+				}
+				toCompose.clear();
+				return result;
+			}
+
+			@Override
+			public RemovalCommand<T> andThen(EditingDomain domain_, Command followUp) {
+				toCompose.add(followUp);
+				return this;
+			}
+
+			@Override
+			public RemovalCommand<T> chain(Command nextCommand) {
+				toCompose.add(nextCommand);
+				return this;
+			}
+
+			@Override
+			public Collection<T> getElementsToRemove() {
+				return RemovalCommand.this.getElementsToRemove();
+			}
+		}
+
+		return new AndThen(next);
+	}
+
+	@Override
+	RemovalCommand<T> chain(Command next);
 
 }

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MElementTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MElementTest.java
@@ -90,6 +90,7 @@ import junit.framework.TestCase;
  * <li>{@link org.eclipse.papyrus.uml.interaction.model.MElement#remove() <em>Remove</em>}</li>
  * <li>{@link org.eclipse.papyrus.uml.interaction.model.MElement#precedes(org.eclipse.papyrus.uml.interaction.model.MElement)
  * <em>Precedes</em>}</li>
+ * <li>{@link org.eclipse.papyrus.uml.interaction.model.MElement#exists() <em>Exists</em>}</li>
  * </ul>
  * </p>
  * 
@@ -558,6 +559,17 @@ public abstract class MElementTest extends TestCase {
 		assumeThat("no following element", getFixture().following(), isPresent());
 		assertThat("precedes() not consistent with following()",
 				getFixture().precedes(getFixture().following().get()), is(true));
+	}
+
+	/**
+	 * Tests the '{@link org.eclipse.papyrus.uml.interaction.model.MElement#exists() <em>Exists</em>}'
+	 * operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @see org.eclipse.papyrus.uml.interaction.model.MElement#exists()
+	 * @generated NOT
+	 */
+	public void testExists() {
+		assertThat("Fixture does not exist", getFixture().exists(), is(true));
 	}
 
 } // MElementTest

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MExecutionTest.java
@@ -12,9 +12,10 @@
  */
 package org.eclipse.papyrus.uml.interaction.model.tests;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.eclipse.emf.ecore.util.EcoreUtil.isAncestor;
 import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.gt;
 import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.lt;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -31,20 +32,23 @@ import java.util.OptionalInt;
 import java.util.function.Predicate;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.edit.command.DeleteCommand;
 import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
 import org.eclipse.uml2.uml.ActionExecutionSpecification;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.ExecutionOccurrenceSpecification;
+import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.InteractionFragment;
 import org.eclipse.uml2.uml.Lifeline;
 import org.eclipse.uml2.uml.MessageOccurrenceSpecification;
-import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.OpaqueAction;
 import org.eclipse.uml2.uml.UMLFactory;
 import org.eclipse.uml2.uml.UMLPackage;
@@ -290,7 +294,6 @@ public class MExecutionTest extends MElementTest {
 	 *      int, int, org.eclipse.emf.ecore.EClass)
 	 * @generated NOT
 	 */
-	@SuppressWarnings("boxing")
 	public void testInsertNestedExecutionAfter__MElement_int_int_EClass() {
 
 		assertThat(getFixture().getNestedExecutions().size(), equalTo(1));
@@ -476,4 +479,30 @@ public class MExecutionTest extends MElementTest {
 		assertFalse(findTypeInChildren(lifeLineView.get(), "Shape_Execution_Specification").isPresent());
 	}
 
+	@Override
+	public void testExists() {
+		MExecution execution = getFixture();
+
+		super.testExists();
+
+		Command remove = execution.remove();
+		assumeThat("Cannot remove to continue test", remove, executable());
+		execute(remove);
+
+		assertThat("Should not exist", execution.exists(), is(false));
+	}
+
+	public void testExists_umlOnly() {
+		MExecution execution = getFixture();
+		MInteraction logicalModel = execution.getInteraction();
+
+		// Only delete the underlying UML
+		Command delete = DeleteCommand.create(domain, execution.getElement());
+		assumeThat("Cannot delete to continue test", delete, executable());
+		execute(delete);
+
+		assumeThat("Logical model execution detached", isAncestor((EObject)logicalModel, (EObject)execution),
+				is(true));
+		assertThat("Should not exist", execution.exists(), is(false));
+	}
 } // MExecutionTest

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/tests/message-signatures.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/tests/message-signatures.notation
@@ -188,16 +188,16 @@
       <owner xmi:type="uml:Interaction" href="message-signatures.uml#_m-OZIM2MEeibJKzk6Q8eKg"/>
     </styles>
     <element xmi:type="uml:Interaction" href="message-signatures.uml#_m-OZIM2MEeibJKzk6Q8eKg"/>
-    <edges xmi:type="notation:Connector" xmi:id="_-rtiIM2MEeibJKzk6Q8eKg" type="Edge_Message" source="_slnfc82MEeibJKzk6Q8eKg" target="_tQrOo82MEeibJKzk6Q8eKg">
+    <edges xmi:type="notation:Connector" xmi:id="_-rtiIM2MEeibJKzk6Q8eKg" type="Edge_Message" source="_slnfc82MEeibJKzk6Q8eKg" target="_-r1d8M2MEeibJKzk6Q8eKg">
       <element xmi:type="uml:Message" href="message-signatures.uml#_-ropoM2MEeibJKzk6Q8eKg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-rtiIc2MEeibJKzk6Q8eKg"/>
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-rtiIs2MEeibJKzk6Q8eKg" id="57"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-rtiI82MEeibJKzk6Q8eKg" id="57"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-rtiI82MEeibJKzk6Q8eKg" id="start"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_-rxzkM2MEeibJKzk6Q8eKg" type="Edge_Message" source="_tQrOo82MEeibJKzk6Q8eKg" target="_slnfc82MEeibJKzk6Q8eKg">
+    <edges xmi:type="notation:Connector" xmi:id="_-rxzkM2MEeibJKzk6Q8eKg" type="Edge_Message" source="_-r1d8M2MEeibJKzk6Q8eKg" target="_slnfc82MEeibJKzk6Q8eKg">
       <element xmi:type="uml:Message" href="message-signatures.uml#_-rwlcM2MEeibJKzk6Q8eKg"/>
       <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-rxzkc2MEeibJKzk6Q8eKg"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-rxzks2MEeibJKzk6Q8eKg" id="97"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-rxzks2MEeibJKzk6Q8eKg" id="end"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-rxzk82MEeibJKzk6Q8eKg" id="97"/>
     </edges>
   </notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateSelfMessageNudgeTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateSelfMessageNudgeTest.java
@@ -61,8 +61,11 @@ public class CreateSelfMessageNudgeTest {
 		/* assert */
 		/* top not moved */
 		assertEquals(execTop, interaction().getLifelines().get(0).getExecutions().get(0).getTop().getAsInt());
-		/* exec bottom to message bottom should be 50 (height of exec) */
-		assertEquals(50, interaction().getLifelines().get(0).getExecutions().get(0).getBottom().getAsInt()
+		/*
+		 * message's padding above is an additional 10 from the top of and its padding below is 30, the
+		 * vertical span of the message
+		 */
+		assertEquals(40, interaction().getLifelines().get(0).getExecutions().get(0).getBottom().getAsInt()
 				- interaction().getMessages().get(0).getBottom().getAsInt());
 	}
 
@@ -93,8 +96,11 @@ public class CreateSelfMessageNudgeTest {
 		/* top not moved */
 		assertEquals(execTop, interaction().getLifelines().get(0).getExecutions().get(0).getTop().getAsInt());
 
-		/* exec bottom to message bottom should be 50 (height of exec) */
-		assertEquals(50, interaction().getLifelines().get(0).getExecutions().get(0).getBottom().getAsInt()
+		/*
+		 * message's padding above is an additional 10 from the top of and its padding below is 30, the
+		 * vertical span of the message
+		 */
+		assertEquals(40, interaction().getLifelines().get(0).getExecutions().get(0).getBottom().getAsInt()
 				- interaction().getMessages().get(0).getBottom().getAsInt());
 	}
 

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/padding/CreateMessagePaddingTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/padding/CreateMessagePaddingTest.java
@@ -162,8 +162,8 @@ public class CreateMessagePaddingTest {
 		/* act */
 		execute(command);
 
-		/* assert */
-		assertEquals(execution1Top + 25, lifeline1().getExecutions().get(0).getTop().getAsInt());
+		/* assert: padding is 10 and we create the message at a distance of 5, so nudge by 5 */
+		assertEquals(execution1Top + 5, lifeline1().getExecutions().get(0).getTop().getAsInt());
 		assertEquals(lifelineBottom + 25, message1().getSend().get().getTop().getAsInt());
 		assertEquals(lifelineBottom + 25, message1().getReceive().get().getTop().getAsInt());
 	}
@@ -183,8 +183,8 @@ public class CreateMessagePaddingTest {
 		/* act */
 		execute(command);
 
-		/* assert */
-		assertEquals(execution1Top + 25, lifeline2().getExecutions().get(0).getTop().getAsInt());
+		/* assert: padding is 10 and we create the message at a distance of 5, so nudge by 5 */
+		assertEquals(execution1Top + 5, lifeline2().getExecutions().get(0).getTop().getAsInt());
 		assertEquals(lifelineBottom + 25, message1().getSend().get().getTop().getAsInt());
 		assertEquals(lifelineBottom + 25, message1().getReceive().get().getTop().getAsInt());
 	}


### PR DESCRIPTION
*This is work in progress for completion of the fragment padding behaviour.*

This pull request addresses a problem of excess nudging down of elements following the insertion of a new fragment.  Previously, the interaction elements following the newly inserted message would be pushed down by an amount equal to the vertical span of empty space preceding those elements (up to the element after which the message is inserted).  Depending on where the message is inserted, in the extreme case it could result in almost doubling the amount of whitespace in the diagram.  Consequently, it would be impossible ever to "fill in" empty space in the diagram by creating messages in it, because unnecessary new whitespace would always be created.

Instead, this pull request nudges the following elements only by the amount of vertical space consumed by the newly inserted message (consistent with the nudge behaviour for insertion of execution specifications).  For horizontal messages, this is zero because they have no height, but for self-messages and sloped asynchronous messages it can be more.  But, even for horizontal messages, there is at least a minimum padding maintained by the nudge as prescribed by the layout constraints.

The primary objective of this pull request is to accomplish the change in nudging by unifying the logic with the `DeferredPaddingCommand` pattern used elsewhere, especially for move scenarios.  This requires several other changes in the *Logical Model* implementation and commands to make it work:

- the `DeferredPaddingCommand` works with logical model elements, so we need to create the logical model representation of the newly inserted message.  *This aligns with other scenarios where the logical model's creation commands also create the logical model view of the new elements*
    - this requires addition of new cases to the *Dependency Graph* API's updater to fit new elements into the graph
- creation of new elements is, itself, deferred, so the accumulation of deferred padding needs to account for that by deferring the determination of what needs to be padded relative to what else.  Accordingly, the `DeferredPaddingCommand` now just accumulates all padding requests to process later when it actually comes time to implement the nudge
- some padding requests are posted that refer to elements that are removed from the model in the interim (e.g., in scenarios of snapping messages to executions, where a start/finish occurrence is replaced by a message end).  So the logical model adds an `exists()` query to detect these cases
- for the same reason as the previous, it is also important now to align the removal commands in the *Logical Model* with creation commands:  whereas creation commands also create the logical model representations of new elements, removal commands now also remove the logical model representations of removed elements
    - this, in turn, implies alignment of the `RemovalCommand` protocol with `CreationCommand` vis-a-vis chaining
- all of this revealed a latent problem in the wrapping of `CreationCommands` to extend them with follow-up actions, in which when the follow-up performs additional model changes, it could trip up on being composed into a plain EMF `CompoundCommand` that doesn't respect the transaction rules, so the editing domain needs to be injected to get the right kind of compound.
    - this trickles down to some clients such as the `CommandUtil` APIs for injecting created views into `ViewDescriptor`s

Some tests, of course, need to be updated that were previously asserting the excessive padding on message insertion.  Other existing tests assure that other nudging scenarios are not broken.