### PR TITLE
Fix #432 Nudging when moving sloped messages up

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/InteractionFragments.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/InteractionFragments.java
@@ -23,11 +23,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
 import org.eclipse.uml2.uml.Element;
@@ -45,18 +47,65 @@ public class InteractionFragments {
 		super();
 	}
 
+	/**
+	 * Find an obstacle in the way of moving an {@code occurrence} (being a point object) up or down in the
+	 * interaction.
+	 * 
+	 * @param occurrence
+	 *            an occurrence being moved
+	 * @param movingUp
+	 *            whether it is being moved up (otherwise down)
+	 * @param newY
+	 *            the new position to which it is being moved
+	 * @return the obstacle blocking its move, that will need to be nudged out of the way
+	 */
 	public static Optional<MElement<? extends Element>> getObstacle(MOccurrence<? extends Element> occurrence,
 			boolean movingUp, int newY) {
 
+		return getObstacle(occurrence, movingUp, newY, newY);
+	}
+
+	/**
+	 * Find an obstacle in the way of moving an {@code element} up or down in the interaction.
+	 * 
+	 * @param element
+	 *            an element being moved
+	 * @param movingUp
+	 *            whether it is being moved up (otherwise down)
+	 * @param newTop
+	 *            the new top position that it will have after being moved
+	 * @param newBottom
+	 *            the new bottom position that it will have after being moved
+	 * @return the obstacle blocking its move, that will need to be nudged out of the way
+	 */
+	public static Optional<MElement<? extends Element>> getObstacle(MElement<? extends Element> element,
+			boolean movingUp, int newTop, int newBottom) {
+
+		// Do we want to normalize message ends as messages or as themselves?
+		boolean messageOnly = !(element instanceof MMessage) && !(element instanceof MOccurrence<?>);
+
 		Optional<MElement<? extends Element>> result = movingUp //
-				? verticallyPreceding(normalizedUp(occurrence)) //
-				: verticallyFollowing(normalizedDown(occurrence));
+				? verticallyPreceding(normalizedUp(element, messageOnly)) //
+				: verticallyFollowing(normalizedDown(element, messageOnly));
 
 		Predicate<MElement<? extends Element>> collisionFilter = movingUp
-				? below(newY - 1 /* need ≥, not > */)
-				: above(newY + 1 /* need ≤, not < */);
+				? below(newTop - 1 /* need ≥, not > */)
+				: above(newBottom + 1 /* need ≤, not < */);
 
-		return result.filter(collisionFilter).map(InteractionFragments::resolveObstacle);
+		return result.filter(collisionFilter).map(resolveObstacle(element));
+	}
+
+	/**
+	 * Obtain a function that resolves an obstable to an element that has a notation view for which layout
+	 * constraints can actually be determined.
+	 * 
+	 * @param reference
+	 *            the reference element for which the obstacle was computed as being in its way
+	 * @return the obstacle resolution function
+	 * @see #resolveObstacle(MElement, MElement)
+	 */
+	static UnaryOperator<MElement<? extends Element>> resolveObstacle(MElement<? extends Element> reference) {
+		return obstacle -> resolveObstacle(obstacle, reference);
 	}
 
 	/**
@@ -65,24 +114,31 @@ public class InteractionFragments {
 	 * 
 	 * @param obstacle
 	 *            an obstacle
+	 * @param reference
+	 *            the reference element for which the {@code obstacle} was computed as being in its way
 	 * @return the {@code obstacle}, or some other element that is implied by it
 	 */
