### PR TITLE
Fix #437 Create-message moving tests skip

### DIFF
--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/DefaultLayoutHelperIntegrationUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/DefaultLayoutHelperIntegrationUITest.java
@@ -16,6 +16,8 @@ import static java.util.Collections.singletonList;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.is;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
 import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -42,14 +44,13 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.t
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
-import org.eclipse.papyrus.uml.interaction.model.MExecutionOccurrence;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
 import org.eclipse.uml2.uml.Element;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -66,8 +67,8 @@ import org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters;
 import org.junit.runners.parameterized.TestWithParameters;
 
 /**
- * An integration test for the {@code DefaultLayoutHelper}, that it correctly
- * computes the locations of visuals in the diagram.
+ * An integration test for the {@code DefaultLayoutHelper}, that it correctly computes the locations of
+ * visuals in the diagram.
  */
 @RunWith(PerEditPartTests.class)
 public class DefaultLayoutHelperIntegrationUITest {
@@ -114,15 +115,14 @@ public class DefaultLayoutHelperIntegrationUITest {
 		// Get the notation view
 		Optional<? extends EObject> view = element.getDiagramView();
 		if (!view.isPresent()) {
-			// These aren't supposed to have views
-			if (!(element instanceof MExecutionOccurrence)) {
-				fail("No diagram view");
-			}
-			Assume.assumeFalse("Execution occurrences have no views", true);
+			// MOccurrences (and only MOccurrences) aren't supposed to have views
+			assertThat("Element that is not an MOccurrence has no view", element,
+					instanceOf(MOccurrence.class));
+			return;
 		}
 
 		// Compare the view's extent as GEF knows it
-		String failure = (String) new NotationSwitch() {
+		String failure = (String)new NotationSwitch() {
 			@Override
 			public Object caseShape(Shape shape) {
 				return verify(GEFMatchers.Figures.isBounded(anything(), is(top), anything(), is(height)),
@@ -141,14 +141,14 @@ public class DefaultLayoutHelperIntegrationUITest {
 					return String.format("Different top and bottom: %d ≠ %d", top, bottom);
 				}
 
-				Edge edge = (Edge) anchor.eContainer();
+				Edge edge = (Edge)anchor.eContainer();
 				switch (anchor.eContainmentFeature().getFeatureID()) {
-				case NotationPackage.EDGE__SOURCE_ANCHOR:
-					return verify(GEFMatchers.Figures.runs(isPoint(anything(), is(top)), anything()),
-							getFigure(edge));
-				case NotationPackage.EDGE__TARGET_ANCHOR:
-					return verify(GEFMatchers.Figures.runs(anything(), isPoint(anything(), is(bottom))),
-							getFigure(edge));
+					case NotationPackage.EDGE__SOURCE_ANCHOR:
+						return verify(GEFMatchers.Figures.runs(isPoint(anything(), is(top)), anything()),
+								getFigure(edge));
+					case NotationPackage.EDGE__TARGET_ANCHOR:
+						return verify(GEFMatchers.Figures.runs(anything(), isPoint(anything(), is(bottom))),
+								getFigure(edge));
 				}
 
 				return null;
@@ -195,8 +195,8 @@ public class DefaultLayoutHelperIntegrationUITest {
 	}
 
 	static IFigure getFigure(View view) {
-		EditPart ep = (EditPart) EDITOR.getDiagramEditPart().getViewer().getEditPartRegistry().get(view);
-		return (ep instanceof GraphicalEditPart) ? ((GraphicalEditPart) ep).getFigure() : null;
+		EditPart ep = (EditPart)EDITOR.getDiagramEditPart().getViewer().getEditPartRegistry().get(view);
+		return (ep instanceof GraphicalEditPart) ? ((GraphicalEditPart)ep).getFigure() : null;
 	}
 
 	//
@@ -241,13 +241,13 @@ public class DefaultLayoutHelperIntegrationUITest {
 			TestClass testClass = getTestClass();
 
 			// Don't assert the root interaction object because the diagram has no bounds
-			for (Iterator<EObject> iter = ((EObject) interaction).eAllContents(); iter.hasNext();) {
+			for (Iterator<EObject> iter = ((EObject)interaction).eAllContents(); iter.hasNext();) {
 				@SuppressWarnings("unchecked")
-				MElement<? extends Element> next = (MElement<? extends Element>) iter.next();
+				MElement<? extends Element> next = (MElement<? extends Element>)iter.next();
 				String uriFragment = EcoreUtil.getURI(next.getElement()).fragment();
 
 				Supplier<MElement<?>> translocator = () -> {
-					Element uml = (Element) EDITOR.getModel().eResource().getEObject(uriFragment);
+					Element uml = (Element)EDITOR.getModel().eResource().getEObject(uriFragment);
 					return getInteraction().getElement(uml).get();
 				};
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSnappingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSnappingUITest.java
@@ -14,9 +14,7 @@ package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.
 
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.at;
 import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.isNear;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeThat;
@@ -29,21 +27,17 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightS
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
-import org.eclipse.uml2.uml.ExecutionOccurrenceSpecification;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.Message;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
- * Integration test cases for the execution start/finish replacement behaviour
- * when snapping to message ends.
+ * Integration test cases for the execution start/finish replacement behaviour when snapping to message ends.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
 @ModelResource("one-exec.di")
 @Maximized
 public class ExecutionSnappingUITest extends AbstractGraphicalEditPolicyUITest {
@@ -59,13 +53,17 @@ public class ExecutionSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 	private static final int LL2_BODY_X = 281;
 
 	private static final boolean ABOVE = true;
+
 	private static final boolean BELOW = false;
 
 	private static final int EXEC_START_Y = 165;
+
 	private static final int EXEC_HEIGHT = 82;
+
 	private static final int EXEC_FINISH_Y = EXEC_START_Y + EXEC_HEIGHT;
 
 	private EditPart execEP;
+
 	private ExecutionSpecification exec;
 
 	/**
@@ -92,64 +90,13 @@ public class ExecutionSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat("Execution specification did not snap to message end", execTop, isNear(msgY));
 
 		// The message receive event starts the execution
-		Message message = (Message) messageEP.getAdapter(EObject.class);
+		Message message = (Message)messageEP.getAdapter(EObject.class);
 		assertThat("Execution not started by message end", exec.getStart(), is(message.getReceiveEvent()));
 
 		// The message send and receive both are still semantically before the execution
 		assertThat("Message ends out of order", message.getSendEvent(),
 				editor.semanticallyPrecedes(message.getReceiveEvent()));
 		assertThat("Execution out of order", exec, editor.semanticallyFollows(message.getReceiveEvent()));
-	}
-
-	@Test
-	@Ignore("Exec start should only bind to request receive")
-	public void snapStartToSyncCallSend() {
-		int msgY = EXEC_START_Y - 30;
-		EditPart messageEP = editor.createConnection(SequenceElementTypes.Sync_Message_Edge,
-				at(LL2_BODY_X, msgY), at(LL1_BODY_X, msgY));
-		msgY = getSourceY(messageEP); // Find where it actually ended up
-
-		// The top of the execution snaps to the message end. Offset by one to click on
-		// the execution figure's edge, accounting also for nudging on message creation
-		int execTop = getTop(execEP);
-		editor.moveSelection(at(LL2_BODY_X, execTop + 1), at(LL2_BODY_X, withinMagnet(msgY, BELOW)));
-
-		execTop = getTop(execEP);
-
-		assertThat("Execution specification did not snap to message end", execTop, isNear(msgY));
-
-		// The message receive event *does not* start the execution
-		Message message = (Message) messageEP.getAdapter(EObject.class);
-		assertThat("Execution is started by message send", exec.getStart(), not(message.getSendEvent()));
-		assertThat("Execution start is lost", exec.getStart(),
-				instanceOf(ExecutionOccurrenceSpecification.class));
-	}
-
-	@Test
-	@Ignore("Exec finish should only bind to reply send")
-	public void snapFinishToReplyReceive() {
-		int msgY = EXEC_FINISH_Y + 20;
-		EditPart messageEP = editor.createConnection(SequenceElementTypes.Reply_Message_Edge,
-				at(LL1_BODY_X, msgY), at(LL2_BODY_X, msgY));
-
-		// Find where things actually ended up
-		msgY = getTargetY(messageEP);
-		int execBottom = getBottom(execEP);
-
-		// The bottom of the execution snaps to the message end. Offset by one to click
-		// on the execution figure's edge
-		editor.moveSelection(at(LL2_BODY_X, execBottom - 1), at(LL2_BODY_X, withinMagnet(msgY, ABOVE)));
-
-		execBottom = getBottom(execEP);
-
-		assertThat("Execution specification did not snap to message end", execBottom, isNear(msgY));
-
-		// The message receive event *does not* finish the execution
-		Message message = (Message) messageEP.getAdapter(EObject.class);
-		assertThat("Execution is finished by message receive", exec.getFinish(),
-				not(message.getReceiveEvent()));
-		assertThat("Execution finish is lost", exec.getFinish(),
-				instanceOf(ExecutionOccurrenceSpecification.class));
 	}
 
 	@Test
@@ -171,7 +118,7 @@ public class ExecutionSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat("Execution specification did not snap to message end", execBottom, isNear(msgY));
 
 		// The message receive event starts the execution
-		Message message = (Message) messageEP.getAdapter(EObject.class);
+		Message message = (Message)messageEP.getAdapter(EObject.class);
 		assertThat("Execution not finished by message end", exec.getFinish(), is(message.getSendEvent()));
 
 		// The message send and receive both are still semantically after the execution

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageSnappingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageSnappingUITest.java
@@ -43,6 +43,9 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixtur
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.papyrus.uml.interaction.tests.runners.Delegate;
+import org.eclipse.papyrus.uml.interaction.tests.runners.FilterWith;
+import org.eclipse.papyrus.uml.interaction.tests.runners.Filtered;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.Message;
 import org.hamcrest.CoreMatchers;
@@ -50,20 +53,24 @@ import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
+import org.junit.runner.manipulation.Filter;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy}
- * class's message re-connection behaviour.
+ * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy} class's message re-connection
+ * behaviour.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
+@SuppressWarnings("hiding")
 @ModelResource("two-lifelines.di")
 @Maximized
-@RunWith(Parameterized.class)
+@RunWith(Filtered.class)
+@Delegate(Parameterized.class)
+@FilterWith(MessageSnappingUITest.Applicable.class)
 public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 
 	@ClassRule
@@ -77,24 +84,30 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 	private static final int LL2_BODY_X = 281;
 
 	private static final boolean EXEC_START = true;
+
 	private static final int EXEC_START_Y = 145;
 
 	private static final boolean EXEC_FINISH = false;
+
 	private static final int EXEC_HEIGHT = 60;
+
 	private static final int EXEC_WIDTH = 10;
 
 	private final boolean snapping;
+
 	private final EditorFixture.Modifiers modifiers;
+
 	private final Function<Matcher<?>, Matcher<?>> modifiersMatcherFunction;
+
 	private EditPart execEP;
+
 	private ExecutionSpecification exec;
 
 	/**
 	 * Initializes me.
 	 *
 	 * @param withSnap
-	 *            whether to allow snapping ({@code true}) or suppress it
-	 *            ({@code false})
+	 *            whether to allow snapping ({@code true}) or suppress it ({@code false})
 	 * @param snapString
 	 *            a string representation of {@code withSnap}
 	 */
@@ -127,16 +140,14 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 			assertThat(messageEP, withModifiers(runs(LL1_BODY_X, execTop, left(LL2_BODY_X), execTop, 1)));
 
 			// The message receive event starts the execution
-			Message message = (Message) messageEP.getAdapter(EObject.class);
+			Message message = (Message)messageEP.getAdapter(EObject.class);
 			assertThat(exec.getStart(), withModifiers(is(message.getReceiveEvent())));
 
 			// The message send and receive both are semantically before the execution
 			assertThat("Message ends out of order", message.getSendEvent(),
 					editor.semanticallyPrecedes(message.getReceiveEvent()));
-			assertThat("Execution out of order", exec,
-					editor.semanticallyFollows(message.getReceiveEvent()));
-			assertThat("Execution finish out of order", exec,
-					editor.semanticallyPrecedes(exec.getFinish()));
+			assertThat("Execution out of order", exec, editor.semanticallyFollows(message.getReceiveEvent()));
+			assertThat("Execution finish out of order", exec, editor.semanticallyPrecedes(exec.getFinish()));
 		});
 	}
 
@@ -151,7 +162,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat(messageEP, withModifiers(runs(LL1_BODY_X, 120, left(LL2_BODY_X), execTop, 1)));
 
 		// The message receive event starts the execution
-		Message message = (Message) messageEP.getAdapter(EObject.class);
+		Message message = (Message)messageEP.getAdapter(EObject.class);
 		assertThat(exec.getStart(), withModifiers(is(message.getReceiveEvent())));
 	}
 
@@ -167,7 +178,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat(messageEP, withModifiers(runs(left(LL2_BODY_X), execBottom, LL1_BODY_X, execBottom, 1)));
 
 		// The message send event finishes the execution
-		Message message = (Message) messageEP.getAdapter(EObject.class);
+		Message message = (Message)messageEP.getAdapter(EObject.class);
 		assertThat(exec.getFinish(), withModifiers(is(message.getSendEvent())));
 	}
 
@@ -181,8 +192,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 		editor.with(modifiers,
 				() -> editor.moveSelection(midMessage, at(midMessage.x(), withinMagnet(EXEC_START))));
 		Point newMessageMidpoint = getMessageGrabPoint(messageEP);
-		assumeThat("Message not moved", newMessageMidpoint,
-				not(isPoint(midMessage.x(), midMessage.y(), 5)));
+		assumeThat("Message not moved", newMessageMidpoint, not(isPoint(midMessage.x(), midMessage.y(), 5)));
 
 		int execTop = getTop(execEP);
 		assertThat(messageEP, withModifiers(runs(LL1_BODY_X, execTop, left(LL2_BODY_X), execTop, 1)));
@@ -202,8 +212,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 	}
 
 	/**
-	 * Verify that magnets are updated when the size of an execution occurrence
-	 * changes.
+	 * Verify that magnets are updated when the size of an execution occurrence changes.
 	 */
 	@Test
 	public void magnetUpdatesOnSize() {
@@ -227,8 +236,7 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 	}
 
 	/**
-	 * Verify that magnets are updated when the location of an execution occurrence
-	 * changes.
+	 * Verify that magnets are updated when the location of an execution occurrence changes.
 	 */
 	@Test
 	public void magnetUpdatesOnLocation() {
@@ -239,8 +247,8 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 		// have a policy for moving it (only for resize) so be direct about it instead
 		// of automating the selection tool
 		EditPart execEP = getLastCreatedEditPart();
-		Node execView = (Node) execEP.getModel();
-		Location location = (Location) execView.getLayoutConstraint();
+		Node execView = (Node)execEP.getModel();
+		Location location = (Location)execView.getLayoutConstraint();
 		SetBoundsCommand command = new SetBoundsCommand(editor.getDiagramEditPart().getEditingDomain(),
 				"Move execution down", new EObjectAdapter(execView),
 				at(location.getX(), location.getY() + 100));
@@ -264,8 +272,8 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 	@Parameters(name = "{1}")
 	public static Iterable<Object[]> parameters() {
 		return Arrays.asList(new Object[][] { //
-				{ true, "snap to magnet" }, //
-				{ false, "suppress snapping" }, //
+				{true, "snap to magnet" }, //
+				{false, "suppress snapping" }, //
 		});
 	}
 
@@ -275,12 +283,12 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 				at(LL2_BODY_X, EXEC_START_Y), sized(0, EXEC_HEIGHT));
 		assumeThat("Execution specification not created", execEP, notNullValue());
 
-		exec = (ExecutionSpecification) execEP.getAdapter(EObject.class);
+		exec = (ExecutionSpecification)execEP.getAdapter(EObject.class);
 	}
 
 	@SuppressWarnings("unchecked")
 	<T> Matcher<T> withModifiers(Matcher<T> matcher) {
-		return (Matcher<T>) modifiersMatcherFunction.apply(matcher);
+		return (Matcher<T>)modifiersMatcherFunction.apply(matcher);
 	}
 
 	int withinMagnet(boolean execStart) {
@@ -299,7 +307,38 @@ public class MessageSnappingUITest extends AbstractGraphicalEditPolicyUITest {
 	}
 
 	static Point getMessageGrabPoint(EditPart editPart) {
-		Connection connection = (Connection) ((ConnectionEditPart) editPart).getFigure();
+		Connection connection = (Connection)((ConnectionEditPart)editPart).getFigure();
 		return connection.getPoints().getMidpoint();
+	}
+
+	//
+	// Nested types
+	//
+
+	/**
+	 * Filter selecting the valid combinations of parameters for the suite.
+	 */
+	public static final class Applicable extends Filter {
+
+		/**
+		 * Initializes me.
+		 */
+		public Applicable() {
+			super();
+		}
+
+		@Override
+		public boolean shouldRun(Description description) {
+			String name = description.getDisplayName();
+
+			// It doesn't make sense to test magnet updates when we aren't snapping to magnets
+			return !name.startsWith("magnetUpdates") || !name.contains("[suppress snapping]");
+		}
+
+		@Override
+		public String describe() {
+			return "applicable parameters";
+		}
+
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.interaction.graph.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.papyrus.uml.interaction.graph.tests/META-INF/MANIFEST.MF
@@ -16,5 +16,6 @@ Bundle-Description: Tests of the core run-time APIs of the sequence diagram.
 Export-Package: org.eclipse.papyrus.uml.interaction.graph.tests,
  org.eclipse.papyrus.uml.interaction.tests.matchers;version="1.0.0",
  org.eclipse.papyrus.uml.interaction.tests.rules;version="1.0.0",
+ org.eclipse.papyrus.uml.interaction.tests.runners;version="1.0.0",
  org.eclipse.papyrus.uml.interaction.tests.util;version="1.0.0"
 Automatic-Module-Name: org.eclipse.papyrus.uml.interaction.graph.tests

--- a/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/runners/Delegate.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/runners/Delegate.java
@@ -1,0 +1,38 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.tests.runners;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.runner.Runner;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+/**
+ * Optionally annotates a {@link Filtered} test class with the delegate runner to instantiate and
+ * {@linkplain FilterWith filter}.
+ * 
+ * @see FilterWith
+ * @see Filtered
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Delegate {
+	/** The delegate runner class to instantiate and filter. */
+	Class<? extends Runner> value() default BlockJUnit4ClassRunner.class;
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/runners/FilterWith.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/runners/FilterWith.java
@@ -1,0 +1,36 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.tests.runners;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.runner.manipulation.Filter;
+
+/**
+ * Annotates a {@link Filtered} test class with the filter to apply to its {@linkplain Delegate delegate}.
+ * 
+ * @see Delegate
+ * @see Filtered
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface FilterWith {
+	/** The runner filter class to instantiate and apply. */
+	Class<? extends Filter> value();
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/runners/Filtered.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.graph.tests/src/org/eclipse/papyrus/uml/interaction/tests/runners/Filtered.java
@@ -1,0 +1,101 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.interaction.tests.runners;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * A self-filtering test suite. May have a {@link Delegate} runner annotation and must have a
+ * {@link FilterWith} filter annotation applied to the class.
+ */
+public class Filtered extends Runner {
+
+	private final ParentRunner<Runner> delegate;
+
+	private final Filter filter;
+
+	/**
+	 * Initializes me.
+	 *
+	 * @param testClass
+	 * @throws InitializationError
+	 */
+	public Filtered(Class<?> testClass) throws InitializationError {
+		super();
+
+		try {
+			delegate = instantiate(testClass, Delegate.class);
+			filter = instantiate(testClass, FilterWith.class);
+			delegate.filter(filter);
+		} catch (Exception e) {
+			throw new InitializationError(e);
+		}
+	}
+
+	@Override
+	public Description getDescription() {
+		return delegate.getDescription();
+	}
+
+	@Override
+	public void run(RunNotifier notifier) {
+		delegate.run(notifier);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T, A extends Annotation> T instantiate(Class<?> suiteClass, Class<A> annotationType)
+			throws InitializationError {
+
+		Class<? extends T> target;
+		A annotation = suiteClass.getAnnotation(annotationType);
+
+		if (annotation == null) {
+			if (annotationType == Delegate.class) {
+				// It has a default value
+				target = (Class<? extends T>)BlockJUnit4ClassRunner.class;
+
+			} else {
+				throw new InitializationError("Missing annotation " + annotationType.getSimpleName());
+			}
+		} else {
+			target = (Class<? extends T>)getValue(annotation);
+		}
+
+		try {
+			return Runner.class.isAssignableFrom(target)
+					? target.getConstructor(Class.class).newInstance(suiteClass)
+					: target.newInstance();
+		} catch (Exception e) {
+			throw new InitializationError(e);
+		}
+	}
+
+	static Object getValue(Annotation annotation) throws InitializationError {
+		try {
+			Method value = annotation.annotationType().getDeclaredMethod("value");
+			return value.invoke(annotation);
+		} catch (Exception e) {
+			throw new InitializationError(e);
+		}
+	}
+
+}


### PR DESCRIPTION
Fix the skipping of the create-message moving tests added in an earlier pull request (at least, on Mac).

Also clean up the other six tests that have historically been skipping by just
- deleting tests that are no longer relevant (anti-requirements that were `@Ignore`d)
- filtering out tests in parameterized suites for combinations of parameters that don't make sense

The latter uses a new `Filtered` test runner implementation for self-filtering suites.

With these changes, we should now have **zero** skipped tests (and zero failures, of course) so that it will be easy to spot new assumption violations in the future.