### PR TITLE
Fix #26 Fragment Padding

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
@@ -69,6 +69,7 @@ import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 import org.eclipse.papyrus.uml.interaction.model.spi.ExecutionCreationCommandParameter;
 import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
 import org.eclipse.papyrus.uml.interaction.model.util.Lifelines;
@@ -514,7 +515,7 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 
 		result = constrainReconnection(request, targetEnd).orElse(result);
 
-		if (result.canExecute()) {
+		if ((result != null) && result.canExecute()) {
 			// If we're still good and we're changing a self-message to a non-self-message,
 			// then straighten the message connection
 			Optional<MLifeline> oldLifeline = targetEnd.getCovered();
@@ -580,7 +581,8 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 					return null;
 				} else if (LogicalModelPredicates.above(end).test(obs)) {
 					// Negative nudge to move it upwards
-					return obs.nudge(newY - obs.getBottom().getAsInt() - padding.getAsInt());
+					return obs.nudge(newY - obs.getBottom().getAsInt() - padding.getAsInt(),
+							NudgeKind.PRECEDING);
 				} else {
 					// Positive nudge to move it downwards
 					return obs.nudge(newY - obs.getTop().getAsInt() + padding.getAsInt());

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDragEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDragEditPolicy.java
@@ -48,6 +48,7 @@ import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 import org.eclipse.papyrus.uml.interaction.model.util.Lifelines;
 import org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates;
 import org.eclipse.uml2.uml.Element;
@@ -128,9 +129,14 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 
 				if (!padding.isPresent()) {
 					return null;
+				} else if (LogicalModelPredicates.spans(execution).test(obs)) {
+					// In the case that the obstacle we're nudging spans the object we're
+					// moving, there's nothing to nudge
+					return null;
 				} else if (LogicalModelPredicates.above(execution).test(obs)) {
 					// Negative nudge to move it upwards
-					return obs.nudge(newTop - obs.getBottom().getAsInt() - padding.getAsInt());
+					return obs.nudge(newTop - obs.getBottom().getAsInt() - padding.getAsInt(),
+							NudgeKind.PRECEDING);
 				} else {
 					// Positive nudge to move it downwards
 					return obs.nudge(newBottom - obs.getTop().getAsInt() + padding.getAsInt());

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDragEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/ExecutionSpecificationDragEditPolicy.java
@@ -14,14 +14,10 @@ package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
 
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.isAllowSemanticReordering;
 import static org.eclipse.papyrus.uml.interaction.internal.model.commands.DependencyContext.defer;
+import static org.eclipse.papyrus.uml.interaction.model.util.InteractionFragments.getObstacle;
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
-import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.filter;
-import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.flatMapToInt;
-import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.flatMapToObj;
-import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.mapToInt;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Supplier;
@@ -36,26 +32,26 @@ import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.commands.Command;
-import org.eclipse.gef.commands.UnexecutableCommand;
 import org.eclipse.gef.requests.ChangeBoundsRequest;
 import org.eclipse.gef.tools.ResizeTracker;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IBorderItemEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.figures.IBorderItemLocator;
 import org.eclipse.gmf.runtime.notation.Node;
+import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.LifelineBodyEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.locators.OnLineBorderItemLocator;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.SequenceResizeTracker;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
-import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.util.Lifelines;
+import org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.ExecutionOccurrenceSpecification;
-import org.eclipse.uml2.uml.InteractionFragment;
 import org.eclipse.uml2.uml.OccurrenceSpecification;
 
 /**
@@ -83,8 +79,6 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 
 	@Override
 	protected Command getResizeCommand(ChangeBoundsRequest request, Node execShape, Rectangle newBounds) {
-		org.eclipse.emf.common.command.Command result = null;
-
 		MExecution execution = getExecution();
 
 		OptionalInt top = execution.getTop();
@@ -93,14 +87,58 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 		int absTop = getLayoutHelper().toAbsoluteY(execShape, newBounds.y());
 		int absBottom = getLayoutHelper().toAbsoluteY(execShape, newBounds.bottom());
 
+		org.eclipse.emf.common.command.Command result = null;
 		if (top.isPresent() && (top.getAsInt() != absTop)) {
-			result = getMoveStartCommand(request, execution, absTop);
+			// Check for semantic re-ordering if we're not connecting to a message
+			if (!Lifelines.getMessageReceive(execution.getOwner(), absTop).isPresent()) {
+				result = getNudgeObstacleCommand(request, execution, absTop < top.getAsInt(), absTop,
+						absBottom);
+			}
+
+			result = chain(result, getMoveStartCommand(request, execution, absTop));
 		}
 		if (bottom.isPresent() && (bottom.getAsInt() != absBottom)) {
+			// Check for semantic re-ordering if we're not connecting to a message
+			if (!Lifelines.getMessageSend(execution.getOwner(), absBottom).isPresent()) {
+				result = getNudgeObstacleCommand(request, execution, absBottom < bottom.getAsInt(), absTop,
+						absBottom);
+			}
+
 			result = chain(result, getMoveFinishCommand(request, execution, absBottom));
 		}
 
 		return wrap(result);
+	}
+
+	private org.eclipse.emf.common.command.Command getNudgeObstacleCommand(ChangeBoundsRequest request,
+			MExecution execution, boolean movingUp, int newTop, int newBottom) {
+
+		org.eclipse.emf.common.command.Command result = null;
+
+		// Check for semantic re-ordering
+		if (!isAllowSemanticReordering(request)) {
+			Optional<MElement<? extends Element>> obstacle = getObstacle(execution, movingUp, newTop,
+					newBottom);
+
+			// If there's an obstacle, bump it and everything following (preceding) out of the way
+			result = obstacle.map(obs -> {
+				// Both diagram views exist if we detected the obstacle
+				OptionalInt padding = getLayoutHelper().getPadding(execution.getDiagramView().get(),
+						(View)obs.getDiagramView().get());
+
+				if (!padding.isPresent()) {
+					return null;
+				} else if (LogicalModelPredicates.above(execution).test(obs)) {
+					// Negative nudge to move it upwards
+					return obs.nudge(newTop - obs.getBottom().getAsInt() - padding.getAsInt());
+				} else {
+					// Positive nudge to move it downwards
+					return obs.nudge(newBottom - obs.getTop().getAsInt() + padding.getAsInt());
+				}
+			}).orElse(null);
+		}
+
+		return result;
 	}
 
 	protected org.eclipse.emf.common.command.Command getMoveStartCommand(ChangeBoundsRequest request,
@@ -167,15 +205,7 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 
 	@Override
 	protected Command getMoveCommand(ChangeBoundsRequest request, Node execShape, Rectangle newBounds) {
-		org.eclipse.emf.common.command.Command result = null;
-
 		MExecution execution = getExecution();
-
-		// Check for semantic re-ordering
-		if (!isAllowSemanticReordering(request)
-				&& impliesFragmentReordering(execution, execShape, newBounds)) {
-			return UnexecutableCommand.INSTANCE;
-		}
 
 		OptionalInt top = execution.getTop();
 		OptionalInt bottom = execution.getBottom();
@@ -183,48 +213,23 @@ public class ExecutionSpecificationDragEditPolicy extends ResizableBorderItemPol
 		int absTop = getLayoutHelper().toAbsoluteY(execShape, newBounds.y());
 		int absBottom = getLayoutHelper().toAbsoluteY(execShape, newBounds.bottom());
 
+		org.eclipse.emf.common.command.Command result = null;
+
+		// Check for semantic re-ordering if we're not connecting to a message
+		if (!Lifelines.getMessageReceive(execution.getOwner(), absTop).isPresent()
+				&& !Lifelines.getMessageSend(execution.getOwner(), absBottom).isPresent()) {
+
+			result = getNudgeObstacleCommand(request, execution, request.getMoveDelta().y() < 0, absTop,
+					absBottom);
+		}
+
 		if (top.isPresent() && (top.getAsInt() != absTop) && bottom.isPresent()
 				&& (bottom.getAsInt() != absBottom)) {
 
-			result = getMoveExecutionCommand(request, execution, absTop, absBottom);
+			result = chain(result, getMoveExecutionCommand(request, execution, absTop, absBottom));
 		}
 
 		return wrap(result);
-	}
-
-	protected boolean impliesFragmentReordering(MExecution execution, Node execShape, Rectangle newBounds) {
-		MInteraction interaction = execution.getInteraction();
-		List<InteractionFragment> fragments = interaction.getElement().getFragments();
-
-		// Get the element above that is being moved and could be re-ordered
-		Optional<? extends MElement<? extends Element>> normalizedStart = execution.getStart();
-		Optional<MMessageEnd> startEnd = as(normalizedStart, MMessageEnd.class);
-		if (startEnd.filter(MMessageEnd::isReceive).isPresent()) {
-			// Take the send end
-			normalizedStart = startEnd.flatMap(MMessageEnd::getOtherEnd);
-		}
-		OptionalInt startIndex = filter(
-				mapToInt(normalizedStart, start -> fragments.indexOf(start.getElement())), i -> i > 0);
-		Optional<? extends MElement<? extends Element>> above = flatMapToObj(startIndex,
-				i -> interaction.getElement(fragments.get(i - 1)));
-
-		// Get the element below that is being moved and could be re-ordered
-		Optional<? extends MElement<? extends Element>> normalizedFinish = execution.getFinish();
-		Optional<MMessageEnd> finishEnd = as(normalizedFinish, MMessageEnd.class);
-		if (finishEnd.filter(MMessageEnd::isSend).isPresent()) {
-			// Take the receive end
-			normalizedFinish = finishEnd.flatMap(MMessageEnd::getOtherEnd);
-		}
-		OptionalInt finishIndex = filter(
-				mapToInt(normalizedFinish, finish -> fragments.indexOf(finish.getElement())),
-				i -> i < (fragments.size() - 1));
-		Optional<? extends MElement<? extends Element>> below = flatMapToObj(finishIndex,
-				i -> interaction.getElement(fragments.get(i + 1)));
-
-		int absNewTop = getLayoutHelper().toAbsoluteY(execShape, newBounds.y());
-		int absNewBottom = getLayoutHelper().toAbsoluteY(execShape, newBounds.bottom());
-		return filter(flatMapToInt(above, MElement::getBottom), b -> b >= absNewTop).isPresent()
-				|| filter(flatMapToInt(below, MElement::getTop), t -> t <= absNewBottom).isPresent();
 	}
 
 	protected org.eclipse.emf.common.command.Command getMoveExecutionCommand(ChangeBoundsRequest request,

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/MessageEndpointEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/MessageEndpointEditPolicy.java
@@ -12,15 +12,17 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
 
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.MessageFeedbackHelper.getLocation;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.forwardParameters;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.getOriginalMouseLocation;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.getOriginalSourceLocation;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.getOriginalTargetLocation;
-import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.isAllowSemanticReordering;
-import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.setAllowSemanticReordering;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.setForce;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.setOriginalMouseLocation;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.setOriginalSourceLocation;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.setOriginalTargetLocation;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.setUpdatedSourceLocation;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.setUpdatedTargetLocation;
 
 import com.google.common.eventbus.EventBus;
 
@@ -149,14 +151,17 @@ public class MessageEndpointEditPolicy extends ConnectionEndpointEditPolicy impl
 	protected void showConnectionMoveFeedback(BendpointRequest request) {
 		if (originalSource == null) {
 			originalSource = getConnection().getSourceAnchor();
-			Point sourceLocation = MessageFeedbackHelper.getLocation(originalSource);
+			Point sourceLocation = getLocation(originalSource);
 			setOriginalSourceLocation(request, sourceLocation);
 		}
+		setUpdatedSourceLocation(request, getLocation(getConnection().getSourceAnchor()));
+
 		if (originalTarget == null) {
 			originalTarget = getConnection().getTargetAnchor();
-			Point targetLocation = MessageFeedbackHelper.getLocation(originalTarget);
+			Point targetLocation = getLocation(originalTarget);
 			setOriginalTargetLocation(request, targetLocation);
 		}
+		setUpdatedTargetLocation(request, getLocation(getConnection().getTargetAnchor()));
 
 		FeedbackHelper helper = getFeedbackHelper(request);
 		helper.setMovingStartAnchor(false);
@@ -262,8 +267,8 @@ public class MessageEndpointEditPolicy extends ConnectionEndpointEditPolicy impl
 			sourceReq.setTargetEditPart(source);
 			sourceReq.setConnectionEditPart(connection);
 			sourceReq.setLocation(sourceLocation);
+			forwardParameters(sourceReq, request);
 			setForce(sourceReq, true);
-			setAllowSemanticReordering(sourceReq, isAllowSemanticReordering(request));
 
 			// In case the result of the drag moves the source end to a different edit-part
 			// (for example, a different execution specification)
@@ -286,8 +291,8 @@ public class MessageEndpointEditPolicy extends ConnectionEndpointEditPolicy impl
 				targetReq.setTargetEditPart(target);
 				targetReq.setConnectionEditPart(connection);
 				targetReq.setLocation(targetLocation);
+				forwardParameters(targetReq, request);
 				setForce(targetReq, true);
-				setAllowSemanticReordering(targetReq, isAllowSemanticReordering(request));
 
 				// In case the result of the drag moves the target end to a different edit-part
 				target = retargetRequest(target, targetReq);

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/NoPapyrusEditPolicyProvider.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/NoPapyrusEditPolicyProvider.java
@@ -164,12 +164,11 @@ public class NoPapyrusEditPolicyProvider extends AbstractProvider implements IEd
 					super.setHost(host);
 				}
 
-				@SuppressWarnings("unchecked")
 				@Override
 				protected DropObjectsRequest castToDropObjectsRequest(ChangeBoundsRequest request) {
 					DropObjectsRequest result = super.castToDropObjectsRequest(request);
 
-					PrivateRequestUtils.forwardParameters(request, result);
+					PrivateRequestUtils.forwardParameters(result, request);
 					PrivateRequestUtils.setChangeBoundsRequest(result, request);
 
 					return result;

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/PrivateRequestUtils.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/PrivateRequestUtils.java
@@ -32,6 +32,10 @@ public final class PrivateRequestUtils {
 
 	private static final String ORIGINAL_TARGET_PARAMETER = "__orig_target__"; //$NON-NLS-1$
 
+	private static final String UPDATED_SOURCE_PARAMETER = "__new_source__"; //$NON-NLS-1$
+
+	private static final String UPDATED_TARGET_PARAMETER = "__new_target__"; //$NON-NLS-1$
+
 	private static final String ALLOW_SEMANTIC_REORDERING_PARAMETER = "__allow_semantic_reordering__"; //$NON-NLS-1$
 
 	private static final String CHANGE_BOUNDS_REQUEST_PARAMETER = "__change_bounds_request__"; //$NON-NLS-1$
@@ -39,6 +43,7 @@ public final class PrivateRequestUtils {
 	private static final String[] PARAMETERS = { //
 			FORCE_PARAMETER, //
 			ORIGINAL_MOUSE_PARAMETER, ORIGINAL_SOURCE_PARAMETER, ORIGINAL_TARGET_PARAMETER, //
+			UPDATED_SOURCE_PARAMETER, UPDATED_TARGET_PARAMETER, //
 			ALLOW_SEMANTIC_REORDERING_PARAMETER, CHANGE_BOUNDS_REQUEST_PARAMETER, //
 	};
 
@@ -121,6 +126,29 @@ public final class PrivateRequestUtils {
 	}
 
 	/**
+	 * Queries the updated source anchor location of a {@code request}.
+	 * 
+	 * @param request
+	 *            a request
+	 * @return the updated source anchor location
+	 */
+	static Point getUpdatedSourceLocation(Request request) {
+		return getParameter(request, UPDATED_SOURCE_PARAMETER, Point.class, null);
+	}
+
+	/**
+	 * Set the updated source anchor location of a {@code request}.
+	 * 
+	 * @param request
+	 *            a request
+	 * @param location
+	 *            the updated source anchor location
+	 */
+	static void setUpdatedSourceLocation(Request request, Point location) {
+		setParameter(request, UPDATED_SOURCE_PARAMETER, location);
+	}
+
+	/**
 	 * Queries the original target anchor location of a {@code request}.
 	 * 
 	 * @param request
@@ -141,6 +169,29 @@ public final class PrivateRequestUtils {
 	 */
 	static void setOriginalTargetLocation(Request request, Point location) {
 		setParameter(request, ORIGINAL_TARGET_PARAMETER, location);
+	}
+
+	/**
+	 * Queries the updated target anchor location of a {@code request}.
+	 * 
+	 * @param request
+	 *            a request
+	 * @return the updated target anchor location
+	 */
+	static Point getUpdatedTargetLocation(Request request) {
+		return getParameter(request, UPDATED_TARGET_PARAMETER, Point.class, null);
+	}
+
+	/**
+	 * Set the updated target anchor location of a {@code request}.
+	 * 
+	 * @param request
+	 *            a request
+	 * @param location
+	 *            the updated target anchor location
+	 */
+	static void setUpdatedTargetLocation(Request request, Point location) {
+		setParameter(request, UPDATED_TARGET_PARAMETER, location);
 	}
 
 	/**
@@ -192,12 +243,12 @@ public final class PrivateRequestUtils {
 	 * are forwarded that the "from" request actually bears, and then only those that are not already defined
 	 * in the "to" request.
 	 * 
-	 * @param fromRequest
-	 *            the request bearing parameters
 	 * @param toRequest
 	 *            a request to which to forward them
+	 * @param fromRequest
+	 *            the request bearing parameters
 	 */
-	public static void forwardParameters(Request fromRequest, Request toRequest) {
+	public static void forwardParameters(Request toRequest, Request fromRequest) {
 		Stream.of(PARAMETERS).filter(p -> hasParameter(fromRequest, p))
 				.filter(p -> !hasParameter(toRequest, p))
 				.forEach(p -> setParameter(toRequest, p, getParameter(fromRequest, p, Object.class, null)));

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/TopCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/TopCommand.java
@@ -1,0 +1,129 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.papyrus.commands.wrappers.GEFCommandWrapper;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.DependencyContext;
+
+/**
+ * The topmost command provided by a GEF {@link EditPolicy}. It wraps a dynamically provided command with an
+ * optional kill-switch provided by the {@code DependencyContext}.
+ */
+public final class TopCommand extends GEFCommandWrapper {
+	// Capture the current dependency context
+	private DependencyContext ctx = DependencyContext.get();
+
+	private Command delegate;
+
+	private Supplier<? extends Command> killSwitchSupplier;
+
+	private boolean prepared;
+
+	private boolean canExecute;
+
+	/**
+	 * Initializes me.
+	 */
+	private TopCommand() {
+		super();
+	}
+
+	@SuppressWarnings("boxing")
+	@Override
+	public boolean canExecute() {
+		if (!prepared) {
+			canExecute = ctx.withContext(super::canExecute);
+			prepared = true;
+		}
+		return canExecute;
+	}
+
+	@Override
+	public void execute() {
+		ctx.withContext(super::execute);
+	}
+
+	@Override
+	protected Command createCommand() {
+		Command result = delegate;
+
+		if ((result != null) && result.canExecute() && (killSwitchSupplier != null)) {
+			Command killSwitch = killSwitchSupplier.get();
+			if (killSwitch != null) {
+				result = result.chain(killSwitch);
+			}
+		}
+
+		return result;
+	}
+
+	void setDelegate(Command delegate) {
+		this.delegate = delegate;
+	}
+
+	void setKillSwitchSupplier(Supplier<? extends Command> killSwitchSupplier) {
+		this.killSwitchSupplier = killSwitchSupplier;
+	}
+
+	static Factory factory(Supplier<? extends Command> delegateSupplier) {
+		return new Factory(delegateSupplier);
+	}
+
+	//
+	// Nested types
+	//
+
+	static class Factory implements Supplier<TopCommand>, Consumer<Supplier<? extends Command>> {
+
+		private final TopCommand product = new TopCommand();
+
+		private final Supplier<? extends Command> commandSupplier;
+
+		private Factory(Supplier<? extends Command> commandSupplier) {
+			super();
+
+			this.commandSupplier = commandSupplier;
+		}
+
+		@Override
+		public TopCommand get() {
+			Command supplied = commandSupplier.get();
+			if (supplied == null) {
+				// Don't provide anything
+				return null;
+			}
+
+			// Inject the delegate
+			product.setDelegate(supplied);
+
+			return product;
+		}
+
+		@Override
+		public void accept(Supplier<? extends Command> supplier) {
+			product.setKillSwitchSupplier(supplier);
+		}
+
+		Consumer<Supplier<? extends org.eclipse.emf.common.command.Command>> adapt(
+				Function<org.eclipse.emf.common.command.Command, Command> transform) {
+
+			return emf -> this.accept(() -> transform.apply(emf.get()));
+		}
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Visitable.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Visitable.java
@@ -108,4 +108,25 @@ public interface Visitable<T extends Visitable<T>> {
 	 */
 	boolean exists();
 
+	/**
+	 * Query whether I am a {@link Group}.
+	 * 
+	 * @return whether I am a {@linkplain Group group} of visitable things.
+	 * @see #toGroup()
+	 */
+	default boolean isGroup() {
+		return this instanceof Group;
+	}
+
+	/**
+	 * Cast me as a {@link Group}.
+	 * 
+	 * @return myself, as a {@code Group}
+	 * @throws ClassCastException
+	 *             if I am {@linkplain #isGroup() not a group}
+	 * @see #isGroup()
+	 */
+	default Group<T> toGroup() {
+		return (Group<T>)this;
+	}
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model.edit/plugin.properties
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model.edit/plugin.properties
@@ -71,3 +71,6 @@ _UI_Unknown_feature = Unspecified
 _UI_MLifeline_destructionOccurrence_feature = Destruction Occurrence
 _UI_MLifeline_ownedDestruction_feature = Owned Destruction
 _UI_MMessage_synchronous_feature = Synchronous
+_UI_NudgeKind_elementOnly_literal = Element Only
+_UI_NudgeKind_following_literal = Following
+_UI_NudgeKind_preceding_literal = Preceding

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.ecore
@@ -35,7 +35,14 @@
       </eGenericType>
     </eOperations>
     <eOperations name="nudge" lowerBound="1" eType="#//Command">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Nudge an element and all of its following trace down or up, according to the sign of {@code deltaY}.  Equivalent to {@link #nudge(int, NudgeKind) nudge(deltaY, NudgeKind.FOLLOWING)}."/>
+      </eAnnotations>
       <eParameters name="deltaY" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+    </eOperations>
+    <eOperations name="nudge" lowerBound="1" eType="#//Command">
+      <eParameters name="deltaY" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+      <eParameters name="mode" lowerBound="1" eType="#//NudgeKind"/>
     </eOperations>
     <eOperations name="remove" lowerBound="1" eType="#//Command"/>
     <eOperations name="precedes" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
@@ -781,4 +788,21 @@
       instanceClassName="org.eclipse.papyrus.uml.interaction.model.spi.ExecutionCreationCommandParameter"
       serializable="false"/>
   <eClassifiers xsi:type="ecore:EClass" name="MDestruction" eSuperTypes="#//MMessageEnd"/>
+  <eClassifiers xsi:type="ecore:EEnum" name="NudgeKind">
+    <eLiterals name="elementOnly">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Nudge only the element and no others."/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="following" value="1">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Nudge the element and all following (below) it in the trace."/>
+      </eAnnotations>
+    </eLiterals>
+    <eLiterals name="preceding" value="2">
+      <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+        <details key="documentation" value="Nudge the element and all preceding (above) it in the trace."/>
+      </eAnnotations>
+    </eLiterals>
+  </eClassifiers>
 </ecore:EPackage>

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/model/seqd.genmodel
@@ -15,6 +15,11 @@
       utilityPackageSuffix="model.util" providerPackageSuffix="model.provider" presentationPackageSuffix="model.presentation"
       testsPackageSuffix="model.tests" generateExampleClass="false" multipleEditorPages="false"
       generateModelWizard="false" ecorePackage="seqd.ecore#/" publicationLocation="">
+    <genEnums typeSafeEnumCompatible="false" ecoreEnum="seqd.ecore#//NudgeKind">
+      <genEnumLiterals ecoreEnumLiteral="seqd.ecore#//NudgeKind/elementOnly"/>
+      <genEnumLiterals ecoreEnumLiteral="seqd.ecore#//NudgeKind/following"/>
+      <genEnumLiterals ecoreEnumLiteral="seqd.ecore#//NudgeKind/preceding"/>
+    </genEnums>
     <genDataTypes ecoreDataType="seqd.ecore#//Optional">
       <genTypeParameters ecoreTypeParameter="seqd.ecore#//Optional/T"/>
     </genDataTypes>
@@ -41,6 +46,10 @@
       <genOperations ecoreOperation="seqd.ecore#//MElement/following"/>
       <genOperations ecoreOperation="seqd.ecore#//MElement/nudge">
         <genParameters ecoreParameter="seqd.ecore#//MElement/nudge/deltaY"/>
+      </genOperations>
+      <genOperations ecoreOperation="seqd.ecore#//MElement/nudge.1">
+        <genParameters ecoreParameter="seqd.ecore#//MElement/nudge.1/deltaY"/>
+        <genParameters ecoreParameter="seqd.ecore#//MElement/nudge.1/mode"/>
       </genOperations>
       <genOperations ecoreOperation="seqd.ecore#//MElement/remove"/>
       <genOperations ecoreOperation="seqd.ecore#//MElement/precedes">

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/SequenceDiagramPackage.java
@@ -15,6 +15,7 @@ package org.eclipse.papyrus.uml.interaction.internal.model;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
@@ -170,12 +171,20 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MELEMENT___NUDGE__INT = 4;
 
 	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MELEMENT___NUDGE__INT_NUDGEKIND = 5;
+
+	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
 	 * @ordered
 	 */
-	int MELEMENT___REMOVE = 5;
+	int MELEMENT___REMOVE = 6;
 
 	/**
 	 * The operation id for the '<em>Precedes</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -183,7 +192,7 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int MELEMENT___PRECEDES__MELEMENT = 6;
+	int MELEMENT___PRECEDES__MELEMENT = 7;
 
 	/**
 	 * The operation id for the '<em>Exists</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -191,7 +200,7 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int MELEMENT___EXISTS = 7;
+	int MELEMENT___EXISTS = 8;
 
 	/**
 	 * The number of operations of the '<em>MElement</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
@@ -200,7 +209,7 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int MELEMENT_OPERATION_COUNT = 8;
+	int MELEMENT_OPERATION_COUNT = 9;
 
 	/**
 	 * The meta object id for the
@@ -315,6 +324,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MINTERACTION___NUDGE__INT = MELEMENT___NUDGE__INT;
+
+	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MINTERACTION___NUDGE__INT_NUDGEKIND = MELEMENT___NUDGE__INT_NUDGEKIND;
 
 	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -577,6 +594,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MLIFELINE___NUDGE__INT = MELEMENT___NUDGE__INT;
+
+	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MLIFELINE___NUDGE__INT_NUDGEKIND = MELEMENT___NUDGE__INT_NUDGEKIND;
 
 	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -888,6 +913,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MEXECUTION___NUDGE__INT = MELEMENT___NUDGE__INT;
 
 	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION___NUDGE__INT_NUDGEKIND = MELEMENT___NUDGE__INT_NUDGEKIND;
+
+	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -1157,6 +1190,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MOCCURRENCE___NUDGE__INT = MELEMENT___NUDGE__INT;
 
 	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MOCCURRENCE___NUDGE__INT_NUDGEKIND = MELEMENT___NUDGE__INT_NUDGEKIND;
+
+	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -1338,6 +1379,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MEXECUTION_OCCURRENCE___NUDGE__INT = MOCCURRENCE___NUDGE__INT;
+
+	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MEXECUTION_OCCURRENCE___NUDGE__INT_NUDGEKIND = MOCCURRENCE___NUDGE__INT_NUDGEKIND;
 
 	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1574,6 +1623,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MMESSAGE_END___NUDGE__INT = MOCCURRENCE___NUDGE__INT;
 
 	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MMESSAGE_END___NUDGE__INT_NUDGEKIND = MOCCURRENCE___NUDGE__INT_NUDGEKIND;
+
+	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -1780,6 +1837,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @ordered
 	 */
 	int MMESSAGE___NUDGE__INT = MELEMENT___NUDGE__INT;
+
+	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MMESSAGE___NUDGE__INT_NUDGEKIND = MELEMENT___NUDGE__INT_NUDGEKIND;
 
 	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2007,6 +2072,14 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MDESTRUCTION___NUDGE__INT = MMESSAGE_END___NUDGE__INT;
 
 	/**
+	 * The operation id for the '<em>Nudge</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 * @ordered
+	 */
+	int MDESTRUCTION___NUDGE__INT_NUDGEKIND = MMESSAGE_END___NUDGE__INT_NUDGEKIND;
+
+	/**
 	 * The operation id for the '<em>Remove</em>' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @generated
@@ -2066,13 +2139,23 @@ public interface SequenceDiagramPackage extends EPackage {
 	int MDESTRUCTION_OPERATION_COUNT = MMESSAGE_END_OPERATION_COUNT + 0;
 
 	/**
+	 * The meta object id for the '{@link org.eclipse.papyrus.uml.interaction.model.NudgeKind <em>Nudge
+	 * Kind</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @see org.eclipse.papyrus.uml.interaction.model.NudgeKind
+	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getNudgeKind()
+	 * @generated
+	 */
+	int NUDGE_KIND = 9;
+
+	/**
 	 * The meta object id for the '<em>Optional</em>' data type. <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * 
 	 * @see java.util.Optional
 	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getOptional()
 	 * @generated
 	 */
-	int OPTIONAL = 9;
+	int OPTIONAL = 10;
 
 	/**
 	 * The meta object id for the '<em>Optional Int</em>' data type. <!-- begin-user-doc --> <!-- end-user-doc
@@ -2082,7 +2165,7 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getOptionalInt()
 	 * @generated
 	 */
-	int OPTIONAL_INT = 10;
+	int OPTIONAL_INT = 11;
 
 	/**
 	 * The meta object id for the '<em>Command</em>' data type. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2091,7 +2174,7 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getCommand()
 	 * @generated
 	 */
-	int COMMAND = 11;
+	int COMMAND = 12;
 
 	/**
 	 * The meta object id for the '<em>Creation Command</em>' data type. <!-- begin-user-doc --> <!--
@@ -2101,7 +2184,7 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getCreationCommand()
 	 * @generated
 	 */
-	int CREATION_COMMAND = 12;
+	int CREATION_COMMAND = 13;
 
 	/**
 	 * The meta object id for the '<em>EObject</em>' data type. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -2110,7 +2193,7 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getEObject()
 	 * @generated
 	 */
-	int EOBJECT = 13;
+	int EOBJECT = 14;
 
 	/**
 	 * The meta object id for the '<em>Execution Creation Command Parameter</em>' data type. <!--
@@ -2120,7 +2203,7 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getExecutionCreationCommandParameter()
 	 * @generated
 	 */
-	int EXECUTION_CREATION_COMMAND_PARAMETER = 14;
+	int EXECUTION_CREATION_COMMAND_PARAMETER = 15;
 
 	/**
 	 * Returns the meta object for class '{@link org.eclipse.papyrus.uml.interaction.model.MElement
@@ -2243,6 +2326,18 @@ public interface SequenceDiagramPackage extends EPackage {
 	 * @generated
 	 */
 	EOperation getMElement__Nudge__int();
+
+	/**
+	 * Returns the meta object for the
+	 * '{@link org.eclipse.papyrus.uml.interaction.model.MElement#nudge(int, org.eclipse.papyrus.uml.interaction.model.NudgeKind)
+	 * <em>Nudge</em>}' operation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the '<em>Nudge</em>' operation.
+	 * @see org.eclipse.papyrus.uml.interaction.model.MElement#nudge(int,
+	 *      org.eclipse.papyrus.uml.interaction.model.NudgeKind)
+	 * @generated
+	 */
+	EOperation getMElement__Nudge__int_NudgeKind();
 
 	/**
 	 * Returns the meta object for the '{@link org.eclipse.papyrus.uml.interaction.model.MElement#remove()
@@ -3203,6 +3298,16 @@ public interface SequenceDiagramPackage extends EPackage {
 	EClass getMDestruction();
 
 	/**
+	 * Returns the meta object for enum '{@link org.eclipse.papyrus.uml.interaction.model.NudgeKind <em>Nudge
+	 * Kind</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for enum '<em>Nudge Kind</em>'.
+	 * @see org.eclipse.papyrus.uml.interaction.model.NudgeKind
+	 * @generated
+	 */
+	EEnum getNudgeKind();
+
+	/**
 	 * Returns the meta object for data type '{@link java.util.Optional <em>Optional</em>}'. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
 	 * 
@@ -3385,6 +3490,14 @@ public interface SequenceDiagramPackage extends EPackage {
 		 * @generated
 		 */
 		EOperation MELEMENT___NUDGE__INT = eINSTANCE.getMElement__Nudge__int();
+
+		/**
+		 * The meta object literal for the '<em><b>Nudge</b></em>' operation. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
+		 * @generated
+		 */
+		EOperation MELEMENT___NUDGE__INT_NUDGEKIND = eINSTANCE.getMElement__Nudge__int_NudgeKind();
 
 		/**
 		 * The meta object literal for the '<em><b>Remove</b></em>' operation. <!-- begin-user-doc --> <!--
@@ -4098,6 +4211,16 @@ public interface SequenceDiagramPackage extends EPackage {
 		 * @generated
 		 */
 		EClass MDESTRUCTION = eINSTANCE.getMDestruction();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.papyrus.uml.interaction.model.NudgeKind
+		 * <em>Nudge Kind</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
+		 * @see org.eclipse.papyrus.uml.interaction.model.NudgeKind
+		 * @see org.eclipse.papyrus.uml.interaction.internal.model.impl.SequenceDiagramPackageImpl#getNudgeKind()
+		 * @generated
+		 */
+		EEnum NUDGE_KIND = eINSTANCE.getNudgeKind();
 
 		/**
 		 * The meta object literal for the '<em>Optional</em>' data type. <!-- begin-user-doc --> <!--

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MDestructionImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MDestructionImpl.java
@@ -12,9 +12,11 @@
  */
 package org.eclipse.papyrus.uml.interaction.internal.model.impl;
 
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage;
 import org.eclipse.papyrus.uml.interaction.model.MDestruction;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 import org.eclipse.uml2.uml.DestructionOccurrenceSpecification;
 
 /**
@@ -49,6 +51,14 @@ public class MDestructionImpl extends MMessageEndImpl implements MDestruction {
 	@Override
 	protected EClass eStaticClass() {
 		return SequenceDiagramPackage.Literals.MDESTRUCTION;
+	}
+
+	/**
+	 * The destruction occurrence has a real shape of its own, so it is nudged in its own right.
+	 */
+	@Override
+	public Command nudge(int deltaY, NudgeKind mode) {
+		return basicNudge(deltaY, mode);
 	}
 
 } // MDestructionImpl

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MElementImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MElementImpl.java
@@ -43,6 +43,7 @@ import org.eclipse.papyrus.uml.interaction.internal.model.commands.NudgeCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommand;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.NamedElement;
@@ -226,8 +227,18 @@ public abstract class MElementImpl<T extends Element> extends MObjectImpl<T> imp
 	 * @generated NOT
 	 */
 	@Override
-	public Command nudge(int deltaY) {
-		return new NudgeCommand(this, deltaY);
+	public final Command nudge(int deltaY) {
+		return nudge(deltaY, NudgeKind.FOLLOWING);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated NOT
+	 */
+	@Override
+	public Command nudge(int deltaY, NudgeKind mode) {
+		return new NudgeCommand(this, deltaY, mode);
 	}
 
 	/**
@@ -485,6 +496,8 @@ public abstract class MElementImpl<T extends Element> extends MObjectImpl<T> imp
 				return following();
 			case SequenceDiagramPackage.MELEMENT___NUDGE__INT:
 				return nudge((Integer)arguments.get(0));
+			case SequenceDiagramPackage.MELEMENT___NUDGE__INT_NUDGEKIND:
+				return nudge((Integer)arguments.get(0), (NudgeKind)arguments.get(1));
 			case SequenceDiagramPackage.MELEMENT___REMOVE:
 				return remove();
 			case SequenceDiagramPackage.MELEMENT___PRECEDES__MELEMENT:

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MMessageEndImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MMessageEndImpl.java
@@ -20,11 +20,11 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.gmf.runtime.notation.IdentityAnchor;
 import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage;
-import org.eclipse.papyrus.uml.interaction.internal.model.commands.NudgeCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.InteractionFragment;
 import org.eclipse.uml2.uml.Lifeline;
@@ -200,19 +200,31 @@ public class MMessageEndImpl extends MOccurrenceImpl<MessageEnd> implements MMes
 
 	@SuppressWarnings("boxing")
 	@Override
-	public Command nudge(int deltaY) {
+	public Command nudge(int deltaY, NudgeKind mode) {
 		/*
 		 * If I am the receiving end of a message, only reorient me if I am a found message or if I am part of
 		 * a sloped message. Otherwise move the sending end.
 		 */
 		if (getTop().orElse(0) != getOtherEnd().map(me -> me.getTop().orElse(0)).orElse(0)) {
 			/* part of sloped message, move me */
-			return new NudgeCommand(this, deltaY);
+			return basicNudge(deltaY, mode);
 		}
 
-		MMessageEndImpl end = getOtherEnd().filter(MMessageEnd::isSend).map(MMessageEndImpl.class::cast)
-				.orElse(this);
-		return new NudgeCommand(end, deltaY);
+		return getOtherEnd().filter(MMessageEnd::isSend).map(MMessageEndImpl.class::cast).orElse(this)
+				.basicNudge(deltaY, mode);
+	}
+
+	/**
+	 * The default (superclass) algorithm for the <em>nudge</em> command.
+	 * 
+	 * @param deltaY
+	 *            the amount by which to nudge down (up if negative)
+	 * @param mode
+	 *            the nudge mode
+	 * @return the basic nudge command
+	 */
+	protected Command basicNudge(int deltaY, NudgeKind mode) {
+		return super.nudge(deltaY, mode);
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/ReplaceOccurrenceCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/ReplaceOccurrenceCommand.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.papyrus.uml.interaction.internal.model.commands.ModelCommand;
@@ -59,13 +58,13 @@ public class ReplaceOccurrenceCommand extends ModelCommand<MExecutionOccurrenceI
 		// Likewise if the message end is not an occurrence (e.g., a gate)
 		if ((started.isPresent() == finished.isPresent())
 				|| !(end.getElement() instanceof OccurrenceSpecification)) {
-			return UnexecutableCommand.INSTANCE;
+			return bomb();
 		}
 
 		// Moreover, it does not make sense to replace an execution start by a message send
 		// nor an execution finish by a message receive
 		if ((getTarget().isStart() != end.isReceive()) || (getTarget().isFinish() != end.isSend())) {
-			return UnexecutableCommand.INSTANCE;
+			return bomb();
 		}
 
 		// First, delete me

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramFactoryImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramFactoryImpl.java
@@ -27,6 +27,7 @@ import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 
 /**
  * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!-- end-user-doc -->
@@ -97,6 +98,8 @@ public class SequenceDiagramFactoryImpl extends EFactoryImpl implements Sequence
 	@Override
 	public Object createFromString(EDataType eDataType, String initialValue) {
 		switch (eDataType.getClassifierID()) {
+			case SequenceDiagramPackage.NUDGE_KIND:
+				return createNudgeKindFromString(eDataType, initialValue);
 			default:
 				throw new IllegalArgumentException(
 						"The datatype '" + eDataType.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -111,6 +114,8 @@ public class SequenceDiagramFactoryImpl extends EFactoryImpl implements Sequence
 	@Override
 	public String convertToString(EDataType eDataType, Object instanceValue) {
 		switch (eDataType.getClassifierID()) {
+			case SequenceDiagramPackage.NUDGE_KIND:
+				return convertNudgeKindToString(eDataType, instanceValue);
 			default:
 				throw new IllegalArgumentException(
 						"The datatype '" + eDataType.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -192,6 +197,29 @@ public class SequenceDiagramFactoryImpl extends EFactoryImpl implements Sequence
 	public MDestruction createMDestruction() {
 		MDestructionImpl mDestruction = new MDestructionImpl();
 		return mDestruction;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	public NudgeKind createNudgeKindFromString(EDataType eDataType, String initialValue) {
+		NudgeKind result = NudgeKind.get(initialValue);
+		if (result == null) {
+			throw new IllegalArgumentException("The value '" + initialValue //$NON-NLS-1$
+					+ "' is not a valid enumerator of '" + eDataType.getName() + "'"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		return result;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	public String convertNudgeKindToString(EDataType eDataType, Object instanceValue) {
+		return instanceValue == null ? null : instanceValue.toString();
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/SequenceDiagramPackageImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EEnum;
 import org.eclipse.emf.ecore.EGenericType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EOperation;
@@ -40,6 +41,7 @@ import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 import org.eclipse.papyrus.uml.interaction.model.spi.ExecutionCreationCommandParameter;
 import org.eclipse.uml2.types.TypesPackage;
 import org.eclipse.uml2.uml.UMLPackage;
@@ -112,6 +114,13 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	private EClass mDestructionEClass = null;
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	private EEnum nudgeKindEEnum = null;
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -342,7 +351,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
-	public EOperation getMElement__Remove() {
+	public EOperation getMElement__Nudge__int_NudgeKind() {
 		return mElementEClass.getEOperations().get(5);
 	}
 
@@ -352,7 +361,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
-	public EOperation getMElement__Precedes__MElement() {
+	public EOperation getMElement__Remove() {
 		return mElementEClass.getEOperations().get(6);
 	}
 
@@ -362,8 +371,18 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
-	public EOperation getMElement__Exists() {
+	public EOperation getMElement__Precedes__MElement() {
 		return mElementEClass.getEOperations().get(7);
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	public EOperation getMElement__Exists() {
+		return mElementEClass.getEOperations().get(8);
 	}
 
 	/**
@@ -1182,6 +1201,16 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 	 * @generated
 	 */
 	@Override
+	public EEnum getNudgeKind() {
+		return nudgeKindEEnum;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
 	public EDataType getOptional() {
 		return optionalEDataType;
 	}
@@ -1277,6 +1306,7 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		createEOperation(mElementEClass, MELEMENT___VERTICAL_DISTANCE__MELEMENT);
 		createEOperation(mElementEClass, MELEMENT___FOLLOWING);
 		createEOperation(mElementEClass, MELEMENT___NUDGE__INT);
+		createEOperation(mElementEClass, MELEMENT___NUDGE__INT_NUDGEKIND);
 		createEOperation(mElementEClass, MELEMENT___REMOVE);
 		createEOperation(mElementEClass, MELEMENT___PRECEDES__MELEMENT);
 		createEOperation(mElementEClass, MELEMENT___EXISTS);
@@ -1376,6 +1406,9 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		createEOperation(mMessageEClass, MMESSAGE___GET_END__MESSAGEEND);
 
 		mDestructionEClass = createEClass(MDESTRUCTION);
+
+		// Create enums
+		nudgeKindEEnum = createEEnum(NUDGE_KIND);
 
 		// Create data types
 		optionalEDataType = createEDataType(OPTIONAL);
@@ -1518,6 +1551,11 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 		op = initEOperation(getMElement__Nudge__int(), this.getCommand(), "nudge", 1, 1, IS_UNIQUE, //$NON-NLS-1$
 				IS_ORDERED);
 		addEParameter(op, ecorePackage.getEInt(), "deltaY", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+
+		op = initEOperation(getMElement__Nudge__int_NudgeKind(), this.getCommand(), "nudge", 1, 1, IS_UNIQUE, //$NON-NLS-1$
+				IS_ORDERED);
+		addEParameter(op, ecorePackage.getEInt(), "deltaY", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
+		addEParameter(op, this.getNudgeKind(), "mode", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
 		initEOperation(getMElement__Remove(), this.getCommand(), "remove", 1, 1, IS_UNIQUE, IS_ORDERED); //$NON-NLS-1$
 
@@ -2081,6 +2119,12 @@ public class SequenceDiagramPackageImpl extends EPackageImpl implements Sequence
 
 		initEClass(mDestructionEClass, MDestruction.class, "MDestruction", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
 				IS_GENERATED_INSTANCE_CLASS);
+
+		// Initialize enums and add enum literals
+		initEEnum(nudgeKindEEnum, NudgeKind.class, "NudgeKind"); //$NON-NLS-1$
+		addEEnumLiteral(nudgeKindEEnum, NudgeKind.ELEMENT_ONLY);
+		addEEnumLiteral(nudgeKindEEnum, NudgeKind.FOLLOWING);
+		addEEnumLiteral(nudgeKindEEnum, NudgeKind.PRECEDING);
 
 		// Initialize data types
 		initEDataType(optionalEDataType, Optional.class, "Optional", !IS_SERIALIZABLE, //$NON-NLS-1$

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/MElement.java
@@ -159,13 +159,24 @@ public interface MElement<T extends Element> extends MObject {
 	Optional<MElement<? extends Element>> following();
 
 	/**
-	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc --> <!-- begin-model-doc --> Nudge an element and all of its
+	 * following trace down or up, according to the sign of {@code deltaY}. Equivalent to
+	 * {@link #nudge(int, NudgeKind) nudge(deltaY, NudgeKind.FOLLOWING)}. <!-- end-model-doc -->
 	 * 
 	 * @model dataType="org.eclipse.papyrus.uml.interaction.model.Command" required="true"
 	 *        deltaYRequired="true"
 	 * @generated
 	 */
 	Command nudge(int deltaY);
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @model dataType="org.eclipse.papyrus.uml.interaction.model.Command" required="true"
+	 *        deltaYRequired="true" modeRequired="true"
+	 * @generated
+	 */
+	Command nudge(int deltaY, NudgeKind mode);
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/NudgeKind.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/model/NudgeKind.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *  
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ * 
+ */
+package org.eclipse.papyrus.uml.interaction.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+/**
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration '<em><b>Nudge Kind</b></em>',
+ * and utility methods for working with them. <!-- end-user-doc -->
+ * 
+ * @see org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage#getNudgeKind()
+ * @model
+ * @generated
+ */
+public enum NudgeKind implements Enumerator {
+	/**
+	 * The '<em><b>Element Only</b></em>' literal object. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
+	 * begin-model-doc --> Nudge only the element and no others. <!-- end-model-doc -->
+	 * 
+	 * @see #ELEMENT_ONLY_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	ELEMENT_ONLY(0, "elementOnly", "elementOnly"), //$NON-NLS-1$ //$NON-NLS-2$
+
+	/**
+	 * The '<em><b>Following</b></em>' literal object. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
+	 * begin-model-doc --> Nudge the element and all following (below) it in the trace. <!-- end-model-doc -->
+	 * 
+	 * @see #FOLLOWING_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	FOLLOWING(1, "following", "following"), //$NON-NLS-1$ //$NON-NLS-2$
+
+	/**
+	 * The '<em><b>Preceding</b></em>' literal object. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
+	 * begin-model-doc --> Nudge the element and all preceding (above) it in the trace. <!-- end-model-doc -->
+	 * 
+	 * @see #PRECEDING_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	PRECEDING(2, "preceding", "preceding"); //$NON-NLS-1$ //$NON-NLS-2$
+
+	/**
+	 * The '<em><b>Element Only</b></em>' literal value. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
+	 * begin-model-doc --> Nudge only the element and no others. <!-- end-model-doc -->
+	 * 
+	 * @see #ELEMENT_ONLY
+	 * @model name="elementOnly"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int ELEMENT_ONLY_VALUE = 0;
+
+	/**
+	 * The '<em><b>Following</b></em>' literal value. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
+	 * begin-model-doc --> Nudge the element and all following (below) it in the trace. <!-- end-model-doc -->
+	 * 
+	 * @see #FOLLOWING
+	 * @model name="following"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int FOLLOWING_VALUE = 1;
+
+	/**
+	 * The '<em><b>Preceding</b></em>' literal value. <!-- begin-user-doc --> <!-- end-user-doc --> <!--
+	 * begin-model-doc --> Nudge the element and all preceding (above) it in the trace. <!-- end-model-doc -->
+	 * 
+	 * @see #PRECEDING
+	 * @model name="preceding"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int PRECEDING_VALUE = 2;
+
+	/**
+	 * An array of all the '<em><b>Nudge Kind</b></em>' enumerators. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @generated
+	 */
+	private static final NudgeKind[] VALUES_ARRAY = new NudgeKind[] {ELEMENT_ONLY, FOLLOWING, PRECEDING, };
+
+	/**
+	 * A public read-only list of all the '<em><b>Nudge Kind</b></em>' enumerators. <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	public static final List<NudgeKind> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
+
+	/**
+	 * Returns the '<em><b>Nudge Kind</b></em>' literal with the specified literal value. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param literal
+	 *            the literal.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static NudgeKind get(String literal) {
+		for (NudgeKind result : VALUES_ARRAY) {
+			if (result.toString().equals(literal)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Nudge Kind</b></em>' literal with the specified name. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param name
+	 *            the name.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static NudgeKind getByName(String name) {
+		for (NudgeKind result : VALUES_ARRAY) {
+			if (result.getName().equals(name)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Nudge Kind</b></em>' literal with the specified integer value. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value
+	 *            the integer value.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static NudgeKind get(int value) {
+		switch (value) {
+			case ELEMENT_ONLY_VALUE:
+				return ELEMENT_ONLY;
+			case FOLLOWING_VALUE:
+				return FOLLOWING;
+			case PRECEDING_VALUE:
+				return PRECEDING;
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	private final int value;
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	private final String name;
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	private final String literal;
+
+	/**
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	private NudgeKind(int value, String name, String literal) {
+		this.value = value;
+		this.name = name;
+		this.literal = literal;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	public int getValue() {
+		return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	public String getLiteral() {
+		return literal;
+	}
+
+	/**
+	 * Returns the literal value of the enumerator, which is its string representation. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		return literal;
+	}
+
+} // NudgeKind

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/Create.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/Create.java
@@ -22,11 +22,11 @@ import org.eclipse.papyrus.uml.interaction.graph.Graph;
 import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
-import org.eclipse.papyrus.uml.interaction.internal.model.impl.MMessageImpl;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.MessageSort;
@@ -73,21 +73,21 @@ public final class Create {
 		 */
 		if (element instanceof MExecution) {
 			/* if we are an execution */
-			return new NudgeCommand((MElementImpl<? extends Element>)element, delta, false);
+			return element.nudge(delta, NudgeKind.ELEMENT_ONLY);
 		} else if (element instanceof MMessage) {
 			/* fix one half message */
 			MMessage message = (MMessage)element;
 			if (message.getElement().getMessageSort() == MessageSort.CREATE_MESSAGE_LITERAL) {
 				return creationMessageNudgeCommand(graph, editingDomain, delta, deltaChildren, message);
 			}
-			return new NudgeCommand((MElementImpl<? extends Element>)element, delta, false);
+			return element.nudge(delta, NudgeKind.ELEMENT_ONLY);
 		} else if (element instanceof MLifeline) {
 			List<Command> nudgeCommands = new ArrayList<>();
-			nudgeCommands.add(new NudgeCommand((MElementImpl<? extends Element>)element, delta, false));
+			nudgeCommands.add(element.nudge(delta, NudgeKind.ELEMENT_ONLY));
 			nudgeCommands.addAll(lifelineChildren(graph, editingDomain, deltaChildren, (MLifeline)element));
 			return CompoundModelCommand.compose(editingDomain, nudgeCommands);
 		}
-		return new NudgeCommand((MElementImpl<? extends Element>)element, delta, false);
+		return new NudgeCommand((MElementImpl<? extends Element>)element, delta, NudgeKind.ELEMENT_ONLY);
 	}
 
 	private static Command creationMessageNudgeCommand(//
@@ -104,7 +104,7 @@ public final class Create {
 		}
 
 		List<Command> nudgeCommands = new ArrayList<>();
-		nudgeCommands.add(new NudgeCommand((MMessageImpl)message, delta, false));
+		nudgeCommands.add(message.nudge(delta, NudgeKind.ELEMENT_ONLY));
 		nudgeCommands.addAll(lifelineChildren(graph, editingDomain, deltaChildren, receiver.get()));
 		return CompoundModelCommand.compose(editingDomain, nudgeCommands);
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/CreateExecutionOccurrenceCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/CreateExecutionOccurrenceCommand.java
@@ -15,7 +15,6 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 import java.util.Optional;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MExecutionImpl;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
@@ -60,7 +59,7 @@ public abstract class CreateExecutionOccurrenceCommand extends ModelCommandWithD
 	protected Command doCreateCommand() {
 		Optional<MOccurrence<?>> previous = isFinish ? getTarget().getFinish() : getTarget().getStart();
 		if (previous.filter(MExecutionOccurrence.class::isInstance).isPresent()) {
-			return UnexecutableCommand.INSTANCE;
+			return bomb();
 		}
 
 		// Create the execution occurrence in the interaction

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/DependencyContext.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/DependencyContext.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CommandWrapper;
 import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 
@@ -321,6 +322,9 @@ public class DependencyContext {
 		} else if (subject instanceof MElement<?>) {
 			// The identity of a logical model element is the underlying UML element
 			result = ((MElement<?>)subject).getElement();
+		} else if (subject instanceof View) {
+			// The identity of a notation view is its semantic element. Normalize in case of null
+			result = normalizeSubject(((View)subject).getElement());
 		}
 
 		return result;

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.gmf.runtime.diagram.core.util.ViewUtil;
 import org.eclipse.gmf.runtime.notation.Shape;
@@ -125,7 +124,7 @@ public class InsertExecutionCommand extends ModelCommand.Creation<MLifelineImpl,
 	protected Command createCommand() {
 		Vertex reference = vertex(before);
 		if (reference == null) {
-			return UnexecutableCommand.INSTANCE;
+			return bomb();
 		}
 
 		OptionalInt referenceY;
@@ -138,7 +137,7 @@ public class InsertExecutionCommand extends ModelCommand.Creation<MLifelineImpl,
 		}
 
 		if (!referenceY.isPresent()) {
-			return UnexecutableCommand.INSTANCE;
+			return bomb();
 		}
 
 		// Determine the semantic element before which to insert the execution and its

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertNestedExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertNestedExecutionCommand.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.gmf.runtime.notation.View;
@@ -128,7 +127,7 @@ public class InsertNestedExecutionCommand extends ModelCommand.Creation<MExecuti
 	protected Command createCommand() {
 		Vertex reference = vertex(before);
 		if (reference == null) {
-			return UnexecutableCommand.INSTANCE;
+			return bomb();
 		}
 
 		OptionalInt referenceY;
@@ -139,7 +138,7 @@ public class InsertNestedExecutionCommand extends ModelCommand.Creation<MExecuti
 		}
 
 		if (!referenceY.isPresent()) {
-			return UnexecutableCommand.INSTANCE;
+			return bomb();
 		}
 
 		List<MElement<? extends Element>> timeline = getTimeline(getTarget().getInteraction());

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/KillSwitch.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/KillSwitch.java
@@ -1,0 +1,95 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CommandWrapper;
+import org.eclipse.emf.common.command.CompoundCommand;
+import org.eclipse.emf.common.command.IdentityCommand;
+import org.eclipse.emf.common.command.UnexecutableCommand;
+
+/**
+ * A command that will be unexecutable if, when queried for {@link Command#canExecute()}, its condition
+ * testing the model and/or diagram visualization evaluates {@code true}.
+ */
+public final class KillSwitch extends CommandWrapper {
+
+	private final BooleanSupplier condition;
+
+	private boolean enabled = true;
+
+	/**
+	 * Initializes me.
+	 */
+	private KillSwitch(BooleanSupplier condition) {
+		super();
+
+		this.condition = condition;
+	}
+
+	@Override
+	protected Command createCommand() {
+		return (enabled && !condition.getAsBoolean()) ? UnexecutableCommand.INSTANCE
+				: IdentityCommand.INSTANCE;
+	}
+
+	void disable() {
+		enabled = false;
+	}
+
+	/**
+	 * Register a kill-switch {@code condition} for the given {@code context}ual object.
+	 * 
+	 * @param context
+	 *            an object (usually a model element or notation element) for which to register a kill switch
+	 * @param condition
+	 *            a condition that, if the kill-switch is {@link #cancel(Object) still registered} at the time
+	 *            of its execution and it evaluates {@code true}, causes the kill switch to be unexecutable,
+	 *            resulting in overall failure of the operation
+	 * @see #cancel(Object)
+	 */
+	public static void register(Object context, BooleanSupplier condition) {
+		DependencyContext ctx = DependencyContext.get();
+
+		CompoundCommand killSwitches = getKillSwitches(ctx);
+		ctx.run(context, KillSwitch.class, () -> killSwitches.append(new KillSwitch(condition)));
+	}
+
+	/**
+	 * Cancel and remove a previously {@code #register(Object, BooleanSupplier) registered} kill switch.
+	 * 
+	 * @param context
+	 *            an object (usually a model element or notation element) for which to cancel a kill switch
+	 * @see #register(Object, BooleanSupplier)
+	 */
+	public static void cancel(Object context) {
+		DependencyContext ctx = DependencyContext.get();
+		ctx.remove(context, KillSwitch.class).ifPresent(KillSwitch::disable);
+	}
+
+	private static CompoundCommand getKillSwitches(DependencyContext ctx) {
+		return ctx.get(KillSwitch.class, CompoundCommand.class,
+				(Supplier<CompoundCommand>)CompoundCommand::new);
+	}
+
+	static Optional<? extends Command> check(DependencyContext ctx) {
+		Predicate<CompoundCommand> empty = CompoundCommand::isEmpty;
+		Optional<CompoundCommand> result = ctx.get(KillSwitch.class, CompoundCommand.class);
+		return result.filter(empty.negate());
+	}
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/ModelCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/ModelCommand.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CommandWrapper;
+import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.gmf.runtime.notation.View;
@@ -325,6 +326,15 @@ public abstract class ModelCommand<T extends MElementImpl<?>> extends CommandWra
 
 	protected Command defer(Supplier<? extends Command> futureCommand) {
 		return DependencyContext.defer(futureCommand);
+	}
+
+	/**
+	 * Obtain an unexecutable command, a bomb to place in a compound command that will disable it.
+	 * 
+	 * @return an unexecutable command
+	 */
+	protected Command bomb() {
+		return UnexecutableCommand.INSTANCE;
 	}
 
 	protected static void findElementsBelow(int yPosition, List<MElement<? extends Element>> elementsBelow,

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/ModelCommandWithDependencies.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/ModelCommandWithDependencies.java
@@ -15,6 +15,7 @@ package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 import java.util.Optional;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
@@ -54,6 +55,12 @@ public abstract class ModelCommandWithDependencies<T extends MElementImpl<?>> ex
 	protected abstract Command doCreateCommand();
 
 	protected boolean hasDependency(MElement<?> subject, Class<?> type) {
+		@SuppressWarnings("rawtypes")
+		Optional<Class> key = deps.get(subject, Class.class, type::isAssignableFrom);
+		return key.isPresent();
+	}
+
+	protected boolean hasDependency(EObject subject, Class<?> type) {
 		@SuppressWarnings("rawtypes")
 		Optional<Class> key = deps.get(subject, Class.class, type::isAssignableFrom);
 		return key.isPresent();

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
@@ -44,7 +44,7 @@ import org.eclipse.uml2.uml.MessageEnd;
  *
  * @author Christian W. Damus
  */
-public class NudgeCommand extends ModelCommand<MElementImpl<?>> {
+public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> {
 
 	private final int deltaY;
 
@@ -75,12 +75,13 @@ public class NudgeCommand extends ModelCommand<MElementImpl<?>> {
 	 */
 	public NudgeCommand(MElementImpl<? extends Element> element, int deltaY, boolean nudgeFollowing) {
 		super(element);
+
 		this.following = nudgeFollowing;
 		this.deltaY = deltaY;
 	}
 
 	@Override
-	protected Command createCommand() {
+	protected Command doCreateCommand() {
 		if (deltaY == 0) {
 			return IdentityCommand.INSTANCE;
 		}
@@ -230,7 +231,12 @@ public class NudgeCommand extends ModelCommand<MElementImpl<?>> {
 		 * that it just follows the shape it's anchored on in that case.
 		 */
 		private boolean skipMove(Shape shape) {
-			return movingShapes.contains(shape) || isShapeOnMovingShape(shape);
+			// Either I have direct knowledge of this shape moving
+			return movingShapes.contains(shape)
+					// Or the context has a nudge command for this shape
+					|| hasDependency(shape, NudgeCommand.class)
+					// Or the shape is (recursively) on a shape being nudged
+					|| isShapeOnMovingShape(shape);
 		}
 
 		/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
@@ -34,7 +34,6 @@ import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
-import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageEnd;
@@ -227,12 +226,11 @@ public class NudgeCommand extends ModelCommand<MElementImpl<?>> {
 		}
 
 		/**
-		 * Only move message ends when anchored on lifeline.
+		 * Only move message ends when anchored on a shape that isn't already moving, as the assumption is
+		 * that it just follows the shape it's anchored on in that case.
 		 */
 		private boolean skipMove(Shape shape) {
-			return !ViewTypes.LIFELINE_BODY.equals(shape.getType()) //
-					|| movingShapes.contains(shape) //
-					|| isShapeOnMovingShape(shape);
+			return movingShapes.contains(shape) || isShapeOnMovingShape(shape);
 		}
 
 		/**

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
@@ -20,7 +20,6 @@ import java.util.Set;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.IdentityCommand;
-import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.gmf.runtime.notation.Diagram;
@@ -197,7 +196,7 @@ public class NudgeCommand extends ModelCommand<MElementImpl<?>> {
 				}
 			} else if (view instanceof Diagram) {
 				// Can't nudge the diagram, of course
-				chain(UnexecutableCommand.INSTANCE);
+				chain(bomb());
 			} else if (isMessageEndNudgeCommand(element)) {
 				/*
 				 * If this is an explicit nudge command for a message end, make sure that this end is nudged,

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
@@ -325,10 +325,13 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 
 			switch (mode) {
 				case PRECEDING:
-					// Look for an execution specification that is being stretched at the top,
+					// The simple case is a shape that will be moved in the normal way
+					Predicate<Vertex> willMove = vertex()::succeeds;
+					// Or, look for an execution specification that is being stretched at the top,
 					// which implicitly is a move even though we aren't nudging the execution, itself
-					result = vertex.map(NudgeCommand.this::isExecutionStretchingAtTop).orElse(Boolean.FALSE)
-							.booleanValue();
+					willMove = willMove.or(NudgeCommand.this::isExecutionStretchingAtTop);
+
+					result = vertex.map(willMove::test).orElse(Boolean.FALSE).booleanValue();
 					break;
 				default:
 					result = false;

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/NudgeCommand.java
@@ -13,20 +13,21 @@
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
 import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.mapToObj;
 
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.IdentityCommand;
-import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.gmf.runtime.notation.Diagram;
 import org.eclipse.gmf.runtime.notation.IdentityAnchor;
-import org.eclipse.gmf.runtime.notation.NotationPackage;
 import org.eclipse.gmf.runtime.notation.Shape;
-import org.eclipse.gmf.runtime.notation.Size;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.graph.GroupKind;
 import org.eclipse.papyrus.uml.interaction.graph.Tag;
@@ -34,7 +35,12 @@ import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
+import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
 import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Interaction;
+import org.eclipse.uml2.uml.Lifeline;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageEnd;
 
@@ -48,7 +54,7 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 
 	private final int deltaY;
 
-	private boolean following;
+	private NudgeKind mode;
 
 	/**
 	 * Initializes me.
@@ -59,7 +65,7 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 	 *            the distance by which to nudge the {@code element}
 	 */
 	public NudgeCommand(MElementImpl<? extends Element> element, int deltaY) {
-		this(element, deltaY, true);
+		this(element, deltaY, NudgeKind.FOLLOWING);
 	}
 
 	/**
@@ -69,14 +75,14 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 	 *            the element to be nudged up or down
 	 * @param deltaY
 	 *            the distance by which to nudge the {@code element}
-	 * @param nudgeFollowing
-	 *            <code>true</code> if following elements should be nudged as well, <code>false</code> if only
-	 *            the given elements should be moved
+	 * @param mode
+	 *            the consequential nudges to compute, also (include following/preceding elements or only the
+	 *            original {@code element} to be nudged)
 	 */
-	public NudgeCommand(MElementImpl<? extends Element> element, int deltaY, boolean nudgeFollowing) {
+	public NudgeCommand(MElementImpl<? extends Element> element, int deltaY, NudgeKind mode) {
 		super(element);
 
-		this.following = nudgeFollowing;
+		this.mode = mode;
 		this.deltaY = deltaY;
 	}
 
@@ -94,13 +100,47 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 			// Visit this vertex
 			vertex.accept(moveDown);
 
-			if (following) {
-				// And all following
-				getGraph().walkAfter(vertex, moveDown);
+			switch (mode) {
+				case FOLLOWING:
+					// And all following
+					getGraph().walkAfter(vertex, moveDown);
+					break;
+				case PRECEDING:
+					// And all the preceding, except for elements that cannot be nudged
+					Predicate<Vertex> visitorFilter = this::nudgeByConsequence;
+
+					// And executions whose start ends are being nudged but not their
+					// bottoms (so we stretch them)
+					Predicate<Vertex> topStretching = this::isExecutionStretchingAtTop;
+					visitorFilter = visitorFilter.and(topStretching.negate());
+
+					getGraph().walkBefore(vertex, visitorFilter, moveDown);
+					break;
+				default:
+					// Nothing further
+					break;
 			}
 		}
 
 		return moveDown.getResult();
+	}
+
+	private boolean nudgeByConsequence(Vertex vertex) {
+		// Don't attempt to nudge lifeline heads and the diagram, itself, in the precedents of a nudge
+		return !(vertex.getInteractionElement() instanceof Lifeline) //
+				&& !(vertex.getInteractionElement() instanceof Interaction);
+	}
+
+	private boolean isExecutionStretchingAtTop(Vertex vertex) {
+		boolean result = false;
+
+		if (vertex.getInteractionElement() instanceof ExecutionSpecification) {
+			// We are stretching this if we will nudge the top but not the bottom
+			result = (mode == NudgeKind.PRECEDING)
+					&& vertex.successor(Tag.EXECUTION_FINISH).filter(vertex()::precedes).isPresent();
+		}
+
+		return result;
 	}
 
 	//
@@ -125,7 +165,6 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 			this.delta = delta;
 		}
 
-		@SuppressWarnings("boxing")
 		@Override
 		protected void process(Vertex vertex) {
 			Element element = vertex.getInteractionElement();
@@ -184,15 +223,40 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 						}
 					}
 				}
+			} else if (vertex.hasTag(Tag.EXECUTION_START) && !isMessageEndNudgeCommand(element)) {
+				// Stretch the execution specification, but only if we aren't nudging the bottom
+				Optional<Vertex> exec = vertex.successor(Tag.EXECUTION_START);
+				if (/* Not already visited */ !visited(exec)
+						&& /* Not to be visited */ (mode != NudgeKind.FOLLOWING)) {
+
+					exec.map(Vertex::getDiagramView).map(Shape.class::cast).ifPresent(shape -> {
+						LayoutHelper layout = layoutHelper();
+						int top = layout.getTop(shape);
+						int bottom = layout.getBottom(shape);
+
+						// Move the top accordingly
+						chain(layout.setTop(shape, top + delta));
+						// But pin the bottom where it is, to effect the stretch
+						chain(layout.setBottom(shape, bottom - delta));
+
+						// And things attached to this shape that are not supposed to be moving
+						// need to be nudged in the opposite direction
+						spannedVerticesNotNudged(exec.get()).map(this::nudgeBack).forEach(this::chain);
+					});
+				}
 			} else if (vertex.hasTag(Tag.EXECUTION_FINISH) && !isMessageEndNudgeCommand(element)) {
 				// Stretch the execution specification, but only if we didn't nudge the top
 				Optional<Vertex> exec = vertex.predecessor(Tag.EXECUTION_FINISH);
-				if (!visited(exec)) {
-					Optional<Shape> shape = exec.map(Vertex::getDiagramView).map(Shape.class::cast);
-					Optional<Size> sizeConstraint = shape.map(Shape::getLayoutConstraint)
-							.filter(Size.class::isInstance).map(Size.class::cast);
-					sizeConstraint.ifPresent(size -> chain(SetCommand.create(getEditingDomain(), size,
-							NotationPackage.Literals.SIZE__HEIGHT, size.getHeight() + delta)));
+				if (/* Not already visited */ !visited(exec)
+						&& /* Not to be visited */ (mode != NudgeKind.PRECEDING)) {
+
+					exec.map(Vertex::getDiagramView).map(Shape.class::cast).ifPresent(shape -> {
+						LayoutHelper layout = layoutHelper();
+						int bottom = layout.getBottom(shape);
+
+						// Move the bottom to effect the stretch
+						chain(layout.setBottom(shape, bottom + delta));
+					});
 				}
 			} else if (view instanceof Diagram) {
 				// Can't nudge the diagram, of course
@@ -233,6 +297,8 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 		private boolean skipMove(Shape shape) {
 			// Either I have direct knowledge of this shape moving
 			return movingShapes.contains(shape)
+					// Or it will be moving but we just haven't visited it, yet
+					|| willBeMoving(shape)
 					// Or the context has a nudge command for this shape
 					|| hasDependency(shape, NudgeCommand.class)
 					// Or the shape is (recursively) on a shape being nudged
@@ -250,6 +316,91 @@ public class NudgeCommand extends ModelCommandWithDependencies<MElementImpl<?>> 
 		private boolean isShapeOnMovingShape(Shape shape) {
 			return movingShapes.contains(shape.eContainer());
 		}
+
+		private boolean willBeMoving(Shape shape) {
+			boolean result;
+
+			// If we can't find a vertex, assume it won't be moving
+			Optional<Vertex> vertex = vertex().graph().vertex(shape);
+
+			switch (mode) {
+				case PRECEDING:
+					// Look for an execution specification that is being stretched at the top,
+					// which implicitly is a move even though we aren't nudging the execution, itself
+					result = vertex.map(NudgeCommand.this::isExecutionStretchingAtTop).orElse(Boolean.FALSE)
+							.booleanValue();
+					break;
+				default:
+					result = false;
+			}
+
+			return result;
+		}
+
+		/**
+		 * Obtain the vertices spanned by an {@code execution} vertex that are neither
+		 * <ul>
+		 * <li>also being nudged nor</li>
+		 * <li>the vertex encapsulating the start or finish occurrence nor</li>
+		 * <li>ahead of our original vertex being nudged in the direction that we're iterating the graph</li>
+		 * </ul>
+		 * 
+		 * @param execution
+		 *            the vertex of an execution specification
+		 * @return the spanned vertices that are not already or going to be visited
+		 */
+		private Stream<Vertex> spannedVerticesNotNudged(Vertex execution) {
+			Stream<Vertex> result;
+
+			if (!execution.isGroup()) {
+				result = Stream.empty();
+			} else {
+				// Not the start or finish, though, which are pinned to the ends of the
+				// execution and so not independently nudgeable (at least, not fir our purpose)
+				Predicate<Vertex> isExec = execution::equals;
+				Predicate<Vertex> isStart = v -> v.successor(Tag.EXECUTION_START).filter(isExec).isPresent();
+				Predicate<Vertex> isFinish = v -> v.predecessor(Tag.EXECUTION_FINISH).filter(isExec)
+						.isPresent();
+				Predicate<Vertex> isBeingNudged = this::visited;
+				isBeingNudged = isBeingNudged.or(this::willBeVisited);
+
+				result = execution.toGroup().members() //
+						.filter(isBeingNudged.or(isStart).or(isFinish).negate());
+			}
+
+			return result;
+		}
+
+		/**
+		 * Query whether a vertex will be visited later on in the current nudge calculation.
+		 * 
+		 * @param vertex
+		 *            a vertex
+		 * @return whether it will be visited
+		 */
+		private boolean willBeVisited(Vertex vertex) {
+			switch (mode) {
+				case PRECEDING:
+					return vertex.precedes(vertex());
+				case FOLLOWING:
+					return vertex.succeeds(vertex());
+				default:
+					return false;
+			}
+		}
+
+		/**
+		 * Create a command to nudge a {@code vertex} back against the prevailing nudge direction.
+		 * 
+		 * @param vertex
+		 *            a vertex to back-nudge
+		 * @return the command
+		 */
+		private Command nudgeBack(Vertex vertex) {
+			OptionalInt top = layoutHelper().getTop(vertex);
+			return mapToObj(top, y -> layoutHelper().setTop(vertex, y - delta)).orElse(bomb());
+		}
+
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
@@ -35,7 +35,6 @@ import java.util.function.Supplier;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.IdentityCommand;
-import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.gmf.runtime.notation.Connector;
 import org.eclipse.gmf.runtime.notation.Shape;
@@ -138,7 +137,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 
 		// Can't put an interaction fragment on a lifeline that is already destroyed
 		if (!existsAt(lifeline, newYPosition)) {
-			return UnexecutableCommand.INSTANCE;
+			return bomb();
 		}
 
 		if ((getTarget() instanceof MDestruction) && lifeline.getDiagramView().isPresent()) {
@@ -151,7 +150,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 			// Can't destroy the lifeline if it has occurrences following the place where
 			// the destruction is to go
 			if (!validateDestruction(newYPosition)) {
-				return UnexecutableCommand.INSTANCE;
+				return bomb();
 			}
 
 			// Move the X shape
@@ -164,7 +163,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 			// Can't create the lifeline if it has occurrences preceding the place where the
 			// creation receive end is to go
 			if (!validateCreation(createPosition)) {
-				return UnexecutableCommand.INSTANCE;
+				return bomb();
 			}
 
 			Connector messageView = Optional.ofNullable(creation.getOwner()).flatMap(MMessage::getDiagramView)
@@ -181,7 +180,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 		} else if ((getTarget() instanceof MExecutionOccurrence)
 				&& getTarget().getExecution().filter(splitsExecution(lifeline)).isPresent()) {
 
-			result = UnexecutableCommand.INSTANCE;
+			result = bomb();
 		} else {
 			// Handle a dependent execution
 			result = dependencies(getTarget()).map(chaining(result)).orElse(result);
@@ -362,7 +361,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 					&& !equalTo(occurrence).test(getTarget())) {
 				OptionalInt y = targetY.orElse(occurrence.getBottom());
 				if (anyDestructionOccurrenceBefore(y)) {
-					return Optional.of(UnexecutableCommand.INSTANCE);
+					return Optional.of(bomb());
 				}
 
 				return Optional.of(new SetCoveredCommand(occurrence, lifeline, y, false));

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetLifelineCreationCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetLifelineCreationCommand.java
@@ -27,6 +27,7 @@ import org.eclipse.papyrus.uml.interaction.internal.model.impl.MLifelineImpl;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.NudgeKind;
 import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.MessageSort;
 
@@ -70,7 +71,7 @@ public class SetLifelineCreationCommand extends ModelCommandWithDependencies<MLi
 				.sorted(vertically().reversed());
 		Optional<Command> nudges = toNudge //
 				.map(elem -> (Command)new NudgeCommand((MElementImpl<? extends Element>)elem, -deltaTop,
-						false))
+						NudgeKind.ELEMENT_ONLY))
 				.reduce(chaining());
 
 		result = nudges.map(chaining(result)).orElse(result);

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetOwnerCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetOwnerCommand.java
@@ -28,7 +28,6 @@ import java.util.function.UnaryOperator;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.IdentityCommand;
-import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
@@ -115,7 +114,7 @@ public class SetOwnerCommand extends ModelCommandWithDependencies<MElementImpl<?
 
 			@Override
 			public Command defaultCase(EObject object) {
-				return UnexecutableCommand.INSTANCE;
+				return bomb();
 			}
 		}.doSwitch((EObject)getTarget());
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
@@ -755,10 +755,12 @@ public class DefaultLayoutHelper implements LayoutHelper {
 	public Command setTop(Node shape, int yPosition) {
 		Command result = UnexecutableCommand.INSTANCE;
 		if (shape.getLayoutConstraint() instanceof Location) {
-			// Compute relative position
+			// Compute relative position. Do not allow a shape to extend above its container
 			int relativeY = toRelativeY(shape, yPosition);
-			result = SetCommand.create(editingDomain, shape.getLayoutConstraint(),
-					NotationPackage.Literals.LOCATION__Y, relativeY);
+			if (relativeY >= 0) {
+				result = SetCommand.create(editingDomain, shape.getLayoutConstraint(),
+						NotationPackage.Literals.LOCATION__Y, relativeY);
+			}
 		}
 		return result;
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultLayoutHelper.java
@@ -47,6 +47,7 @@ import org.eclipse.gmf.runtime.notation.util.NotationSwitch;
 import org.eclipse.papyrus.uml.interaction.graph.Vertex;
 import org.eclipse.papyrus.uml.interaction.graph.util.CrossReferenceUtil;
 import org.eclipse.papyrus.uml.interaction.graph.util.Suppliers;
+import org.eclipse.papyrus.uml.interaction.internal.model.commands.KillSwitch;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredSetCommand;
 import org.eclipse.papyrus.uml.interaction.model.spi.FontHelper;
 import org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints;
@@ -760,6 +761,14 @@ public class DefaultLayoutHelper implements LayoutHelper {
 			if (relativeY >= 0) {
 				result = SetCommand.create(editingDomain, shape.getLayoutConstraint(),
 						NotationPackage.Literals.LOCATION__Y, relativeY);
+				// Cancel a kill switch if there was one
+				KillSwitch.cancel(shape);
+			} else {
+				// Drop in a kill switch in case this isn't a temporary condition
+				EObject container = shape.eContainer();
+				KillSwitch.register(shape,
+						// The kill switch only remains valid if the shape isn't deleted
+						() -> (shape.eContainer() == container) && (container.eResource() != null));
 			}
 		}
 		return result;
@@ -798,6 +807,16 @@ public class DefaultLayoutHelper implements LayoutHelper {
 				String newID = m.replaceFirst("$1" + Integer.toString(anchorPos)); //$NON-NLS-1$
 				result = SetCommand.create(editingDomain, anchor,
 						NotationPackage.Literals.IDENTITY_ANCHOR__ID, newID);
+
+				if (anchorPos < 0) {
+					// Drop in a kill switch in case this isn't a temporary condition
+					KillSwitch.register(anchor,
+							// The kill switch only remains valid if the anchor isn't deleted
+							() -> (anchor.eContainer() == onShape) && (onShape.eResource() != null));
+				} else {
+					// Cancel a kill switch if there was one
+					KillSwitch.cancel(anchor);
+				}
 			} else {
 				m = EXEC_START_FINISH_ANCHOR_PATTERN.matcher(id);
 				if (m.matches()) {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/InteractionFragments.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/InteractionFragments.java
@@ -1,0 +1,216 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.model.util;
+
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.above;
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.below;
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.as;
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.filter;
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.flatMapToObj;
+import static org.eclipse.papyrus.uml.interaction.model.util.Optionals.test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.Predicate;
+
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
+import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.InteractionFragment;
+
+/**
+ * Various static utilities for working with interaction fragments in the <em>Logical Model</em>.
+ */
+public class InteractionFragments {
+
+	/**
+	 * Not instantiable by clients.
+	 */
+	private InteractionFragments() {
+		super();
+	}
+
+	public static Optional<MElement<? extends Element>> getObstacle(MOccurrence<? extends Element> occurrence,
+			boolean movingUp, int newY) {
+
+		Optional<MElement<? extends Element>> result = movingUp //
+				? verticallyPreceding(normalizedUp(occurrence)) //
+				: verticallyFollowing(normalizedDown(occurrence));
+
+		Predicate<MElement<? extends Element>> collisionFilter = movingUp
+				? below(newY - 1 /* need ≥, not > */)
+				: above(newY + 1 /* need ≤, not < */);
+
+		return result.filter(collisionFilter).map(InteractionFragments::resolveObstacle);
+	}
+
+	/**
+	 * Resolve an {@code obstable} to an element that has a notation view for which layout constraints can
+	 * actually be determined.
+	 * 
+	 * @param obstacle
+	 *            an obstacle
+	 * @return the {@code obstacle}, or some other element that is implied by it
+	 */
+	static MElement<? extends Element> resolveObstacle(MElement<? extends Element> obstacle) {
+		return new SequenceDiagramSwitch<MElement<? extends Element>>() {
+			@Override
+			public MElement<? extends Element> caseMMessageEnd(MMessageEnd object) {
+				if (!object.isStart() && !object.isFinish()) {
+					return object.getOwner();
+				}
+				return null;
+			}
+
+			@Override
+			public MElement<? extends Element> caseMExecutionOccurrence(MExecutionOccurrence object) {
+				return object.getExecution().orElse(null);
+			}
+
+			@Override
+			public <T extends Element> MElement<? extends Element> caseMOccurrence(MOccurrence<T> object) {
+				return Optionals.elseMaybe(object.getStartedExecution(), object.getFinishedExecution())
+						.orElse(null);
+			}
+
+			@Override
+			public <T extends Element> MElement<? extends Element> caseMElement(MElement<T> object) {
+				return object;
+			}
+		}.doSwitch(obstacle);
+	}
+
+	public static Optional<MElement<? extends Element>> getObstacle(MExecution execution, boolean movingUp,
+			int newTop, int newBottom) {
+
+		Optional<MElement<? extends Element>> result = movingUp //
+				? verticallyPreceding(normalizedUp(execution)) //
+				: verticallyFollowing(normalizedDown(execution));
+
+		Predicate<MElement<? extends Element>> collisionFilter = movingUp
+				? below(newTop - 1 /* need ≥, not > */)
+				: above(newBottom + 1 /* need ≤, not < */);
+
+		return result.filter(collisionFilter).map(InteractionFragments::resolveObstacle);
+	}
+
+	private static MElement<? extends Element> normalizedUp(MElement<? extends Element> obstacle) {
+		return new SequenceDiagramSwitch<MElement<? extends Element>>() {
+
+			@Override
+			public MElement<? extends Element> caseMMessageEnd(MMessageEnd object) {
+				// The real element in consideration is the message, and it begins at the send end
+				return object.getOtherEnd().filter(MMessageEnd::isSend).map(this::doSwitch).orElse(null);
+			}
+
+			@Override
+			public <T extends Element> MElement<? extends Element> caseMOccurrence(MOccurrence<T> object) {
+				// The finish occurrence follows all fragments that the execution spans
+				Optional<MExecution> finishedExecution = object.getFinishedExecution();
+				if (test(finishedExecution, verticallyPreceding(object), LogicalModelPredicates::equal)) {
+					// Execution doesn't span anything
+					return finishedExecution.get().getStart().orElse(null);
+				}
+				return null;
+			}
+
+			@Override
+			public MElement<? extends Element> caseMExecution(MExecution object) {
+				return object.getStart().<MElement<? extends Element>> map(this::doSwitch).orElse(null);
+			}
+
+			@Override
+			public <T extends Element> MElement<? extends Element> caseMElement(MElement<T> object) {
+				return object;
+			}
+
+		}.doSwitch(obstacle);
+	}
+
+	private static MElement<? extends Element> normalizedDown(MElement<? extends Element> obstacle) {
+		return new SequenceDiagramSwitch<MElement<? extends Element>>() {
+
+			@Override
+			public MElement<? extends Element> caseMMessageEnd(MMessageEnd object) {
+				// The real element in consideration is the message, and it finishes at the receiveend
+				return object.getOtherEnd().filter(MMessageEnd::isReceive).map(this::doSwitch).orElse(null);
+			}
+
+			@Override
+			public <T extends Element> MElement<? extends Element> caseMOccurrence(MOccurrence<T> object) {
+				// The execution itself precedes any fragments that it spans
+				Optional<MElement<? extends Element>> startedExecution = as(object.getStartedExecution(),
+						MElement.class);
+				return startedExecution.orElse(null);
+			}
+
+			@Override
+			public MElement<? extends Element> caseMExecution(MExecution object) {
+				return object.getFinish().<MElement<? extends Element>> map(this::doSwitch).orElse(null);
+			}
+
+			@Override
+			public <T extends Element> MElement<? extends Element> caseMElement(MElement<T> object) {
+				return object;
+			}
+
+		}.doSwitch(obstacle);
+	}
+
+	/**
+	 * Obtains the next interaction fragment in the vertical timeline that happens after a given
+	 * {@code fragment}. This is distinct from the {@linkplain MElement#following() causally following}
+	 * element, which may occur later in time.
+	 * 
+	 * @param fragment
+	 *            an interaction fragment
+	 * @return the next fragment in the timeline
+	 * @see MElement#following()
+	 */
+	public static Optional<MElement<? extends Element>> verticallyFollowing(
+			MElement<? extends Element> fragment) {
+
+		MInteraction interaction = fragment.getInteraction();
+		List<InteractionFragment> fragments = interaction.getElement().getFragments();
+
+		OptionalInt index = filter(OptionalInt.of(fragments.indexOf(fragment.getElement())),
+				i -> i + 1 < fragments.size());
+		return flatMapToObj(index, i -> interaction.getElement(fragments.get(i + 1)));
+	}
+
+	/**
+	 * Obtains the previous interaction fragment in the vertical timeline that happens before a given
+	 * {@code fragment}. This is distinct from the {@linkplain MElement#precedes(MElement) causally preceding}
+	 * element, which may occur earlier in time.
+	 * 
+	 * @param fragment
+	 *            an interaction fragment
+	 * @return the previous fragment in the timeline
+	 * @see MElement#precedes(MElement)
+	 */
+	public static Optional<MElement<? extends Element>> verticallyPreceding(
+			MElement<? extends Element> fragment) {
+
+		MInteraction interaction = fragment.getInteraction();
+		List<InteractionFragment> fragments = interaction.getElement().getFragments();
+
+		OptionalInt index = filter(OptionalInt.of(fragments.indexOf(fragment.getElement())), i -> i > 0);
+		return flatMapToObj(index, i -> interaction.getElement(fragments.get(i - 1)));
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/InteractionFragments.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/InteractionFragments.java
@@ -71,10 +71,7 @@ public class InteractionFragments {
 		return new SequenceDiagramSwitch<MElement<? extends Element>>() {
 			@Override
 			public MElement<? extends Element> caseMMessageEnd(MMessageEnd object) {
-				if (!object.isStart() && !object.isFinish()) {
-					return object.getOwner();
-				}
-				return null;
+				return object.getOwner();
 			}
 
 			@Override

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/LogicalModelPredicates.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/LogicalModelPredicates.java
@@ -117,6 +117,21 @@ public class LogicalModelPredicates {
 	}
 
 	/**
+	 * Are two logical model elements equal? Elements are equal if their {@linkplain MElement#getElement()
+	 * underlying UML elements} are identical.
+	 * 
+	 * @param element
+	 *            an element
+	 * @param other
+	 *            another element
+	 * @return whether the elements represent the same UML elements
+	 */
+	public static boolean equal(MElement<? extends Element> element, MElement<? extends Element> other) {
+		return (element == null) ? (other == null)
+				: (other != null) && (other.getElement() == element.getElement());
+	}
+
+	/**
 	 * Obtain a predicate matching elements that are equal to some {@code element}. Elements are equal if
 	 * their {@linkplain MElement#getElement() underlying UML elements} are identical.
 	 * 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
@@ -14,6 +14,7 @@ package org.eclipse.papyrus.uml.interaction.model.util;
 
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -262,7 +263,20 @@ public class Optionals {
 	 * @return the {@code value} if it satisfies the {@code predicate}, otherwise empty
 	 */
 	public static OptionalInt filter(OptionalInt value, IntPredicate predicate) {
-		return (value.isPresent() && predicate.test(value.getAsInt())) ? value : OptionalInt.empty();
+		return test(value, predicate) ? value : OptionalInt.empty();
+	}
+
+	/**
+	 * Query whether an optional integer {@code value} matches some {@code predicate}.
+	 * 
+	 * @param value
+	 *            an optional integer value
+	 * @param predicate
+	 *            an integer predicate
+	 * @return whether the {@code value} satisfies the {@code predicate}
+	 */
+	public static boolean test(OptionalInt value, IntPredicate predicate) {
+		return value.isPresent() && predicate.test(value.getAsInt());
 	}
 
 	/**
@@ -282,5 +296,24 @@ public class Optionals {
 		} else {
 			orElse.run();
 		}
+	}
+
+	/**
+	 * Query whether two optionals match on a {@code predicate}.
+	 * 
+	 * @param optional1
+	 *            an optional
+	 * @param optional2
+	 *            another optional
+	 * @param predicate
+	 *            a predicate
+	 * @return {@code true} if both optionals are {@linkplain Optional#isPresent() present} and satisfy the
+	 *         {@code predicate}; {@code false}, otherwise
+	 */
+	public static <T> boolean test(Optional<? extends T> optional1, Optional<? extends T> optional2,
+			BiPredicate<? super T, ? super T> predicate) {
+
+		return optional1.isPresent() && optional2.isPresent()
+				&& predicate.test(optional1.get(), optional2.get());
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/65-moving.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/65-moving.notation
@@ -20,7 +20,7 @@
         <children xmi:type="notation:Shape" xmi:id="_F8jUo2pHEeiIJqtZNCF3Dw" type="Shape_Lifeline_Body">
           <children xmi:type="notation:Shape" xmi:id="_QWOLYIOnEeiaaZTinMWZHw" type="Shape_Execution_Specification">
             <element xmi:type="uml:ActionExecutionSpecification" href="65-moving.uml#_QWHdsIOnEeiaaZTinMWZHw"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QWOLYYOnEeiaaZTinMWZHw" x="-5" y="12" width="10" height="327"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QWOLYYOnEeiaaZTinMWZHw" x="-5" y="68" width="10" height="271"/>
           </children>
           <layoutConstraint xmi:type="notation:Size" xmi:id="_F8jUpGpHEeiIJqtZNCF3Dw" width="2" height="150"/>
         </children>
@@ -63,20 +63,20 @@
   <edges xmi:type="notation:Connector" xmi:id="_ATloUOKpEeix5N_q7jP6rA" type="Edge_Message" source="_FTODw2pHEeiIJqtZNCF3Dw" target="_QWOLYIOnEeiaaZTinMWZHw">
     <element xmi:type="uml:Message" href="65-moving.uml#_ATlBQuKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ATloUeKpEeix5N_q7jP6rA"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ATloUuKpEeix5N_q7jP6rA" id="12"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ATloUuKpEeix5N_q7jP6rA" id="68"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ATloU-KpEeix5N_q7jP6rA" id="start"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_OPil0eKpEeix5N_q7jP6rA" type="Edge_Message" source="_FTODw2pHEeiIJqtZNCF3Dw" target="_QWOLYIOnEeiaaZTinMWZHw">
     <element xmi:type="uml:Message" href="65-moving.uml#_OPil0OKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_OPil0uKpEeix5N_q7jP6rA"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OPil0-KpEeix5N_q7jP6rA" id="89"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OPil1OKpEeix5N_q7jP6rA" id="77"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OPil0-KpEeix5N_q7jP6rA" id="112"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_OPil1OKpEeix5N_q7jP6rA" id="44"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_Ox2BoOKpEeix5N_q7jP6rA" type="Edge_Message" source="_FTODw2pHEeiIJqtZNCF3Dw" target="_QWOLYIOnEeiaaZTinMWZHw">
     <element xmi:type="uml:Message" href="65-moving.uml#_Ox1akuKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Ox2BoeKpEeix5N_q7jP6rA"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ox2BouKpEeix5N_q7jP6rA" id="305"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ox2Bo-KpEeix5N_q7jP6rA" id="293"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Ox2Bo-KpEeix5N_q7jP6rA" id="237"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_k49CseKpEeix5N_q7jP6rA" type="Edge_Message" source="_QWOLYIOnEeiaaZTinMWZHw" target="_FTODw2pHEeiIJqtZNCF3Dw">
     <element xmi:type="uml:Message" href="65-moving.uml#_k49CsOKpEeix5N_q7jP6rA"/>
@@ -87,20 +87,20 @@
   <edges xmi:type="notation:Connector" xmi:id="_vx2e4uKpEeix5N_q7jP6rA" type="Edge_Message" source="_QWOLYIOnEeiaaZTinMWZHw" target="_vx3F8OKpEeix5N_q7jP6rA">
     <element xmi:type="uml:Message" href="65-moving.uml#_vx2e4eKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vx2e4-KpEeix5N_q7jP6rA"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx2e5OKpEeix5N_q7jP6rA" id="173"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx2e5OKpEeix5N_q7jP6rA" id="117"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx2e5eKpEeix5N_q7jP6rA" id="start"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_vx3F9eKpEeix5N_q7jP6rA" type="Edge_Message" source="_vx3F8OKpEeix5N_q7jP6rA" target="_QWOLYIOnEeiaaZTinMWZHw">
     <element xmi:type="uml:Message" href="65-moving.uml#_vx3F9OKpEeix5N_q7jP6rA"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_vx3F9uKpEeix5N_q7jP6rA"/>
     <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx3F9-KpEeix5N_q7jP6rA" id="end"/>
-    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx3F-OKpEeix5N_q7jP6rA" id="242"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_vx3F-OKpEeix5N_q7jP6rA" id="186"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_lN3PwON6Eeix-PwTlDMrnw" type="Edge_Message" source="_QWOLYIOnEeiaaZTinMWZHw" target="_S7leM-KpEeix5N_q7jP6rA">
     <children xmi:type="notation:DecorationNode" xmi:id="_lN3PweN6Eeix-PwTlDMrnw" type="Edge_Message_Name"/>
     <element xmi:type="uml:Message" href="65-moving.uml#_lN2oseN6Eeix-PwTlDMrnw"/>
     <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_lN3PwuN6Eeix-PwTlDMrnw"/>
-    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lN3Pw-N6Eeix-PwTlDMrnw" id="147"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lN3Pw-N6Eeix-PwTlDMrnw" id="91"/>
     <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_lN3PxON6Eeix-PwTlDMrnw" id="159"/>
   </edges>
   <edges xmi:type="notation:Connector" xmi:id="_wDtX8ON6Eeix-PwTlDMrnw" type="Edge_Message" source="_F8jUo2pHEeiIJqtZNCF3Dw" target="_FTODw2pHEeiIJqtZNCF3Dw">

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -553,4 +553,84 @@ public class ExecutionSpecificationDragEditPolicyUITest {
 		}
 	}
 
+	/**
+	 * Tests for bumping executions by stretching executions below them upwards.
+	 */
+	@ModelResource("one-exec.di")
+	@Maximized
+	public static class BumpingUpwards extends AbstractGraphicalEditPolicyUITest {
+		@Rule
+		public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+		@AutoFixture("Execution1")
+		private EditPart exec1EP;
+
+		@AutoFixture
+		private Rectangle exec1Geom;
+
+		private EditPart exec2EP;
+
+		private Rectangle exec2Geom;
+
+		/**
+		 * Initializes me.
+		 */
+		public BumpingUpwards() {
+			super();
+		}
+
+		@Test
+		public void stretchUpExecToBumpOther() {
+			// First, select the new execution to activate selection handles
+			editor.select(exec2Geom.getCenter());
+
+			Point grabAt = getResizeHandleGrabPoint(exec2EP, PositionConstants.NORTH);
+			Point dropAt = grabAt.getTranslated(0, -50);
+
+			// Now, stretch up the execution below
+			editor.drag(grabAt, dropAt);
+
+			// Bump up 20 + 10 for padding
+			Rectangle newExec1Geom = exec1Geom.getTranslated(0, -30);
+
+			Rectangle newExec2Geom = exec2Geom.getTranslated(0, -50);
+			newExec2Geom.setHeight(exec2Geom.height() + 50);
+
+			assertThat("Execution above not bumped up", exec1EP, isBounded(isRect(newExec1Geom)));
+
+			assertThat("Execution not stretched correctly", exec2EP, isBounded(isRect(newExec2Geom)));
+		}
+
+		/**
+		 * Verify that bumping up is limited by the position of the lifeline head.
+		 */
+		@Test
+		public void attemptStretchUpExecTooFar() {
+			// First, select the new execution to activate selection handles
+			editor.select(exec2Geom.getCenter());
+
+			Point grabAt = getResizeHandleGrabPoint(exec2EP, PositionConstants.NORTH);
+			Point dropAt = grabAt.getTranslated(0, -100);
+
+			// Now, stretch up the execution below
+			editor.drag(grabAt, dropAt);
+
+			assertThat("Execution above was moved", exec1EP, isBounded(isRect(exec1Geom)));
+
+			assertThat("Execution below was stretched", exec2EP, isBounded(isRect(exec2Geom)));
+		}
+
+		//
+		// Test fixtures
+		//
+
+		@Before
+		public void createExecutionBelow() {
+			Point where = exec1Geom.getBottom().getTranslated(0, 30);
+
+			exec2EP = editor.createShape(SequenceElementTypes.Behavior_Execution_Shape, where, null);
+			exec2Geom = getBounds(exec2EP);
+		}
+	}
+
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/NudgeRegressionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/NudgeRegressionUITest.java
@@ -1,0 +1,167 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.is;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.gt;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.lt;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+
+import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.ConnectionEditPart;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Integration regression tests for certain nudge scenarios in
+ * <a href="https://github.com/eclipsesource/papyrus-seqd/issues/26">Issue #26 Fragment padding</a>.
+ */
+@ModelResource("Nudging.di")
+@Maximized
+public class NudgeRegressionUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@Rule
+	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+	@AutoFixture
+	private EditPart exec1;
+
+	@AutoFixture
+	private Rectangle exec1Geom;
+
+	@AutoFixture
+	private EditPart exec2;
+
+	@AutoFixture
+	private Rectangle exec2Geom;
+
+	@AutoFixture
+	private EditPart exec3;
+
+	@AutoFixture
+	private Rectangle exec3Geom;
+
+	@AutoFixture
+	private EditPart async1;
+
+	@AutoFixture
+	private PointList async1Geom;
+
+	@AutoFixture
+	private EditPart async2;
+
+	@AutoFixture
+	private PointList async2Geom;
+
+	/**
+	 * Initializes me.
+	 */
+	public NudgeRegressionUITest() {
+		super();
+	}
+
+	@Test
+	public void moveExecUp() {
+		Point grabAt = exec1Geom.getCenter();
+		Point dropAt = exec1Geom.getCenter().getTranslated(0, -35);
+
+		int x = async1Geom.getLastPoint().x(); // This should not change
+
+		editor.moveSelection(grabAt, dropAt);
+		autoFixtures.refresh();
+
+		int y = exec1Geom.y(); // This will have changed
+
+		assertThat("async1 not bumped", async1Geom.getLastPoint(), isPoint(is(x), lt(y)));
+	}
+
+	@Test
+	public void attemptMoveExecUpTooFar() {
+		Point grabAt = exec1Geom.getCenter();
+		// This is too far, would bump async1 into the lifeline head
+		Point dropAt = async1Geom.getLastPoint().getTranslated(0, 5);
+
+		PointList expectedAsync1 = async1Geom.getCopy();
+		Rectangle expectedExec1 = exec1Geom.getCopy();
+
+		editor.moveSelection(grabAt, dropAt);
+		autoFixtures.refresh();
+
+		assertThat("exec1 was moved", exec1Geom, equalTo(expectedExec1));
+		// PointList does not implement equals!
+		assertThat("async1 was bumped", async1Geom.toIntArray(), equalTo(expectedAsync1.toIntArray()));
+	}
+
+	@Test
+	public void stretchExecDown() {
+		editor.select(exec2Geom.getCenter());
+		Point grabAt = getResizeHandleGrabPoint(exec2, PositionConstants.SOUTH);
+		Point dropAt = exec1Geom.getBottom().getTranslated(0, +25);
+
+		int top = exec1Geom.y(); // This should not change
+
+		editor.drag(grabAt, dropAt);
+		autoFixtures.refresh();
+
+		assertThat("exec1 moved", exec1Geom.y(), is(top));
+		assertThat("exec1 not stretched", exec1Geom.bottom(), gt(exec2Geom.bottom()));
+	}
+
+	@Test
+	public void moveMessageUp() {
+		Point grabAt = async2Geom.getMidpoint();
+		Point dropAt = new Point(grabAt.x(), exec3Geom.getCenter().y());
+
+		int height = exec3Geom.height();
+		int y = exec3Geom.bottom();
+
+		editor.moveSelection(grabAt, dropAt);
+		autoFixtures.refresh();
+
+		int msgY = async2Geom.getLastPoint().y();
+
+		assertThat("message not moved", msgY, lt(y));
+		assertThat("execution not bumped", exec3Geom.bottom(), lt(msgY));
+		assertThat("execution reshaped", exec3Geom.height(), is(height));
+	}
+
+	//
+	// Test framework
+	//
+
+	/**
+	 * Verify that nothing done in the test resulted in sloping message connections.
+	 */
+	@After
+	public void assertAllMessagesHorizontal() {
+		@SuppressWarnings("unchecked")
+		List<ConnectionEditPart> connections = editor.getDiagramEditPart().getConnections();
+		connections.forEach(
+				c -> assertThat("Message is not horizontal", c, GEFMatchers.EditParts.isHorizontal()));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/Nudging.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/Nudging.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/Nudging.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/Nudging.notation
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_6Fo5QPlaEeiUDs0SSuHgJg" type="LightweightSequenceDiagram" name="main" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_6Fo5QflaEeiUDs0SSuHgJg" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_6Fo5QvlaEeiUDs0SSuHgJg" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_6Fo5Q_laEeiUDs0SSuHgJg" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_6rVnUPlaEeiUDs0SSuHgJg" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_6rVnUflaEeiUDs0SSuHgJg" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_6rVnUvlaEeiUDs0SSuHgJg" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_6rVnU_laEeiUDs0SSuHgJg" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_6rVnVPlaEeiUDs0SSuHgJg" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="Nudging.uml#_6paUsPlaEeiUDs0SSuHgJg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6rVnVflaEeiUDs0SSuHgJg" x="133" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_6vSTMPlaEeiUDs0SSuHgJg" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_6vSTMflaEeiUDs0SSuHgJg" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_6vSTMvlaEeiUDs0SSuHgJg" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_6vSTM_laEeiUDs0SSuHgJg" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_8WzDkflaEeiUDs0SSuHgJg" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="Nudging.uml#_8WzDkPlaEeiUDs0SSuHgJg"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8WzDkvlaEeiUDs0SSuHgJg" x="-5" y="84" width="10" height="123"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_6vSTNPlaEeiUDs0SSuHgJg" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="Nudging.uml#_6teVUPlaEeiUDs0SSuHgJg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6vSTNflaEeiUDs0SSuHgJg" x="359" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_SA-4EPlbEeiEd7ueRYhdrg" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_SA-4EflbEeiEd7ueRYhdrg" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_SA-4EvlbEeiEd7ueRYhdrg" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_SA-4E_lbEeiEd7ueRYhdrg" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_Y27cMflbEeiEd7ueRYhdrg" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="Nudging.uml#_Y27cMPlbEeiEd7ueRYhdrg"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y27cMvlbEeiEd7ueRYhdrg" x="-4" y="118" width="10" height="64"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_LMj98flbEeiEd7ueRYhdrg" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="Nudging.uml#_LMj98PlbEeiEd7ueRYhdrg"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LMj98vlbEeiEd7ueRYhdrg" x="-5" y="258" width="10" height="40"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_SA-4FPlbEeiEd7ueRYhdrg" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="Nudging.uml#_R_GBsPlbEeiEd7ueRYhdrg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_SA-4FflbEeiEd7ueRYhdrg" x="536" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6Fo5RPlaEeiUDs0SSuHgJg" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_6Fo5RflaEeiUDs0SSuHgJg" name="diagram_compatibility_version" stringValue="1.4.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_6Fo5RvlaEeiUDs0SSuHgJg"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_6Fo5R_laEeiUDs0SSuHgJg" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="Nudging.uml#_6FnEEPlaEeiUDs0SSuHgJg"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="Nudging.uml#_6FnEEPlaEeiUDs0SSuHgJg"/>
+  <edges xmi:type="notation:Connector" xmi:id="_7f8UEPlaEeiUDs0SSuHgJg" type="Edge_Message" source="_6rVnU_laEeiUDs0SSuHgJg" target="_6vSTM_laEeiUDs0SSuHgJg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_7f8UEflaEeiUDs0SSuHgJg" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="Nudging.uml#_7f7F8flaEeiUDs0SSuHgJg"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7f8UEvlaEeiUDs0SSuHgJg"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7f8UE_laEeiUDs0SSuHgJg" id="56"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7f8UFPlaEeiUDs0SSuHgJg" id="56"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_8WycgPlaEeiUDs0SSuHgJg" type="Edge_Message" source="_6rVnU_laEeiUDs0SSuHgJg" target="_8WzDkflaEeiUDs0SSuHgJg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_8WycgflaEeiUDs0SSuHgJg" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="Nudging.uml#_8Wx1cvlaEeiUDs0SSuHgJg"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8WycgvlaEeiUDs0SSuHgJg"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8Wycg_laEeiUDs0SSuHgJg" id="84"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8WychPlaEeiUDs0SSuHgJg" id="start"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_8W0RsPlaEeiUDs0SSuHgJg" type="Edge_Message" source="_8WzDkflaEeiUDs0SSuHgJg" target="_6rVnU_laEeiUDs0SSuHgJg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_8W0RsflaEeiUDs0SSuHgJg" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="Nudging.uml#_8WzqoPlaEeiUDs0SSuHgJg"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_8W0RsvlaEeiUDs0SSuHgJg"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8W0Rs_laEeiUDs0SSuHgJg" id="end"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_8W0RtPlaEeiUDs0SSuHgJg" id="207"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_9ZX64PlaEeiUDs0SSuHgJg" type="Edge_Message" source="_6rVnU_laEeiUDs0SSuHgJg" target="_6vSTM_laEeiUDs0SSuHgJg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_9ZX64flaEeiUDs0SSuHgJg" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="Nudging.uml#_9ZXT0vlaEeiUDs0SSuHgJg"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_9ZX64vlaEeiUDs0SSuHgJg"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ZX64_laEeiUDs0SSuHgJg" id="323"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_9ZX65PlaEeiUDs0SSuHgJg" id="323"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_LMjW4PlbEeiEd7ueRYhdrg" type="Edge_Message" source="_6vSTM_laEeiUDs0SSuHgJg" target="_LMj98flbEeiEd7ueRYhdrg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_LMjW4flbEeiEd7ueRYhdrg" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="Nudging.uml#_LMiv0PlbEeiEd7ueRYhdrg"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LMjW4vlbEeiEd7ueRYhdrg"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LMjW4_lbEeiEd7ueRYhdrg" id="258"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LMjW5PlbEeiEd7ueRYhdrg" id="start"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_LMlzIPlbEeiEd7ueRYhdrg" type="Edge_Message" source="_LMj98flbEeiEd7ueRYhdrg" target="_6vSTM_laEeiUDs0SSuHgJg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_LMlzIflbEeiEd7ueRYhdrg" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="Nudging.uml#_LMklAvlbEeiEd7ueRYhdrg"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LMlzIvlbEeiEd7ueRYhdrg"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LMlzI_lbEeiEd7ueRYhdrg" id="end"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LMlzJPlbEeiEd7ueRYhdrg" id="298"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_Y261IPlbEeiEd7ueRYhdrg" type="Edge_Message" source="_8WzDkflaEeiUDs0SSuHgJg" target="_Y27cMflbEeiEd7ueRYhdrg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_Y261IflbEeiEd7ueRYhdrg" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="Nudging.uml#_Y26OEvlbEeiEd7ueRYhdrg"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y261IvlbEeiEd7ueRYhdrg"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y261I_lbEeiEd7ueRYhdrg" id="34"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y261JPlbEeiEd7ueRYhdrg" id="start"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_Y28DQPlbEeiEd7ueRYhdrg" type="Edge_Message" source="_Y27cMflbEeiEd7ueRYhdrg" target="_8WzDkflaEeiUDs0SSuHgJg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_Y28DQflbEeiEd7ueRYhdrg" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="Nudging.uml#_Y27cNflbEeiEd7ueRYhdrg"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Y28DQvlbEeiEd7ueRYhdrg"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y28DQ_lbEeiEd7ueRYhdrg" id="end"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Y28DRPlbEeiEd7ueRYhdrg" id="98"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/Nudging.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/Nudging.uml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_6FjZsPlaEeiUDs0SSuHgJg" name="Nudging">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_6JdCQPlaEeiUDs0SSuHgJg">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_6FnEEPlaEeiUDs0SSuHgJg" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_6paUsPlaEeiUDs0SSuHgJg" name="lifeline1" coveredBy="_7f6e4PlaEeiUDs0SSuHgJg _8Wx1cPlaEeiUDs0SSuHgJg _8WzDlPlaEeiUDs0SSuHgJg _9ZXT0PlaEeiUDs0SSuHgJg"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_6teVUPlaEeiUDs0SSuHgJg" name="lifeline2" coveredBy="_7f7F8PlaEeiUDs0SSuHgJg _9ZXT0flaEeiUDs0SSuHgJg _8WzDkPlaEeiUDs0SSuHgJg _8Wx1cflaEeiUDs0SSuHgJg _8WzDk_laEeiUDs0SSuHgJg _Y26OEPlbEeiEd7ueRYhdrg _Y27cNPlbEeiEd7ueRYhdrg _LMklAflbEeiEd7ueRYhdrg _LMiIwPlbEeiEd7ueRYhdrg"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_R_GBsPlbEeiEd7ueRYhdrg" name="lifeline3" coveredBy="_Y26OEflbEeiEd7ueRYhdrg _Y27cMPlbEeiEd7ueRYhdrg _Y27cM_lbEeiEd7ueRYhdrg _LMj98PlbEeiEd7ueRYhdrg _LMiIwflbEeiEd7ueRYhdrg _LMklAPlbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_7f6e4PlaEeiUDs0SSuHgJg" name="async1-send" covered="_6paUsPlaEeiUDs0SSuHgJg" message="_7f7F8flaEeiUDs0SSuHgJg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_7f7F8PlaEeiUDs0SSuHgJg" name="async1-recv" covered="_6teVUPlaEeiUDs0SSuHgJg" message="_7f7F8flaEeiUDs0SSuHgJg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_8Wx1cPlaEeiUDs0SSuHgJg" name="request1-send" covered="_6paUsPlaEeiUDs0SSuHgJg" message="_8Wx1cvlaEeiUDs0SSuHgJg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_8Wx1cflaEeiUDs0SSuHgJg" name="request1-recv" covered="_6teVUPlaEeiUDs0SSuHgJg" message="_8Wx1cvlaEeiUDs0SSuHgJg"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_8WzDkPlaEeiUDs0SSuHgJg" name="exec1" covered="_6teVUPlaEeiUDs0SSuHgJg" finish="_8WzDk_laEeiUDs0SSuHgJg" start="_8Wx1cflaEeiUDs0SSuHgJg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_Y26OEPlbEeiEd7ueRYhdrg" name="request2-send" covered="_6teVUPlaEeiUDs0SSuHgJg" message="_Y26OEvlbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_Y26OEflbEeiEd7ueRYhdrg" name="request2-recv" covered="_R_GBsPlbEeiEd7ueRYhdrg" message="_Y26OEvlbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_Y27cMPlbEeiEd7ueRYhdrg" name="exec2" covered="_R_GBsPlbEeiEd7ueRYhdrg" finish="_Y27cM_lbEeiEd7ueRYhdrg" start="_Y26OEflbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_Y27cM_lbEeiEd7ueRYhdrg" name="reply2-send" covered="_R_GBsPlbEeiEd7ueRYhdrg" message="_Y27cNflbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_Y27cNPlbEeiEd7ueRYhdrg" name="reply2-recv" covered="_6teVUPlaEeiUDs0SSuHgJg" message="_Y27cNflbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_8WzDk_laEeiUDs0SSuHgJg" name="reply1-send" covered="_6teVUPlaEeiUDs0SSuHgJg" message="_8WzqoPlaEeiUDs0SSuHgJg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_8WzDlPlaEeiUDs0SSuHgJg" name="reply1-recv" covered="_6paUsPlaEeiUDs0SSuHgJg" message="_8WzqoPlaEeiUDs0SSuHgJg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_LMiIwPlbEeiEd7ueRYhdrg" name="request3-send" covered="_6teVUPlaEeiUDs0SSuHgJg" message="_LMiv0PlbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_LMiIwflbEeiEd7ueRYhdrg" name="request3-recv" covered="_R_GBsPlbEeiEd7ueRYhdrg" message="_LMiv0PlbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_LMj98PlbEeiEd7ueRYhdrg" name="exec3" covered="_R_GBsPlbEeiEd7ueRYhdrg" finish="_LMklAPlbEeiEd7ueRYhdrg" start="_LMiIwflbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_LMklAPlbEeiEd7ueRYhdrg" name="reply3-send" covered="_R_GBsPlbEeiEd7ueRYhdrg" message="_LMklAvlbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_LMklAflbEeiEd7ueRYhdrg" name="reply3-recv" covered="_6teVUPlaEeiUDs0SSuHgJg" message="_LMklAvlbEeiEd7ueRYhdrg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_9ZXT0PlaEeiUDs0SSuHgJg" name="async2-send" covered="_6paUsPlaEeiUDs0SSuHgJg" message="_9ZXT0vlaEeiUDs0SSuHgJg"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_9ZXT0flaEeiUDs0SSuHgJg" name="async2-recv" covered="_6teVUPlaEeiUDs0SSuHgJg" message="_9ZXT0vlaEeiUDs0SSuHgJg"/>
+    <message xmi:type="uml:Message" xmi:id="_7f7F8flaEeiUDs0SSuHgJg" name="async1" messageSort="asynchCall" receiveEvent="_7f7F8PlaEeiUDs0SSuHgJg" sendEvent="_7f6e4PlaEeiUDs0SSuHgJg"/>
+    <message xmi:type="uml:Message" xmi:id="_8Wx1cvlaEeiUDs0SSuHgJg" name="request1" receiveEvent="_8Wx1cflaEeiUDs0SSuHgJg" sendEvent="_8Wx1cPlaEeiUDs0SSuHgJg"/>
+    <message xmi:type="uml:Message" xmi:id="_8WzqoPlaEeiUDs0SSuHgJg" name="reply1" messageSort="reply" receiveEvent="_8WzDlPlaEeiUDs0SSuHgJg" sendEvent="_8WzDk_laEeiUDs0SSuHgJg"/>
+    <message xmi:type="uml:Message" xmi:id="_9ZXT0vlaEeiUDs0SSuHgJg" name="async2" messageSort="asynchCall" receiveEvent="_9ZXT0flaEeiUDs0SSuHgJg" sendEvent="_9ZXT0PlaEeiUDs0SSuHgJg"/>
+    <message xmi:type="uml:Message" xmi:id="_LMiv0PlbEeiEd7ueRYhdrg" name="request3" receiveEvent="_LMiIwflbEeiEd7ueRYhdrg" sendEvent="_LMiIwPlbEeiEd7ueRYhdrg"/>
+    <message xmi:type="uml:Message" xmi:id="_LMklAvlbEeiEd7ueRYhdrg" name="reply3" messageSort="reply" receiveEvent="_LMklAflbEeiEd7ueRYhdrg" sendEvent="_LMklAPlbEeiEd7ueRYhdrg"/>
+    <message xmi:type="uml:Message" xmi:id="_Y26OEvlbEeiEd7ueRYhdrg" name="request2" receiveEvent="_Y26OEflbEeiEd7ueRYhdrg" sendEvent="_Y26OEPlbEeiEd7ueRYhdrg"/>
+    <message xmi:type="uml:Message" xmi:id="_Y27cNflbEeiEd7ueRYhdrg" name="reply2" messageSort="reply" receiveEvent="_Y27cNPlbEeiEd7ueRYhdrg" sendEvent="_Y27cM_lbEeiEd7ueRYhdrg"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ShrinkExpandExecutionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ShrinkExpandExecutionUITest.java
@@ -296,10 +296,16 @@ public class ShrinkExpandExecutionUITest extends AbstractGraphicalEditPolicyUITe
 		assertThat("Misshapen bumped message", newAsync3Geom.getLastPoint().y(),
 				is(newAsync3Geom.getFirstPoint().y()));
 
+		Point async1Send = async1Geom.getFirstPoint();
+		Point async1Recv = async1Geom.getLastPoint();
+		assertThat("Other earlier message not nudged also", async1,
+				runs(isPoint(is(async1Send.x()), lt(async1Send.y())), //
+						isPoint(is(async1Recv.x()), lt(async1Recv.y()))));
+
 		// Verify expected non-changes
 
-		assertThat("Unrelated message changed", async1,
-				runs(isPoint(async1Geom.getFirstPoint()), isPoint(async1Geom.getLastPoint())));
+		assertThat("Unrelated message changed", async2,
+				runs(isPoint(async2Geom.getFirstPoint()), isPoint(async2Geom.getLastPoint())));
 	}
 
 	@Test

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MDestructionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MDestructionTest.java
@@ -34,7 +34,6 @@ import junit.textui.TestRunner;
  * 
  * @generated
  */
-@SuppressWarnings("restriction")
 public class MDestructionTest extends MMessageEndTest {
 
 	/**

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageEndTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageEndTest.java
@@ -96,7 +96,6 @@ public class MMessageEndTest extends MOccurrenceTest {
 	protected String getInteractionName() {
 		switch (getName()) {
 			case "testGetExecution":
-				return "ExecutionSpecificationSideAnchors";
 			default:
 				return super.getInteractionName();
 		}
@@ -104,7 +103,15 @@ public class MMessageEndTest extends MOccurrenceTest {
 
 	@Override
 	protected void initializeFixture() {
-		setFixture(interaction.getMessages().get(0).getReceive().get());
+		switch (getName()) {
+			case "testNudge__int_NudgeKind":
+				// This message end can be nudged up without running into padding constraints
+				setFixture(interaction.getMessages().get(1).getSend().get());
+				break;
+			default:
+				setFixture(interaction.getMessages().get(0).getReceive().get());
+				break;
+		}
 	}
 
 	/**

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MMessageTest.java
@@ -93,7 +93,15 @@ public class MMessageTest extends MElementTest {
 		if (interaction.getMessages().isEmpty()) {
 			setFixture(null);
 		} else {
-			setFixture(interaction.getMessages().get(0));
+			switch (getName()) {
+				case "testNudge__int_NudgeKind":
+					// This message can be nudged up without running into padding constraints
+					setFixture(interaction.getMessages().get(1));
+					break;
+				default:
+					setFixture(interaction.getMessages().get(0));
+					break;
+			}
 		}
 	}
 


### PR DESCRIPTION
This branch implements changes to sweep obstacles out of the way when moving elements without the semantic re-ordering keyboard modifier, including

- nudging ("bumping along") elements out of the way when moving execution specifications
- bumping elements along when moving messages
- JUnit test coverage for the above scenarios, primarily focused on nudging down
- conversion of existing tests that asserted no change in the model (on attempt to re-order elements without the keyboard modifier) as now changes do happen, but of a different nature