-	static MElement<? extends Element> resolveObstacle(MElement<? extends Element> obstacle) {
+	private static MElement<? extends Element> resolveObstacle(MElement<? extends Element> obstacle,
+			MElement<? extends Element> reference) {
+		Predicate<MElement<? extends Element>> spansReference = LogicalModelPredicates.spans(reference);
+		Predicate<MElement<? extends Element>> notSpanning = spansReference.negate();
+
 		return new SequenceDiagramSwitch<MElement<? extends Element>>() {
 			@Override
 			public MElement<? extends Element> caseMMessageEnd(MMessageEnd object) {
-				return object.getOwner();
+				return Optional.ofNullable(object.getOwner()).filter(notSpanning).orElse(null);
 			}
 
 			@Override
 			public MElement<? extends Element> caseMExecutionOccurrence(MExecutionOccurrence object) {
-				return object.getExecution().orElse(null);
+				return object.getExecution().filter(notSpanning).orElse(null);
 			}
 
 			@Override
 			public <T extends Element> MElement<? extends Element> caseMOccurrence(MOccurrence<T> object) {
-				return Optionals.elseMaybe(object.getStartedExecution(), object.getFinishedExecution())
-						.orElse(null);
+				// Does the execution span the reference element? If so, only nudge the actual occurrence
+				return Optionals.elseMaybe(object.getStartedExecution().filter(notSpanning),
+						object.getFinishedExecution().filter(notSpanning)).orElse(null);
 			}
 
 			@Override
@@ -92,27 +148,16 @@ public class InteractionFragments {
 		}.doSwitch(obstacle);
 	}
 
-	public static Optional<MElement<? extends Element>> getObstacle(MExecution execution, boolean movingUp,
-			int newTop, int newBottom) {
-
-		Optional<MElement<? extends Element>> result = movingUp //
-				? verticallyPreceding(normalizedUp(execution)) //
-				: verticallyFollowing(normalizedDown(execution));
-
-		Predicate<MElement<? extends Element>> collisionFilter = movingUp
-				? below(newTop - 1 /* need ≥, not > */)
-				: above(newBottom + 1 /* need ≤, not < */);
-
-		return result.filter(collisionFilter).map(InteractionFragments::resolveObstacle);
-	}
-
-	private static MElement<? extends Element> normalizedUp(MElement<? extends Element> obstacle) {
+	private static MElement<? extends Element> normalizedUp(MElement<? extends Element> obstacle,
+			boolean messageOnly) {
 		return new SequenceDiagramSwitch<MElement<? extends Element>>() {
 
 			@Override
 			public MElement<? extends Element> caseMMessageEnd(MMessageEnd object) {
-				// The real element in consideration is the message, and it begins at the send end
-				return object.getOtherEnd().filter(MMessageEnd::isSend).map(this::doSwitch).orElse(null);
+				return messageOnly
+						// The real element to consider is the message, and it begins at the send end
+						? object.getOtherEnd().filter(MMessageEnd::isSend).map(this::doSwitch).orElse(null)
+						: null;
 			}
 
 			@Override
@@ -124,6 +169,12 @@ public class InteractionFragments {
 					return finishedExecution.get().getStart().orElse(null);
 				}
 				return null;
+			}
+
+			@Override
+			public MElement<? extends Element> caseMMessage(MMessage object) {
+				// The message's upper extremity is the send event
+				return object.getSend().map(this::doSwitch).orElse(null);
 			}
 
 			@Override
@@ -139,13 +190,16 @@ public class InteractionFragments {
 		}.doSwitch(obstacle);
 	}
 
-	private static MElement<? extends Element> normalizedDown(MElement<? extends Element> obstacle) {
+	private static MElement<? extends Element> normalizedDown(MElement<? extends Element> obstacle,
+			boolean messageOnly) {
 		return new SequenceDiagramSwitch<MElement<? extends Element>>() {
 
 			@Override
 			public MElement<? extends Element> caseMMessageEnd(MMessageEnd object) {
-				// The real element in consideration is the message, and it finishes at the receiveend
-				return object.getOtherEnd().filter(MMessageEnd::isReceive).map(this::doSwitch).orElse(null);
+				return messageOnly
+						// The real element to consider is the message, and it finishes at the receive end
+						? object.getOtherEnd().filter(MMessageEnd::isReceive).map(this::doSwitch).orElse(null)
+						: null;
 			}
 
 			@Override
@@ -154,6 +208,12 @@ public class InteractionFragments {
 				Optional<MElement<? extends Element>> startedExecution = as(object.getStartedExecution(),
 						MElement.class);
 				return startedExecution.orElse(null);
+			}
+
+			@Override
+			public MElement<? extends Element> caseMMessage(MMessage object) {
+				// The message's lower extremity is the receive event
+				return object.getReceive().map(this::doSwitch).orElse(null);
 			}
 
 			@Override
@@ -207,7 +267,14 @@ public class InteractionFragments {
 		List<InteractionFragment> fragments = interaction.getElement().getFragments();
 
 		OptionalInt index = filter(OptionalInt.of(fragments.indexOf(fragment.getElement())), i -> i > 0);
-		return flatMapToObj(index, i -> interaction.getElement(fragments.get(i - 1)));
+		Optional<MElement<? extends Element>> result = flatMapToObj(index,
+				i -> interaction.getElement(fragments.get(i - 1)));
+
+		// Take the start of an execution instead of the execution, itself
+		return Optionals.elseMaybe( //
+				result.filter(MExecution.class::isInstance).map(MExecution.class::cast)
+						.flatMap(MExecution::getStart),
+				result);
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/model/util/Optionals.java
@@ -17,6 +17,7 @@ import java.util.OptionalInt;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntBinaryOperator;
 import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
 import java.util.function.IntUnaryOperator;
@@ -71,6 +72,23 @@ public class Optionals {
 	 */
 	public static OptionalInt map(OptionalInt optional, IntUnaryOperator operator) {
 		return optional.isPresent() ? OptionalInt.of(operator.applyAsInt(optional.getAsInt())) : optional;
+	}
+
+	/**
+	 * Applies an integer-valued binary {@code operator} to two optional integers.
+	 * 
+	 * @param left
+	 *            an optional integer value, left input to the {@code operator}
+	 * @param right
+	 *            another optional integer value, right input to the {@code operator}
+	 * @param operator
+	 *            an operator to apply
+	 * @return the optional {@code operator} result
+	 */
+	public static OptionalInt apply(OptionalInt left, OptionalInt right, IntBinaryOperator operator) {
+		return (left.isPresent() && right.isPresent())
+				? OptionalInt.of(operator.applyAsInt(left.getAsInt(), right.getAsInt()))
+				: OptionalInt.empty();
 	}
 
 	/**

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
 Bundle-Description: Tests of the core run-time APIs of the sequence diagram.
 Export-Package: org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers;version="1.0.0"
 Automatic-Module-Name: org.eclipse.papyrus.uml.diagram.sequence.runtime.tests
+Import-Package: com.google.common.collect;version="21.0.0"

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AbstractGraphicalEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AbstractGraphicalEditPolicyUITest.java
@@ -34,6 +34,7 @@ import org.eclipse.gef.EditPart;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.LayerConstants;
 import org.eclipse.gef.editparts.LayerManager;
+import org.eclipse.gef.handles.ConnectionHandle;
 import org.eclipse.gef.handles.ResizeHandle;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
@@ -56,13 +57,18 @@ public abstract class AbstractGraphicalEditPolicyUITest {
 	private static final int RESIZE_HANDLE_SIZE = 7;
 
 	/**
-	 * Tolerance for assertion of locations based on the dragging of a resize
-	 * handle.
+	 * Tolerance for assertion of locations based on the dragging of a resize handle.
 	 */
-	protected static final int RESIZE_TOLERANCE = (int) Math.floor(RESIZE_HANDLE_SIZE / 2.0);
+	protected static final int RESIZE_TOLERANCE = (int)Math.floor(RESIZE_HANDLE_SIZE / 2.0);
 
 	/** The width of an execution specification. */
 	protected static final int EXEC_WIDTH = 10;
+
+	/** Constant for the source end of a connection edit-part. */
+	protected static final int SOURCE_END = 0;
+
+	/** Constant for the target end of a connection edit-part. */
+	protected static final int TARGET_END = 1;
 
 	/** Some Linux environments are off by 1 in a lot of test scenarios. */
 	@ClassRule
@@ -86,17 +92,16 @@ public abstract class AbstractGraphicalEditPolicyUITest {
 	}
 
 	/**
-	 * Create a new shape in the current diagram by automating the creation tool.
-	 * Fails if the shape cannot be created or cannot be found in the diagram after
-	 * creation.
+	 * Create a new shape in the current diagram by automating the creation tool. Fails if the shape cannot be
+	 * created or cannot be found in the diagram after creation.
 	 *
 	 * @param type
 	 *            the type of shape to create
 	 * @param location
 	 *            the location (mouse pointer) at which to create the shape
 	 * @param size
-	 *            the size of the shape to create, or {@code null} for the default
-	 *            size as would be created when just clicking in the diagram
+	 *            the size of the shape to create, or {@code null} for the default size as would be created
+	 *            when just clicking in the diagram
 	 * @return the newly created shape edit-part
 	 */
 	protected EditPart createShape(IElementType type, Point location, Dimension size) {
@@ -105,18 +110,15 @@ public abstract class AbstractGraphicalEditPolicyUITest {
 	}
 
 	/**
-	 * Create a new connection in the current diagram by automating the creation
-	 * tool. Fails if the connection cannot be created or cannot be found in the
-	 * diagram after creation.
+	 * Create a new connection in the current diagram by automating the creation tool. Fails if the connection
+	 * cannot be created or cannot be found in the diagram after creation.
 	 *
 	 * @param type
 	 *            the type of shape to create
 	 * @param start
-	 *            the location (mouse pointer) at which to start drawing the
-	 *            connection
+	 *            the location (mouse pointer) at which to start drawing the connection
 	 * @param finish
-	 *            the location (mouse pointer) at which to finish drawing the
-	 *            connection
+	 *            the location (mouse pointer) at which to finish drawing the connection
 	 * @return the newly created connection edit-part
 	 */
 	protected EditPart createConnection(IElementType type, Point start, Point finish) {
@@ -134,7 +136,7 @@ public abstract class AbstractGraphicalEditPolicyUITest {
 	}
 
 	protected static Rectangle getBounds(EditPart editPart) {
-		IFigure figure = ((GraphicalEditPart) editPart).getFigure();
+		IFigure figure = ((GraphicalEditPart)editPart).getFigure();
 		Rectangle result = figure.getBounds().getCopy();
 		figure.getParent().translateToAbsolute(result);
 		return result;
@@ -153,40 +155,39 @@ public abstract class AbstractGraphicalEditPolicyUITest {
 	}
 
 	protected static IFigure getResizeHandle(EditPart editPart, int position) {
-		((IGraphicalEditPart) editPart).getFigure();
-		LayerManager manager = (LayerManager) editPart.getViewer().getEditPartRegistry()
-				.get(LayerManager.ID);
+		((IGraphicalEditPart)editPart).getFigure();
+		LayerManager manager = (LayerManager)editPart.getViewer().getEditPartRegistry().get(LayerManager.ID);
 		IFigure handleLayer = manager.getLayer(LayerConstants.HANDLE_LAYER);
 
 		Rectangle bounds = getBounds(editPart);
 		Point hitTarget;
 		switch (position) {
-		case PositionConstants.NORTH_WEST:
-			hitTarget = bounds.getTopLeft();
-			break;
-		case PositionConstants.NORTH:
-			hitTarget = bounds.getTop();
-			break;
-		case PositionConstants.NORTH_EAST:
-			hitTarget = bounds.getTopRight();
-			break;
-		case PositionConstants.EAST:
-			hitTarget = bounds.getRight();
-			break;
-		case PositionConstants.SOUTH_EAST:
-			hitTarget = bounds.getBottomRight();
-			break;
-		case PositionConstants.SOUTH:
-			hitTarget = bounds.getBottom();
-			break;
-		case PositionConstants.SOUTH_WEST:
-			hitTarget = bounds.getBottomLeft();
-			break;
-		case PositionConstants.WEST:
-			hitTarget = bounds.getLeft();
-			break;
-		default:
-			throw new IllegalArgumentException("position : " + position);
+			case PositionConstants.NORTH_WEST:
+				hitTarget = bounds.getTopLeft();
+				break;
+			case PositionConstants.NORTH:
+				hitTarget = bounds.getTop();
+				break;
+			case PositionConstants.NORTH_EAST:
+				hitTarget = bounds.getTopRight();
+				break;
+			case PositionConstants.EAST:
+				hitTarget = bounds.getRight();
+				break;
+			case PositionConstants.SOUTH_EAST:
+				hitTarget = bounds.getBottomRight();
+				break;
+			case PositionConstants.SOUTH:
+				hitTarget = bounds.getBottom();
+				break;
+			case PositionConstants.SOUTH_WEST:
+				hitTarget = bounds.getBottomLeft();
+				break;
+			case PositionConstants.WEST:
+				hitTarget = bounds.getLeft();
+				break;
+			default:
+				throw new IllegalArgumentException("position : " + position);
 		}
 
 		@SuppressWarnings("unchecked")
@@ -201,13 +202,43 @@ public abstract class AbstractGraphicalEditPolicyUITest {
 		return getResizeHandle(editPart, position).getBounds().getCenter();
 	}
 
+	protected static IFigure getConnectionHandle(EditPart editPart, int end) {
+		((IGraphicalEditPart)editPart).getFigure();
+		LayerManager manager = (LayerManager)editPart.getViewer().getEditPartRegistry().get(LayerManager.ID);
+		IFigure handleLayer = manager.getLayer(LayerConstants.HANDLE_LAYER);
+
+		PointList points = getPoints(editPart);
+		Point hitTarget;
+		switch (end) {
+			case SOURCE_END:
+				hitTarget = points.getFirstPoint();
+				break;
+			case TARGET_END:
+				hitTarget = points.getLastPoint();
+				break;
+			default:
+				throw new IllegalArgumentException("end : " + end);
+		}
+
+		@SuppressWarnings("unchecked")
+		List<? extends IFigure> handles = handleLayer.getChildren();
+		Optional<? extends IFigure> result = handles.stream().filter(ConnectionHandle.class::isInstance)
+				.filter(h -> h.getBounds().contains(hitTarget)).findAny();
+		assertThat("Connection handle not found", result.isPresent(), is(true));
+		return result.get();
+	}
+
+	protected static Point getConnectionHandleGrabPoint(EditPart editPart, int end) {
+		return getConnectionHandle(editPart, end).getBounds().getCenter();
+	}
+
 	protected static Point getSource(EditPart connectionEditPart) {
 		PointList points = getPoints(connectionEditPart);
 		return points.getFirstPoint();
 	}
 
 	protected static PointList getPoints(EditPart connectionEditPart) {
-		Connection connection = (Connection) ((ConnectionEditPart) connectionEditPart).getFigure();
+		Connection connection = (Connection)((ConnectionEditPart)connectionEditPart).getFigure();
 		PointList result = connection.getPoints().getCopy();
 		connection.getParent().translateToAbsolute(result);
 		return result;

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessageNudgingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessageNudgingUITest.java
@@ -1,0 +1,145 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static java.lang.Integer.signum;
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
+import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.lt;
+import static org.eclipse.uml2.uml.util.UMLUtil.getQualifiedText;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.Interaction;
+import org.eclipse.uml2.uml.InteractionFragment;
+import org.eclipse.uml2.uml.MessageOccurrenceSpecification;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Integration regression tests for certain nudge scenarios involving asynchronous messages in
+ * <a href="https://github.com/eclipsesource/papyrus-seqd/issues/432">Issue #432</a>.
+ */
+@ModelResource("AsyncMessages.di")
+@Maximized
+public class AsyncMessageNudgingUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@Rule
+	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+	@AutoFixture
+	private EditPart asyncMessage1;
+
+	@AutoFixture
+	private PointList asyncMessage1Geom;
+
+	@AutoFixture
+	private EditPart asyncMessage2;
+
+	@AutoFixture
+	private PointList asyncMessage2Geom;
+
+	@AutoFixture
+	private MessageOccurrenceSpecification _1s;
+
+	@AutoFixture
+	private MessageOccurrenceSpecification _1r;
+
+	@AutoFixture
+	private MessageOccurrenceSpecification _2s;
+
+	@AutoFixture
+	private MessageOccurrenceSpecification _2r;
+
+	/**
+	 * Initializes me.
+	 */
+	public AsyncMessageNudgingUITest() {
+		super();
+	}
+
+	/**
+	 * Test nudging a sloped message up not above another sloped message, but so that it would be trying to
+	 * split that message (and verify that the other message is appropriately nudged out of the way).
+	 */
+	@Test
+	public void nudgeAsync2UpABit() {
+		// This would drop the sending end of message 2 within the vertical span of message 1
+		Point grabAt = asyncMessage2Geom.getMidpoint();
+		Point dropAt = new Point(grabAt.x(), asyncMessage1Geom.getLastPoint().y());
+
+		editor.moveSelection(grabAt, dropAt);
+		autoFixtures.refresh();
+
+		assertThat("AsyncMessage1 not bumped", asyncMessage1Geom.getLastPoint(),
+				isPoint(anything(), lt(asyncMessage2Geom.getFirstPoint().y())));
+	}
+
+	/**
+	 * Test nudging a sloped message up fully above another sloped message (and verify that the other message
+	 * is appropriately nudged out of the way).
+	 */
+	@Test
+	public void nudgeAsync2AboveAsync1() {
+		int async2Height = asyncMessage2Geom.getLastPoint().y() - asyncMessage2Geom.getFirstPoint().y();
+
+		// This would drop the receiving end of message 2 above the sending end of message 1
+		Point grabAt = asyncMessage2Geom.getMidpoint();
+		Point dropAt = new Point(grabAt.x(), asyncMessage1Geom.getFirstPoint().y() - (async2Height / 2) - 10);
+
+		editor.moveSelection(grabAt, dropAt);
+		autoFixtures.refresh();
+
+		assertThat("AsyncMessage1 not bumped", asyncMessage1Geom.getLastPoint(),
+				isPoint(anything(), lt(asyncMessage2Geom.getFirstPoint().y())));
+	}
+
+	//
+	// Test framework
+	//
+
+	/**
+	 * None of our nudging operations changes the semantic order of the involved interaction fragments.
+	 */
+	@After
+	public void assertFragmentsSemanticOrder() {
+		Interaction interaction = editor.getInteraction();
+		List<InteractionFragment> allFragments = interaction.getFragments();
+		List<InteractionFragment> fragmentsOfInterest = Arrays.asList(_1s, _1r, _2s, _2r);
+
+		for (int i = 1; i < fragmentsOfInterest.size(); i++) {
+			InteractionFragment prev = fragmentsOfInterest.get(i - 1);
+			InteractionFragment next = fragmentsOfInterest.get(i);
+
+			int expectedOrder = fragmentsOfInterest.indexOf(next) - fragmentsOfInterest.indexOf(prev);
+			int actualOrder = allFragments.indexOf(next) - allFragments.indexOf(prev);
+
+			if (signum(actualOrder) != signum(expectedOrder)) {
+				fail(String.format("Interaction fragments out of order: %s ≺ %s", getQualifiedText(next),
+						getQualifiedText(prev)));
+			}
+		}
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages.notation
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Y0vRYP4dEeifDLKIoxuqew" type="LightweightSequenceDiagram" name="Lightweight Sequence Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_Y0vRYf4dEeifDLKIoxuqew" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_Y0vRYv4dEeifDLKIoxuqew" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_Y0vRY_4dEeifDLKIoxuqew" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_bkfcMP4dEeifDLKIoxuqew" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_bkfcMf4dEeifDLKIoxuqew" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_bkfcMv4dEeifDLKIoxuqew" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_bkfcM_4dEeifDLKIoxuqew" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_bkgDQP4dEeifDLKIoxuqew" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="AsyncMessages.uml#_bhUzcP4dEeifDLKIoxuqew"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bkgDQf4dEeifDLKIoxuqew" x="46" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_b-R1MP4dEeifDLKIoxuqew" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_b-R1Mf4dEeifDLKIoxuqew" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_b-R1Mv4dEeifDLKIoxuqew" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_b-R1M_4dEeifDLKIoxuqew" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_b-R1NP4dEeifDLKIoxuqew" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="AsyncMessages.uml#_b8zOgP4dEeifDLKIoxuqew"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b-R1Nf4dEeifDLKIoxuqew" x="245" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_cOy9cP4dEeifDLKIoxuqew" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_cOy9cf4dEeifDLKIoxuqew" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_cOy9cv4dEeifDLKIoxuqew" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_cOy9c_4dEeifDLKIoxuqew" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_cOy9dP4dEeifDLKIoxuqew" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="AsyncMessages.uml#_cNKlwP4dEeifDLKIoxuqew"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cOy9df4dEeifDLKIoxuqew" x="432" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y0vRZP4dEeifDLKIoxuqew" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_Y0vRZf4dEeifDLKIoxuqew" name="diagram_compatibility_version" stringValue="1.4.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_Y0vRZv4dEeifDLKIoxuqew"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_Y0vRZ_4dEeifDLKIoxuqew" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="AsyncMessages.uml#_Yz6yAP4dEeifDLKIoxuqew"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="AsyncMessages.uml#_Yz6yAP4dEeifDLKIoxuqew"/>
+  <edges xmi:type="notation:Connector" xmi:id="_czYRMP4dEeifDLKIoxuqew" type="Edge_Message" source="_bkfcM_4dEeifDLKIoxuqew" target="_b-R1M_4dEeifDLKIoxuqew">
+    <children xmi:type="notation:DecorationNode" xmi:id="_czYRMf4dEeifDLKIoxuqew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="AsyncMessages.uml#_czXqIv4dEeifDLKIoxuqew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_czYRMv4dEeifDLKIoxuqew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_czYRM_4dEeifDLKIoxuqew" id="139"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_czYRNP4dEeifDLKIoxuqew" id="187"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_dzXHgP4dEeifDLKIoxuqew" type="Edge_Message" source="_b-R1M_4dEeifDLKIoxuqew" target="_cOy9c_4dEeifDLKIoxuqew">
+    <children xmi:type="notation:DecorationNode" xmi:id="_dzXHgf4dEeifDLKIoxuqew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="AsyncMessages.uml#_dzV5YP4dEeifDLKIoxuqew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dzXHgv4dEeifDLKIoxuqew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dzXHg_4dEeifDLKIoxuqew" id="212"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dzXHhP4dEeifDLKIoxuqew" id="250"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_eUSDQP4dEeifDLKIoxuqew" type="Edge_Message" source="_cOy9c_4dEeifDLKIoxuqew" target="_b-R1M_4dEeifDLKIoxuqew">
+    <children xmi:type="notation:DecorationNode" xmi:id="_eUSDQf4dEeifDLKIoxuqew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="AsyncMessages.uml#_eURcMv4dEeifDLKIoxuqew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eUSDQv4dEeifDLKIoxuqew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUSDQ_4dEeifDLKIoxuqew" id="301"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUSDRP4dEeifDLKIoxuqew" id="316"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_ff0CQP4dEeifDLKIoxuqew" type="Edge_Message" source="_b-R1M_4dEeifDLKIoxuqew" target="_bkfcM_4dEeifDLKIoxuqew">
+    <children xmi:type="notation:DecorationNode" xmi:id="_ff0CQf4dEeifDLKIoxuqew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="AsyncMessages.uml#_ffzbMv4dEeifDLKIoxuqew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ff0CQv4dEeifDLKIoxuqew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ff0CQ_4dEeifDLKIoxuqew" id="341"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ff0CRP4dEeifDLKIoxuqew" id="401"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages.uml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Yy43QP4dEeifDLKIoxuqew" name="TestSeqD">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_Y730IP4dEeifDLKIoxuqew">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_Yz6yAP4dEeifDLKIoxuqew" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_bhUzcP4dEeifDLKIoxuqew" name="Lifeline1" coveredBy="_czXqIP4dEeifDLKIoxuqew _ffzbMf4dEeifDLKIoxuqew"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_b8zOgP4dEeifDLKIoxuqew" name="Lifeline2" coveredBy="_czXqIf4dEeifDLKIoxuqew _dzVSUP4dEeifDLKIoxuqew _eURcMf4dEeifDLKIoxuqew _ffzbMP4dEeifDLKIoxuqew"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_cNKlwP4dEeifDLKIoxuqew" name="Lifeline3" coveredBy="_dzVSUf4dEeifDLKIoxuqew _eURcMP4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_czXqIP4dEeifDLKIoxuqew" name="1s" covered="_bhUzcP4dEeifDLKIoxuqew" message="_czXqIv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_czXqIf4dEeifDLKIoxuqew" name="1r" covered="_b8zOgP4dEeifDLKIoxuqew" message="_czXqIv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_dzVSUP4dEeifDLKIoxuqew" name="2s" covered="_b8zOgP4dEeifDLKIoxuqew" message="_dzV5YP4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_dzVSUf4dEeifDLKIoxuqew" name="2r" covered="_cNKlwP4dEeifDLKIoxuqew" message="_dzV5YP4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_eURcMP4dEeifDLKIoxuqew" name="3s" covered="_cNKlwP4dEeifDLKIoxuqew" message="_eURcMv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_eURcMf4dEeifDLKIoxuqew" name="3r" covered="_b8zOgP4dEeifDLKIoxuqew" message="_eURcMv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_ffzbMP4dEeifDLKIoxuqew" name="4s" covered="_b8zOgP4dEeifDLKIoxuqew" message="_ffzbMv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_ffzbMf4dEeifDLKIoxuqew" name="4r" covered="_bhUzcP4dEeifDLKIoxuqew" message="_ffzbMv4dEeifDLKIoxuqew"/>
+    <message xmi:type="uml:Message" xmi:id="_czXqIv4dEeifDLKIoxuqew" name="AsyncMessage1" messageSort="asynchCall" receiveEvent="_czXqIf4dEeifDLKIoxuqew" sendEvent="_czXqIP4dEeifDLKIoxuqew"/>
+    <message xmi:type="uml:Message" xmi:id="_dzV5YP4dEeifDLKIoxuqew" name="AsyncMessage2" messageSort="asynchCall" receiveEvent="_dzVSUf4dEeifDLKIoxuqew" sendEvent="_dzVSUP4dEeifDLKIoxuqew"/>
+    <message xmi:type="uml:Message" xmi:id="_eURcMv4dEeifDLKIoxuqew" name="AsyncMessage3" messageSort="asynchCall" receiveEvent="_eURcMf4dEeifDLKIoxuqew" sendEvent="_eURcMP4dEeifDLKIoxuqew"/>
+    <message xmi:type="uml:Message" xmi:id="_ffzbMv4dEeifDLKIoxuqew" name="AsyncMessage4" messageSort="asynchCall" receiveEvent="_ffzbMf4dEeifDLKIoxuqew" sendEvent="_ffzbMP4dEeifDLKIoxuqew"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages2.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages2.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages2.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages2.notation
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Y0vRYP4dEeifDLKIoxuqew" type="LightweightSequenceDiagram" name="Lightweight Sequence Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_Y0vRYf4dEeifDLKIoxuqew" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_Y0vRYv4dEeifDLKIoxuqew" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_Y0vRY_4dEeifDLKIoxuqew" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_bkfcMP4dEeifDLKIoxuqew" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_bkfcMf4dEeifDLKIoxuqew" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_bkfcMv4dEeifDLKIoxuqew" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_bkfcM_4dEeifDLKIoxuqew" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_bkgDQP4dEeifDLKIoxuqew" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="AsyncMessages2.uml#_bhUzcP4dEeifDLKIoxuqew"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bkgDQf4dEeifDLKIoxuqew" x="46" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_b-R1MP4dEeifDLKIoxuqew" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_b-R1Mf4dEeifDLKIoxuqew" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_b-R1Mv4dEeifDLKIoxuqew" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_b-R1M_4dEeifDLKIoxuqew" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_b-R1NP4dEeifDLKIoxuqew" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="AsyncMessages2.uml#_b8zOgP4dEeifDLKIoxuqew"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_b-R1Nf4dEeifDLKIoxuqew" x="245" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_cOy9cP4dEeifDLKIoxuqew" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_cOy9cf4dEeifDLKIoxuqew" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_cOy9cv4dEeifDLKIoxuqew" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_cOy9c_4dEeifDLKIoxuqew" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_cOy9dP4dEeifDLKIoxuqew" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="AsyncMessages2.uml#_cNKlwP4dEeifDLKIoxuqew"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_cOy9df4dEeifDLKIoxuqew" x="432" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Y0vRZP4dEeifDLKIoxuqew" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_Y0vRZf4dEeifDLKIoxuqew" name="diagram_compatibility_version" stringValue="1.4.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_Y0vRZv4dEeifDLKIoxuqew"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_Y0vRZ_4dEeifDLKIoxuqew" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="AsyncMessages2.uml#_Yz6yAP4dEeifDLKIoxuqew"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="AsyncMessages2.uml#_Yz6yAP4dEeifDLKIoxuqew"/>
+  <edges xmi:type="notation:Connector" xmi:id="_czYRMP4dEeifDLKIoxuqew" type="Edge_Message" source="_bkfcM_4dEeifDLKIoxuqew" target="_b-R1M_4dEeifDLKIoxuqew">
+    <children xmi:type="notation:DecorationNode" xmi:id="_czYRMf4dEeifDLKIoxuqew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="AsyncMessages2.uml#_czXqIv4dEeifDLKIoxuqew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_czYRMv4dEeifDLKIoxuqew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_czYRM_4dEeifDLKIoxuqew" id="121"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_czYRNP4dEeifDLKIoxuqew" id="249"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_dzXHgP4dEeifDLKIoxuqew" type="Edge_Message" source="_b-R1M_4dEeifDLKIoxuqew" target="_cOy9c_4dEeifDLKIoxuqew">
+    <children xmi:type="notation:DecorationNode" xmi:id="_dzXHgf4dEeifDLKIoxuqew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="AsyncMessages2.uml#_dzV5YP4dEeifDLKIoxuqew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_dzXHgv4dEeifDLKIoxuqew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dzXHg_4dEeifDLKIoxuqew" id="191"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_dzXHhP4dEeifDLKIoxuqew" id="292"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_eUSDQP4dEeifDLKIoxuqew" type="Edge_Message" source="_cOy9c_4dEeifDLKIoxuqew" target="_b-R1M_4dEeifDLKIoxuqew">
+    <children xmi:type="notation:DecorationNode" xmi:id="_eUSDQf4dEeifDLKIoxuqew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="AsyncMessages2.uml#_eURcMv4dEeifDLKIoxuqew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eUSDQv4dEeifDLKIoxuqew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUSDQ_4dEeifDLKIoxuqew" id="320"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eUSDRP4dEeifDLKIoxuqew" id="335"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_ff0CQP4dEeifDLKIoxuqew" type="Edge_Message" source="_b-R1M_4dEeifDLKIoxuqew" target="_bkfcM_4dEeifDLKIoxuqew">
+    <children xmi:type="notation:DecorationNode" xmi:id="_ff0CQf4dEeifDLKIoxuqew" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="AsyncMessages2.uml#_ffzbMv4dEeifDLKIoxuqew"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ff0CQv4dEeifDLKIoxuqew"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ff0CQ_4dEeifDLKIoxuqew" id="360"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ff0CRP4dEeifDLKIoxuqew" id="384"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages2.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AsyncMessages2.uml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Yy43QP4dEeifDLKIoxuqew" name="TestSeqD">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_Y730IP4dEeifDLKIoxuqew">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_Yz6yAP4dEeifDLKIoxuqew" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_bhUzcP4dEeifDLKIoxuqew" name="Lifeline1" coveredBy="_czXqIP4dEeifDLKIoxuqew _ffzbMf4dEeifDLKIoxuqew"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_b8zOgP4dEeifDLKIoxuqew" name="Lifeline2" coveredBy="_czXqIf4dEeifDLKIoxuqew _dzVSUP4dEeifDLKIoxuqew _eURcMf4dEeifDLKIoxuqew _ffzbMP4dEeifDLKIoxuqew"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_cNKlwP4dEeifDLKIoxuqew" name="Lifeline3" coveredBy="_dzVSUf4dEeifDLKIoxuqew _eURcMP4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_czXqIP4dEeifDLKIoxuqew" name="1s" covered="_bhUzcP4dEeifDLKIoxuqew" message="_czXqIv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_dzVSUP4dEeifDLKIoxuqew" name="2s" covered="_b8zOgP4dEeifDLKIoxuqew" message="_dzV5YP4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_czXqIf4dEeifDLKIoxuqew" name="1r" covered="_b8zOgP4dEeifDLKIoxuqew" message="_czXqIv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_dzVSUf4dEeifDLKIoxuqew" name="2r" covered="_cNKlwP4dEeifDLKIoxuqew" message="_dzV5YP4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_eURcMP4dEeifDLKIoxuqew" name="3s" covered="_cNKlwP4dEeifDLKIoxuqew" message="_eURcMv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_eURcMf4dEeifDLKIoxuqew" name="3r" covered="_b8zOgP4dEeifDLKIoxuqew" message="_eURcMv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_ffzbMP4dEeifDLKIoxuqew" name="4s" covered="_b8zOgP4dEeifDLKIoxuqew" message="_ffzbMv4dEeifDLKIoxuqew"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_ffzbMf4dEeifDLKIoxuqew" name="4r" covered="_bhUzcP4dEeifDLKIoxuqew" message="_ffzbMv4dEeifDLKIoxuqew"/>
+    <message xmi:type="uml:Message" xmi:id="_czXqIv4dEeifDLKIoxuqew" name="AsyncMessage1" messageSort="asynchCall" receiveEvent="_czXqIf4dEeifDLKIoxuqew" sendEvent="_czXqIP4dEeifDLKIoxuqew"/>
+    <message xmi:type="uml:Message" xmi:id="_dzV5YP4dEeifDLKIoxuqew" name="AsyncMessage2" messageSort="asynchCall" receiveEvent="_dzVSUf4dEeifDLKIoxuqew" sendEvent="_dzVSUP4dEeifDLKIoxuqew"/>
+    <message xmi:type="uml:Message" xmi:id="_eURcMv4dEeifDLKIoxuqew" name="AsyncMessage3" messageSort="asynchCall" receiveEvent="_eURcMf4dEeifDLKIoxuqew" sendEvent="_eURcMP4dEeifDLKIoxuqew"/>
+    <message xmi:type="uml:Message" xmi:id="_ffzbMv4dEeifDLKIoxuqew" name="AsyncMessage4" messageSort="asynchCall" receiveEvent="_ffzbMf4dEeifDLKIoxuqew" sendEvent="_ffzbMP4dEeifDLKIoxuqew"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixtureRule.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/AutoFixtureRule.java
@@ -211,7 +211,8 @@ public class AutoFixtureRule implements TestRule {
 				if (next instanceof NamedElement) {
 					NamedElement element = (NamedElement)next;
 					String elementName = element.getName();
-					if ((name.equals(elementName) || name.equals(getValidJavaIdentifier(elementName)))
+					if ((name.equalsIgnoreCase(elementName)
+							|| name.equalsIgnoreCase(getValidJavaIdentifier(elementName)))
 							&& filter.test(element)) {
 						result = element;
 					}


### PR DESCRIPTION
Fix the nudging of moving sloped messages up by ensuring that
- the moving of the source end computes a nudge from that end, and
- the a nudge computed by the receive end does not override the nudge computed by the source end when moving a message up
