### PR TITLE
Fix #427: Reordering of message ends

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/MessageEndpointEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/MessageEndpointEditPolicy.java
@@ -54,7 +54,6 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.M
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.handles.SequenceConnectionEndpointHandle;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.CommandCreatedEvent;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.util.MessageUtil;
-import org.eclipse.papyrus.uml.interaction.internal.model.commands.DependencyContext;
 import org.eclipse.papyrus.uml.interaction.model.MDestruction;
 import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
 import org.eclipse.uml2.uml.Element;
@@ -92,7 +91,7 @@ public class MessageEndpointEditPolicy extends ConnectionEndpointEditPolicy impl
 	@Override
 	public Command getCommand(Request request) {
 		// Provide a dependency context for all command construction
-		return DependencyContext.getDynamic().withContext(() -> {
+		return withPadding(request, () -> {
 			Command result;
 
 			if (REQ_CREATE_BENDPOINT.equals(request.getType())) {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MInteractionImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src-gen/org/eclipse/papyrus/uml/interaction/internal/model/impl/MInteractionImpl.java
@@ -383,7 +383,7 @@ public class MInteractionImpl extends MElementImpl<Interaction> implements MInte
 	 */
 	@Override
 	public Command sort() {
-		return withDependencies(SortSemanticsCommand.class, () -> new SortSemanticsCommand(this));
+		return new SortSemanticsCommand(this);
 	}
 
 	private int bottomOfMElement(MElement<? extends Element> mElement) {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RootContextHandler.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/RootContextHandler.java
@@ -1,0 +1,110 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.internal.model.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.MInteractionImpl;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.uml2.uml.Element;
+
+/**
+ * A handler of the topmost {@link DependencyContext command context} that captures post-processing commands
+ * to decorate a command created by the client. The post-processing commands supported so far include
+ * <ul>
+ * <li>the {@link DeferredPaddingCommand deferred padding} for layout changes</li>
+ * <li>the {@link MInteraction#sort() sorting} of interaction fragments to match visual changes</li>
+ * </ul>
+ * 
+ * @param <C>
+ *            the command type
+ */
+public final class RootContextHandler<C> implements Consumer<DependencyContext>, UnaryOperator<C> {
+
+	// Room for the deferred padding command, sorting command, and user's command
+	private final List<C> commands = new ArrayList<>(3);
+
+	private final MInteractionImpl interaction;
+
+	private final Function<Command, C> coercionFunction;
+
+	private final BinaryOperator<C> combiner;
+
+	/**
+	 * Initializes me.
+	 */
+	private RootContextHandler(MElement<? extends Element> owner, Function<Command, C> coercionFunction,
+			BinaryOperator<C> combiner) {
+		super();
+
+		this.interaction = ((MElementImpl<?>)owner).getInteractionImpl();
+		this.coercionFunction = coercionFunction;
+		this.combiner = combiner;
+	}
+
+	@Override
+	public void accept(DependencyContext ctx) {
+		append(ctx.defer(c -> DeferredPaddingCommand.get(c, interaction)));
+
+		// If any of the computed commands requires sorting, it'll be in the context
+		append(ctx.defer(c -> c.get(interaction, SortSemanticsCommand.class).orElse(null)));
+	}
+
+	private void append(Command command) {
+		if (command != null) {
+			commands.add(coercionFunction.apply(command));
+		}
+	}
+
+	private void prepend(C command) {
+		if (command != null) {
+			commands.add(0, command);
+		}
+	}
+
+	private void clear() {
+		commands.clear();
+	}
+
+	@Override
+	public C apply(C command) {
+		C result = command;
+
+		if (result != null) {
+			prepend(command); // Do user command first, then padding and sorting
+			result = commands.stream().reduce(combiner).get(); // Have at least the 'command'
+			clear();
+		}
+
+		return result;
+	}
+
+	public static RootContextHandler<Command> create(MElement<? extends Element> owner) {
+		return create(owner, Function.identity(), Command::chain);
+	}
+
+	public static <C> RootContextHandler<C> create(MElement<? extends Element> owner,
+			Function<Command, C> coercionFunction, BinaryOperator<C> combiner) {
+
+		return new RootContextHandler<C>(owner, coercionFunction, combiner);
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/FragmentReorder.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/FragmentReorder.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/FragmentReorder.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/FragmentReorder.notation
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Fv0C0PGDEeiJ6OxnblKpmQ" type="LightweightSequenceDiagram" name="Lightweight Sequence Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_Fv0C0fGDEeiJ6OxnblKpmQ" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_Fv0C0vGDEeiJ6OxnblKpmQ" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_Fv0C0_GDEeiJ6OxnblKpmQ" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_Bk-1kPGNEei-V9s6WYZOtg" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_Bk-1kfGNEei-V9s6WYZOtg" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_Bk-1kvGNEei-V9s6WYZOtg" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_Bk-1k_GNEei-V9s6WYZOtg" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_Bk-1lPGNEei-V9s6WYZOtg" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="FragmentReorder.uml#_BigwYPGNEei-V9s6WYZOtg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Bk-1lfGNEei-V9s6WYZOtg" x="53" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_BrzPQPGNEei-V9s6WYZOtg" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_BrzPQfGNEei-V9s6WYZOtg" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_BrzPQvGNEei-V9s6WYZOtg" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_BrzPQ_GNEei-V9s6WYZOtg" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_BrzPRPGNEei-V9s6WYZOtg" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="FragmentReorder.uml#_BpMAIPGNEei-V9s6WYZOtg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BrzPRfGNEei-V9s6WYZOtg" x="210" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_B1kPQPGNEei-V9s6WYZOtg" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_B1kPQfGNEei-V9s6WYZOtg" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_B1kPQvGNEei-V9s6WYZOtg" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_B1kPQ_GNEei-V9s6WYZOtg" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_B1kPRPGNEei-V9s6WYZOtg" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="FragmentReorder.uml#_BvkU8PGNEei-V9s6WYZOtg"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B1kPRfGNEei-V9s6WYZOtg" x="392" y="124" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Fv0C1PGDEeiJ6OxnblKpmQ" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_Fv0C1fGDEeiJ6OxnblKpmQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_Fv0C1vGDEeiJ6OxnblKpmQ"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_Fv0C1_GDEeiJ6OxnblKpmQ" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="FragmentReorder.uml#_FvAxkPGDEeiJ6OxnblKpmQ"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="FragmentReorder.uml#_FvAxkPGDEeiJ6OxnblKpmQ"/>
+  <edges xmi:type="notation:Connector" xmi:id="_tL38cPJSEeiOXo8y-_L2Ew" type="Edge_Message" source="_Bk-1k_GNEei-V9s6WYZOtg" target="_BrzPQ_GNEei-V9s6WYZOtg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_tL38cfJSEeiOXo8y-_L2Ew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="FragmentReorder.uml#_tL3VYfJSEeiOXo8y-_L2Ew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_tL38cvJSEeiOXo8y-_L2Ew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tL38c_JSEeiOXo8y-_L2Ew" id="191"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_tL38dPJSEeiOXo8y-_L2Ew" id="198"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_yy0W0PJSEeiOXo8y-_L2Ew" type="Edge_Message" source="_BrzPQ_GNEei-V9s6WYZOtg" target="_B1kPQ_GNEei-V9s6WYZOtg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_yy0W0fJSEeiOXo8y-_L2Ew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="FragmentReorder.uml#_yyzIsfJSEeiOXo8y-_L2Ew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_yy0W0vJSEeiOXo8y-_L2Ew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yy0W0_JSEeiOXo8y-_L2Ew" id="154"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_yy0W1PJSEeiOXo8y-_L2Ew" id="84"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_HgHFQfJTEeiOXo8y-_L2Ew" type="Edge_Message" source="_BrzPQ_GNEei-V9s6WYZOtg" target="_B1kPQPGNEei-V9s6WYZOtg">
+    <children xmi:type="notation:DecorationNode" xmi:id="_HgHFQvJTEeiOXo8y-_L2Ew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="FragmentReorder.uml#_HgHFQPJTEeiOXo8y-_L2Ew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HgHFQ_JTEeiOXo8y-_L2Ew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HgHFRPJTEeiOXo8y-_L2Ew" id="85"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_HgHFRfJTEeiOXo8y-_L2Ew" id="14"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/FragmentReorder.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/FragmentReorder.uml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_FuDIQPGDEeiJ6OxnblKpmQ" name="LWSeqd">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_F3wd4PGDEeiJ6OxnblKpmQ">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_FvAxkPGDEeiJ6OxnblKpmQ" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_BigwYPGNEei-V9s6WYZOtg" name="Lifeline1" coveredBy="_tL2uUPJSEeiOXo8y-_L2Ew"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_BpMAIPGNEei-V9s6WYZOtg" name="Lifeline2" coveredBy="_tL3VYPJSEeiOXo8y-_L2Ew _yyyhoPJSEeiOXo8y-_L2Ew _HgGeMPJTEeiOXo8y-_L2Ew"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_BvkU8PGNEei-V9s6WYZOtg" name="Lifeline3" coveredBy="_yyzIsPJSEeiOXo8y-_L2Ew _HgGeMfJTEeiOXo8y-_L2Ew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_HgGeMPJTEeiOXo8y-_L2Ew" name="cs" covered="_BpMAIPGNEei-V9s6WYZOtg" message="_HgHFQPJTEeiOXo8y-_L2Ew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_HgGeMfJTEeiOXo8y-_L2Ew" name="cr" covered="_BvkU8PGNEei-V9s6WYZOtg" message="_HgHFQPJTEeiOXo8y-_L2Ew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_yyyhoPJSEeiOXo8y-_L2Ew" name="2s" covered="_BpMAIPGNEei-V9s6WYZOtg" message="_yyzIsfJSEeiOXo8y-_L2Ew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_yyzIsPJSEeiOXo8y-_L2Ew" name="2r" covered="_BvkU8PGNEei-V9s6WYZOtg" message="_yyzIsfJSEeiOXo8y-_L2Ew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_tL2uUPJSEeiOXo8y-_L2Ew" name="1s" covered="_BigwYPGNEei-V9s6WYZOtg" message="_tL3VYfJSEeiOXo8y-_L2Ew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_tL3VYPJSEeiOXo8y-_L2Ew" name="1r" covered="_BpMAIPGNEei-V9s6WYZOtg" message="_tL3VYfJSEeiOXo8y-_L2Ew"/>
+    <message xmi:type="uml:Message" xmi:id="_tL3VYfJSEeiOXo8y-_L2Ew" name="AsyncMessage1" messageSort="asynchCall" receiveEvent="_tL3VYPJSEeiOXo8y-_L2Ew" sendEvent="_tL2uUPJSEeiOXo8y-_L2Ew"/>
+    <message xmi:type="uml:Message" xmi:id="_yyzIsfJSEeiOXo8y-_L2Ew" name="AsyncMessage2" messageSort="asynchCall" receiveEvent="_yyzIsPJSEeiOXo8y-_L2Ew" sendEvent="_yyyhoPJSEeiOXo8y-_L2Ew"/>
+    <message xmi:type="uml:Message" xmi:id="_HgHFQPJTEeiOXo8y-_L2Ew" name="CreateMessage1" messageSort="createMessage" receiveEvent="_HgGeMfJTEeiOXo8y-_L2Ew" sendEvent="_HgGeMPJTEeiOXo8y-_L2Ew"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/FragmentReorderUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/FragmentReorderUITest.java
@@ -1,0 +1,151 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.util.LogicalModelOrdering;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.Interaction;
+import org.eclipse.uml2.uml.InteractionFragment;
+import org.eclipse.uml2.uml.MessageEnd;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Integration tests for the semantic reordering of fragments.
+ */
+@ModelResource("FragmentReorder.di")
+@Maximized
+public class FragmentReorderUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@Rule
+	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+	@AutoFixture("AsyncMessage1")
+	private EditPart async1;
+
+	@AutoFixture
+	private PointList async1Geom;
+
+	@AutoFixture("AsyncMessage2")
+	private EditPart async2;
+
+	@AutoFixture
+	private PointList async2Geom;
+
+	@AutoFixture("CreateMessage1")
+	private EditPart create;
+
+	@AutoFixture
+	private PointList createGeom;
+
+	@AutoFixture("1s")
+	private MessageEnd async1Send;
+
+	@AutoFixture("1r")
+	private MessageEnd async1Recv;
+
+	@AutoFixture("2s")
+	private MessageEnd async2Send;
+
+	@AutoFixture("2r")
+	private MessageEnd async2Recv;
+
+	@AutoFixture("cs")
+	private MessageEnd createSend;
+
+	@AutoFixture("cr")
+	private MessageEnd createRecv;
+
+	/**
+	 * Initializes me.
+	 */
+	public FragmentReorderUITest() {
+		super();
+	}
+
+	/**
+	 * Regression test for <a href="https://github.com/eclipsesource/papyrus-seqd/issues/427">issue #427</a>.
+	 */
+	@Test
+	public void reorderAsyncMessageEnds() {
+		Point grabAt = async1Geom.getMidpoint();
+		// Drop it mid-way between the create message and AsyncMessage2
+		Point dropAt = new Point(grabAt.x(),
+				(createGeom.getFirstPoint().y() + async2Geom.getFirstPoint().y()) / 2);
+
+		editor.select(grabAt);
+		editor.with(editor.allowSemanticReordering(), () -> editor.drag(grabAt, dropAt));
+
+		autoFixtures.refresh();
+
+		// Verify graph dependencies match the new semantic order
+		editor.verifyGraph().verifyDependencies(from -> {
+			switch (from) {
+				case "cs":
+					return asList("cr", "1r", "2s");
+				case "1s":
+					return asList("1r", "2s");
+				case "1r":
+					return asList("2s");
+				case "2s":
+					return asList("2r");
+				default:
+					return null;
+			}
+		});
+
+		List<Element> expectedOrder = Arrays.asList(createSend, createRecv, async1Send, async1Recv,
+				async2Send, async2Recv);
+
+		// Verify the semantic order
+		MInteraction mInteraction = MInteraction.getInstance(editor.getSequenceDiagram().get());
+		Function<Optional<MElement<? extends Element>>, MElement<? extends Element>> getter = Optional::get;
+		Function<Element, MElement<? extends Element>> mElement = getter.compose(mInteraction::getElement);
+		List<Element> semanticOrder = Stream
+				.of(async2Recv, async2Send, async1Recv, async1Send, createRecv, createSend)
+				.sorted(Comparator.comparing(mElement, LogicalModelOrdering.semantically()))
+				.collect(Collectors.toList());
+		assertThat("Wrong semantic ordering", semanticOrder, equalTo(expectedOrder));
+
+		// Verify the element order in the model
+		Interaction interaction = editor.getInteraction();
+		List<Element> modelOrder = Stream
+				.of((InteractionFragment)async2Recv, async2Send, async1Recv, async1Send, createRecv,
+						createSend)
+				.sorted(Comparator.comparing(interaction.getFragments()::indexOf))
+				.collect(Collectors.toList());
+		assertThat("Wrong model ordering", modelOrder, equalTo(expectedOrder));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixtureRule.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixtureRule.java
@@ -210,7 +210,9 @@ public class AutoFixtureRule implements TestRule {
 				EObject next = iter.next();
 				if (next instanceof NamedElement) {
 					NamedElement element = (NamedElement)next;
-					if (name.equals(getValidJavaIdentifier(element.getName())) && filter.test(element)) {
+					String elementName = element.getName();
+					if ((name.equals(elementName) || name.equals(getValidJavaIdentifier(elementName)))
+							&& filter.test(element)) {
 						result = element;
 					}
 				} else {


### PR DESCRIPTION
Ensure that semantic reordering is always applied after all other changes, but still only once.  Do this by accumulating a deferred fragment sort command as we do a deferred padding command in the root dependency context, using a new RootContextHandler that provides the command handling that can be shared by both edit-policies and the model implementation.

Fixes #431 also.
