### PR TITLE
Fix #439 Cannot delete a message

### DIFF
--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/DeletionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/DeletionUITest.java
@@ -1,0 +1,92 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.above;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * This is the {@code DeletionUITest} type. Enjoy.
+ *
+ * @author Christian W. Damus
+ */
+@ModelResource("Nudging.di")
+@Maximized
+public class DeletionUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@Rule
+	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+	@AutoFixture
+	private EditPart async1;
+
+	@AutoFixture
+	private PointList async1Geom;
+
+	@AutoFixture
+	private EditPart request1;
+
+	@AutoFixture
+	private PointList request1Geom;
+
+	@AutoFixture
+	private EditPart async2;
+
+	@AutoFixture
+	private PointList async2Geom;
+
+	/**
+	 * Initializes me.
+	 */
+	public DeletionUITest() {
+		super();
+	}
+
+	@Test
+	public void deleteMessage() {
+		EObject message = async1.getAdapter(EObject.class);
+
+		editor.select(async1Geom.getMidpoint());
+		editor.delete();
+
+		assertThat("Message edit-part not deleted", async1.getRoot(), nullValue());
+		assertThat("Message element not deleted", message.eResource(), nullValue());
+
+		PointList newRequest1Geom = getPoints(request1);
+		assertThat("Message below not pulled up", newRequest1Geom.getMidpoint(),
+				above(request1Geom.getMidpoint()));
+	}
+
+	@Test
+	public void deleteOther() {
+		EObject message = async2.getAdapter(EObject.class);
+
+		editor.select(async2Geom.getMidpoint());
+		editor.delete();
+
+		assertThat("Message edit-part not deleted", async2.getRoot(), nullValue());
+		assertThat("Message element not deleted", message.eResource(), nullValue());
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/matchers/GEFMatchers.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/matchers/GEFMatchers.java
@@ -76,14 +76,11 @@ public class GEFMatchers {
 	}
 
 	/**
-	 * Set the default tolerance for geometry assertions. The default-default
-	 * tolerance is zero.
+	 * Set the default tolerance for geometry assertions. The default-default tolerance is zero.
 	 *
 	 * @param newDefaultTolerance
 	 *            the new default tolerance
-	 *
 	 * @return the previous default tolerance (useful to restore it, later)
-	 *
 	 * @throws IllegalArgumentException
 	 *             if the tolerance is negative
 	 */
@@ -100,20 +97,15 @@ public class GEFMatchers {
 	}
 
 	/**
-	 * Set the {@linkplain #setDefaultTolerance(int) default tolerance} for the
-	 * duration of a test.
+	 * Set the {@linkplain #setDefaultTolerance(int) default tolerance} for the duration of a test.
 	 *
 	 * @param tolerance
 	 *            the tolerance to apply to the test
 	 * @param platformFilters
-	 *            optional {@linkplain Platform#getOS() platform os/arch/ws}
-	 *            specifiers to match to enable the tolerance. If none of the
-	 *            specified filters matches, then the tolerance rule has no effect
-	 *            (whatever is otherwise the default tolerance will continue to be
-	 *            effective)
-	 *
+	 *            optional {@linkplain Platform#getOS() platform os/arch/ws} specifiers to match to enable the
+	 *            tolerance. If none of the specified filters matches, then the tolerance rule has no effect
+	 *            (whatever is otherwise the default tolerance will continue to be effective)
 	 * @return the tolerance rule
-	 *
 	 * @see #setDefaultTolerance(int)
 	 */
 	public static TestRule defaultTolerance(int tolerance, String... platformFilters) {
@@ -159,7 +151,6 @@ public class GEFMatchers {
 	 *            the expected width
 	 * @param height
 	 *            the expected height
-	 *
 	 * @return the rectangle matcher
 	 */
 	public static Matcher<Rectangle> isRect(int x, int y, int width, int height) {
@@ -177,7 +168,6 @@ public class GEFMatchers {
 	 *            matcher for the width, or {@code null} if none
 	 * @param height
 	 *            matcher for the height or {@code null} if none
-	 *
 	 * @return the rectangle matcher
 	 */
 	public static Matcher<Rectangle> isRect(Matcher<? super Integer> x, Matcher<? super Integer> y,
@@ -189,8 +179,8 @@ public class GEFMatchers {
 				boolean appended = false;
 				description.appendText("rectangle that ");
 
-				SelfDescribing[] parts = { x, y, width, height };
-				String[] names = { "x", "y", "width", "height" };
+				SelfDescribing[] parts = {x, y, width, height };
+				String[] names = {"x", "y", "width", "height" };
 				for (int i = 0; i < parts.length; i++) {
 					if (parts[i] == null) {
 						continue;
@@ -244,7 +234,6 @@ public class GEFMatchers {
 	 *            the expected x location
 	 * @param y
 	 *            the expected y location
-	 *
 	 * @return the point matcher
 	 */
 	public static Matcher<Point> isPoint(int x, int y) {
@@ -256,7 +245,6 @@ public class GEFMatchers {
 	 *
 	 * @param location
 	 *            the expected point location
-	 *
 	 * @return the point matcher
 	 */
 	public static Matcher<Point> isPoint(Point location) {
@@ -270,7 +258,6 @@ public class GEFMatchers {
 	 *            the expected point location
 	 * @param tolerance
 	 *            a tolerance to allow in the point's coördinates
-	 *
 	 * @return the point matcher
 	 */
 	public static Matcher<Point> isPoint(Point location, int tolerance) {
@@ -284,7 +271,6 @@ public class GEFMatchers {
 	 *            matcher for the x location, or {@code null} if none
 	 * @param y
 	 *            matcher for the y location, or {@code null} if none
-	 *
 	 * @return the point matcher
 	 */
 	public static Matcher<Point> isPoint(Matcher<? super Integer> x, Matcher<? super Integer> y) {
@@ -295,8 +281,8 @@ public class GEFMatchers {
 				boolean appended = false;
 				description.appendText("point that ");
 
-				SelfDescribing[] parts = { x, y };
-				String[] names = { "x", "y" };
+				SelfDescribing[] parts = {x, y };
+				String[] names = {"x", "y" };
 				for (int i = 0; i < parts.length; i++) {
 					if (parts[i] == null) {
 						continue;
@@ -340,7 +326,6 @@ public class GEFMatchers {
 	 *            the expected width
 	 * @param height
 	 *            the expected height
-	 *
 	 * @return the dimension matcher
 	 */
 	public static Matcher<Dimension> isSize(int width, int height) {
@@ -354,11 +339,9 @@ public class GEFMatchers {
 	 *            matcher for the width, or {@code null} if none
 	 * @param height
 	 *            matcher for the height or {@code null} if none
-	 *
 	 * @return the dimension matcher
 	 */
-	public static Matcher<Dimension> isSize(Matcher<? super Integer> width,
-			Matcher<? super Integer> height) {
+	public static Matcher<Dimension> isSize(Matcher<? super Integer> width, Matcher<? super Integer> height) {
 
 		return new TypeSafeDiagnosingMatcher<Dimension>() {
 			@Override
@@ -366,8 +349,8 @@ public class GEFMatchers {
 				boolean appended = false;
 				description.appendText("dimension that ");
 
-				SelfDescribing[] parts = { width, height };
-				String[] names = { "width", "height" };
+				SelfDescribing[] parts = {width, height };
+				String[] names = {"width", "height" };
 				for (int i = 0; i < parts.length; i++) {
 					if (parts[i] == null) {
 						continue;
@@ -409,7 +392,6 @@ public class GEFMatchers {
 	 *
 	 * @param where
 	 *            the point matchers
-	 *
 	 * @return the point-list matcher
 	 */
 	@SafeVarargs
@@ -451,7 +433,6 @@ public class GEFMatchers {
 	 *            the start matcher
 	 * @param to
 	 *            the end matcher
-	 *
 	 * @return the point-list matcher
 	 */
 	public static Matcher<PointList> runs(Matcher<? super Point> from, Matcher<? super Point> to) {
@@ -482,12 +463,11 @@ public class GEFMatchers {
 	}
 
 	/**
-	 * Matcher for a horizontal point-list, in which all Y coördinates are the same,
-	 * within a {@code tolerance}.
+	 * Matcher for a horizontal point-list, in which all Y coördinates are the same, within a
+	 * {@code tolerance}.
 	 *
 	 * @param tolerance
 	 *            the tolerated deviation of any Y coördinates from the average
-	 *
 	 * @return the point-list matcher
 	 */
 	public static Matcher<PointList> isHorizontal(double tolerance) {
@@ -530,6 +510,15 @@ public class GEFMatchers {
 		};
 	}
 
+	public static Matcher<Point> above(Point location) {
+		return new FeatureMatcher<Point, Integer>(NumberMatchers.lt(location.y()), "y coördinate", "y") {
+			@Override
+			protected Integer featureValueOf(Point actual) {
+				return actual.y();
+			}
+		};
+	}
+
 	/**
 	 * Matcher for the start and end of point-list.
 	 *
@@ -537,7 +526,6 @@ public class GEFMatchers {
 	 *            the start point
 	 * @param toX,&nbsp;toY
 	 *            the end point
-	 *
 	 * @return the point-list matcher
 	 */
 	public static Matcher<PointList> runs(int fromX, int fromY, int toX, int toY) {
@@ -553,7 +541,6 @@ public class GEFMatchers {
 	 *            the expected y location
 	 * @param tolerance
 	 *            a tolerance for errors in the point coördinate values
-	 *
 	 * @return the point matcher
 	 */
 	public static Matcher<Point> isPoint(int x, int y, int tolerance) {
@@ -569,7 +556,6 @@ public class GEFMatchers {
 	 *            the expected height
 	 * @param tolerance
 	 *            a tolerance for errors in the dimension measures
-	 *
 	 * @return the point matcher
 	 */
 	public static Matcher<Dimension> isSize(int width, int height, int tolerance) {
@@ -589,7 +575,6 @@ public class GEFMatchers {
 	 *            the expected height
 	 * @param tolerance
 	 *            a tolerance for errors in the rectangle coördinate values
-	 *
 	 * @return the rectangle matcher
 	 */
 	public static Matcher<Rectangle> isRect(int x, int y, int width, int height, int tolerance) {
@@ -602,7 +587,6 @@ public class GEFMatchers {
 	 *
 	 * @param rect
 	 *            the expected rectangle geometry
-	 *
 	 * @return the rectangle matcher
 	 */
 	public static Matcher<Rectangle> isRect(Rectangle rect) {
@@ -616,7 +600,6 @@ public class GEFMatchers {
 	 *            the expected rectangle geometry
 	 * @param tolerance
 	 *            a tolerance for errors in the rectangle coördinate values
-	 *
 	 * @return the rectangle matcher
 	 */
 	public static Matcher<Rectangle> isRect(Rectangle rect, int tolerance) {
@@ -632,7 +615,6 @@ public class GEFMatchers {
 	 *            the end point
 	 * @param tolerance
 	 *            a tolerance for errors in the point coördinate values
-	 *
 	 * @return the point-list matcher
 	 */
 	public static Matcher<PointList> runs(int fromX, int fromY, int toX, int toY, int tolerance) {
@@ -715,9 +697,9 @@ public class GEFMatchers {
 
 	static Function<GraphicalEditPart, IFigure> feedback() {
 		return ep -> {
-			IFigure feedbackLayer = ((LayerManager) ep.getRoot()).getLayer(LayerConstants.FEEDBACK_LAYER);
+			IFigure feedbackLayer = ((LayerManager)ep.getRoot()).getLayer(LayerConstants.FEEDBACK_LAYER);
 			// We anticipate only a single active feedback figure
-			return ((List<?>) feedbackLayer.getChildren()).stream().filter(IFigure.class::isInstance)
+			return ((List<?>)feedbackLayer.getChildren()).stream().filter(IFigure.class::isInstance)
 					.map(IFigure.class::cast).findAny().orElse(null);
 		};
 	}
@@ -767,8 +749,8 @@ public class GEFMatchers {
 	}
 
 	/**
-	 * Assertions on the geometry of GEF figures. All coördinates are in absolute
-	 * space, as is the convention of the <em>Logical Model</em>.
+	 * Assertions on the geometry of GEF figures. All coördinates are in absolute space, as is the convention
+	 * of the <em>Logical Model</em>.
 	 */
 	public static class Figures {
 
@@ -854,8 +836,8 @@ public class GEFMatchers {
 	}
 
 	/**
-	 * Assertions on the geometry of GEF edit-parts. All coördinates are in absolute
-	 * space, as is the convention of the <em>Logical Model</em>.
+	 * Assertions on the geometry of GEF edit-parts. All coördinates are in absolute space, as is the
+	 * convention of the <em>Logical Model</em>.
 	 */
 	public static class EditParts {
 

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MInteractionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src-gen/org/eclipse/papyrus/uml/interaction/model/tests/MInteractionTest.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CommandWrapper;
+import org.eclipse.emf.common.command.IdentityCommand;
 import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.gmf.runtime.notation.Bounds;
@@ -304,6 +306,19 @@ public class MInteractionTest extends MElementTest {
 
 		List<String> sortedOrder = fragments.stream().map(NamedElement::getName).collect(Collectors.toList());
 		assertThat("Fragments not correctly sorted", sortedOrder, is(correctOrder));
+	}
+
+	public void testSort_alreadySorted() {
+		Command sort = getFixture().sort();
+		assertThat("Cannot sort", sort, executable());
+
+		// Go through the motions
+		execute(sort);
+
+		// The sort should have been trivial
+		assertThat("Unexpected kind of command", sort, instanceOf(CommandWrapper.class));
+		CommandWrapper wrapper = (CommandWrapper)sort;
+		assertThat("Sort was not a no-op", wrapper.getCommand(), is(IdentityCommand.INSTANCE));
 	}
 
 } // MInteractionTest


### PR DESCRIPTION
Fix the failure of a nudge operation that isn’t needed for messages that are implicitly nudged by their attached
source and target views also being nudged, which is needlessly unexecutable.

Also fix the `SortSemanticsCommand` that sporadically fails on shuffles of the fragments that break the naïve
`MoveCommand` implementation.
