### PR TITLE
Issue #389: Update self message router and feeback

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/MessageFigure.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/MessageFigure.java
@@ -48,15 +48,18 @@ public class MessageFigure extends PolylineConnectionEx {
 
 	@Override
 	public void validate() {
-		super.validate();
-
+		if (isValid()) {
+			return;
+		}
 		MessageDirection direction = computeDirection();
 		if (getSourceAnchor() instanceof ISideAnchor) {
-			((ISideAnchor)getSourceAnchor()).setConnectionSide(direction.getExecutionSide(true));
+			int side = direction.getExecutionSide(true);
+			((ISideAnchor)getSourceAnchor()).setConnectionSide(side);
 		}
 		if (getTargetAnchor() instanceof ISideAnchor) {
 			((ISideAnchor)getTargetAnchor()).setConnectionSide(direction.getExecutionSide(false));
 		}
+		super.validate();
 	}
 
 	MessageDirection computeDirection() {

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationEndAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationEndAnchor.java
@@ -40,7 +40,7 @@ public class ExecutionSpecificationEndAnchor extends AbstractConnectionAnchor im
 	public Point getReferencePoint() {
 		Rectangle body = getOwner().getBounds().getCopy();
 		getOwner().translateToAbsolute(body);
-		return body.getBottomLeft();
+		return body.getBottom();
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationEndAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationEndAnchor.java
@@ -37,6 +37,13 @@ public class ExecutionSpecificationEndAnchor extends AbstractConnectionAnchor im
 	}
 
 	@Override
+	public Point getReferencePoint() {
+		Rectangle body = getOwner().getBounds().getCopy();
+		getOwner().translateToAbsolute(body);
+		return body.getBottomLeft();
+	}
+
+	@Override
 	public Point getLocation(Point reference) {
 		Rectangle body = getOwner().getBounds().getCopy();
 		getOwner().translateToAbsolute(body);

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationSideAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationSideAnchor.java
@@ -12,6 +12,7 @@
 package org.eclipse.papyrus.uml.diagram.sequence.figure.anchors;
 
 import static org.eclipse.draw2d.PositionConstants.LEFT;
+import static org.eclipse.draw2d.PositionConstants.RIGHT;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.draw2d.AbstractConnectionAnchor;
@@ -29,7 +30,7 @@ public class ExecutionSpecificationSideAnchor extends AbstractConnectionAnchor i
 
 	public ExecutionSpecificationSideAnchor(IFigure figure, int height) {
 		super(figure);
-		this.side = LEFT;
+		this.side = RIGHT;
 		this.height = height;
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationSideAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationSideAnchor.java
@@ -30,7 +30,7 @@ public class ExecutionSpecificationSideAnchor extends AbstractConnectionAnchor i
 
 	public ExecutionSpecificationSideAnchor(IFigure figure, int height) {
 		super(figure);
-		this.side = RIGHT;
+		this.side = RIGHT; // by default, anchors are located on the right.
 		this.height = height;
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationStartAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/ExecutionSpecificationStartAnchor.java
@@ -37,6 +37,13 @@ public class ExecutionSpecificationStartAnchor extends AbstractConnectionAnchor 
 	}
 
 	@Override
+	public Point getReferencePoint() {
+		Rectangle body = getOwner().getBounds().getCopy();
+		getOwner().translateToAbsolute(body);
+		return body.getTop();
+	}
+
+	@Override
 	public Point getLocation(Point reference) {
 		Rectangle body = getOwner().getBounds().getCopy();
 		getOwner().translateToAbsolute(body);

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/LifelineBodyAnchor.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.figure/src/org/eclipse/papyrus/uml/diagram/sequence/figure/anchors/LifelineBodyAnchor.java
@@ -25,9 +25,7 @@ import org.eclipse.papyrus.uml.diagram.sequence.figure.anchors.AnchorParser.Anch
  */
 public class LifelineBodyAnchor extends AbstractConnectionAnchor implements ISequenceAnchor {
 
-	private final LifelineBodyFigure lifelinebodyFigure;
 	private int distance;
-
 
 	public LifelineBodyAnchor(LifelineBodyFigure lifelinebodyFigure, int distance) {
 		super(lifelinebodyFigure);
@@ -35,7 +33,6 @@ public class LifelineBodyAnchor extends AbstractConnectionAnchor implements ISeq
 		// Note: this causes issues for policies/interaction, because the body is far away
 		// from the Lifeline's Bounds. However, we're only interested in rendering here, and this works fine
 		this.distance = distance;
-		this.lifelinebodyFigure = lifelinebodyFigure;
 	}
 
 	@Override
@@ -45,13 +42,24 @@ public class LifelineBodyAnchor extends AbstractConnectionAnchor implements ISeq
 
 	@Override
 	public Point getLocation(Point reference) {
-		Rectangle body = lifelinebodyFigure.getBounds().getCopy();
-		lifelinebodyFigure.translateToAbsolute(body);
-		int boundedHeight = Math.min(distance, body.height);
-		int realHeight = (int)Math.round(boundedHeight * getScale(lifelinebodyFigure));
-		Point location = new Point(0, realHeight);
-		location.translate(body.getTopLeft());
-		return location;
+		return getReferencePoint();
+	}
+
+	@Override
+	public Point getReferencePoint() {
+		if (getOwner() == null) {
+			return null;
+		} else {
+			// reference point is the top of the lifeline
+			// useful for the router
+			Rectangle body = getOwner().getBounds().getCopy();
+			getOwner().translateToAbsolute(body);
+			int boundedHeight = Math.min(distance, body.height);
+			int realHeight = (int)Math.round(boundedHeight * getScale(getOwner()));
+			Point location = new Point(1, realHeight);
+			location.translate(body.getTopLeft());
+			return location;
+		}
 	}
 
 	/**

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/ExecutionSpecificationEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/ExecutionSpecificationEditPart.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
+import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.EditPolicy;
 import org.eclipse.gef.Request;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.BorderedBorderItemEditPart;
@@ -136,7 +137,11 @@ public class ExecutionSpecificationEditPart extends BorderedBorderItemEditPart i
 	}
 
 	private void refreshEditPartOfShape(Shape shape) {
-		Object lifelineEditPart = getViewer().getEditPartRegistry().get(shape);
+		EditPartViewer viewer = getViewer();
+		if (viewer == null) {
+			return;
+		}
+		Object lifelineEditPart = viewer.getEditPartRegistry().get(shape);
 		if (lifelineEditPart instanceof EditPart) {
 			EditPart editPart = (EditPart)lifelineEditPart;
 			List<?> lifelineEditpartChildren = editPart.getChildren();

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/MessageEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/MessageEditPart.java
@@ -16,11 +16,14 @@ import static org.eclipse.papyrus.uml.interaction.model.spi.LayoutConstraints.Mo
 
 import com.google.common.eventbus.EventBus;
 
+import java.beans.PropertyChangeEvent;
 import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.draw2d.Connection;
 import org.eclipse.draw2d.ConnectionAnchor;
+import org.eclipse.draw2d.ConnectionLayer;
+import org.eclipse.draw2d.ConnectionRouter;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.PolygonDecoration;
 import org.eclipse.draw2d.PolylineDecoration;
@@ -31,31 +34,42 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.gef.DragTracker;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPolicy;
+import org.eclipse.gef.LayerConstants;
 import org.eclipse.gef.Request;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.ConnectionNodeEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editpolicies.EditPolicyRoles;
+import org.eclipse.gmf.runtime.draw2d.ui.internal.figures.ConnectionLayerEx;
 import org.eclipse.gmf.runtime.draw2d.ui.mapmode.IMapMode;
 import org.eclipse.gmf.runtime.notation.ArrowType;
 import org.eclipse.gmf.runtime.notation.IdentityAnchor;
+import org.eclipse.gmf.runtime.notation.NotationPackage;
+import org.eclipse.gmf.runtime.notation.Routing;
+import org.eclipse.gmf.runtime.notation.RoutingStyle;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.MessageFigure;
 import org.eclipse.papyrus.uml.diagram.sequence.figure.magnets.ConnectionFigureMagnetHelper;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.Activator;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LogicalModelElementSemanticEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.MessageBendpointsEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.MessageEndpointEditPolicy;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.locators.SelfMessageRouter;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.MessageMoveTracker;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.tools.SequenceConnectionSelectionTracker;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.UMLPackage;
 
+@SuppressWarnings("restriction")
 public class MessageEditPart extends ConnectionNodeEditPart implements ISequenceEditPart {
 
 	private final EventBus bus = new EventBus();
 
 	private ConnectionFigureMagnetHelper magnetHelper;
+
+	private SelfMessageRouter selfMessageRouter;
 
 	public MessageEditPart(View view) {
 		super(view);
@@ -91,6 +105,11 @@ public class MessageEditPart extends ConnectionNodeEditPart implements ISequence
 			refreshLineType();
 		}
 		refreshLifelineIfHeightOrPositionHasChanged(notification);
+	}
+
+	@Override
+	protected void refreshBendpoints() {
+		// nothing to refresh, as bendpoints are not used
 	}
 
 	protected void updateArrowDecoration() {
@@ -222,6 +241,43 @@ public class MessageEditPart extends ConnectionNodeEditPart implements ISequence
 	@Override
 	protected void refreshRouterChange() {
 		// No bendpoints in messages to refresh
+	}
+
+	@Override
+	protected void handlePropertyChangeEvent(PropertyChangeEvent event) {
+
+	}
+
+	@Override
+	protected void installRouter() {
+		ConnectionLayer cLayer = (ConnectionLayer)getLayer(LayerConstants.CONNECTION_LAYER);
+		RoutingStyle style = (RoutingStyle)((View)getModel())
+				.getStyle(NotationPackage.Literals.ROUTING_STYLE);
+
+		if (style != null && cLayer instanceof ConnectionLayerEx) {
+
+			ConnectionLayerEx cLayerEx = (ConnectionLayerEx)cLayer;
+			Routing routing = style.getRouting();
+			if (Routing.MANUAL_LITERAL == routing) {
+				getConnectionFigure().setConnectionRouter(cLayerEx.getObliqueRouter());
+			} else if (Routing.RECTILINEAR_LITERAL == routing) {
+				getConnectionFigure().setConnectionRouter(getSelfMessageRouter());
+			} else if (Routing.TREE_LITERAL == routing) {
+				getConnectionFigure().setConnectionRouter(cLayerEx.getTreeRouter());
+			}
+
+		}
+
+		refreshRouterChange();
+	}
+
+	private ConnectionRouter getSelfMessageRouter() {
+		if (selfMessageRouter == null) {
+			int minimumWidth = Activator.getDefault().getLayoutConstraints(getEditingDomain())
+					.getMinimumWidth(ViewTypes.MESSAGE);
+			selfMessageRouter = new SelfMessageRouter(minimumWidth);
+		}
+		return selfMessageRouter;
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/MessageEditPart.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/parts/MessageEditPart.java
@@ -151,6 +151,9 @@ public class MessageEditPart extends ConnectionNodeEditPart implements ISequence
 	}
 
 	private void refreshEditPartOfShape(Shape shape) {
+		if(getViewer() == null) {
+			return;
+		}
 		Object lifelineEditPart = getViewer().getEditPartRegistry().get(shape);
 		if (lifelineEditPart instanceof EditPart) {
 			EditPart editPart = (EditPart)lifelineEditPart;
@@ -245,7 +248,11 @@ public class MessageEditPart extends ConnectionNodeEditPart implements ISequence
 
 	@Override
 	protected void handlePropertyChangeEvent(PropertyChangeEvent event) {
-
+		// Avoid calling super, as it only handles the refresh of the routing property. The super method
+		// refreshes the router based on the routing style of the notation model. In the case of feedback, the
+		// router may be different (getting from a self message to a normal message for example). So refresh
+		// should be avoided in this case, and connection router shall be updated on notation model change
+		// only. The feedback router is handled in the feedback related methods.
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/AbstractSequenceGraphicalNodeEditPolicy.java
@@ -14,7 +14,6 @@ package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies;
 
 import static java.lang.Math.abs;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.getUpdatedSourceLocation;
-import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.getUpdatedTargetLocation;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.isAllowSemanticReordering;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.PrivateRequestUtils.isForce;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.util.CommandUtil.injectViewInto;
@@ -479,15 +478,12 @@ public abstract class AbstractSequenceGraphicalNodeEditPolicy extends GraphicalN
 		OptionalInt yPosition = OptionalInt.of(y);
 
 		org.eclipse.emf.common.command.Command result = null;
+
 		// Check for semantic re-ordering if we're not connecting to an execution
-		if (!getExecutionFinish(lifeline.get(), request.getLocation()).isPresent()
-				// Or if we're moving both ends and the other is not connecting to an execution
-				&& !(isForce(request) && message.getReceiver()
-						.flatMap(rcvr -> getExecutionStart(rcvr, getUpdatedTargetLocation(request)))
-						.isPresent())) {
+		if (!getExecutionFinish(lifeline.get(), request.getLocation()).isPresent()) {
+			// should ensure the execution start is nudged
 			result = getNudgeObstacleCommand(request, message.getSend().get(), y);
 		}
-
 		// If the message didn't have a send end, we wouldn't be reconnecting it
 		MMessageEnd sourceEnd = message.getSend().get();
 		org.eclipse.emf.common.command.Command createFinish = null;

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineBodyDropEditPolicy.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/LifelineBodyDropEditPolicy.java
@@ -30,7 +30,9 @@ import org.eclipse.gmf.runtime.diagram.ui.editpolicies.DragDropEditPolicy;
 import org.eclipse.gmf.runtime.diagram.ui.requests.DropObjectsRequest;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
 import org.eclipse.papyrus.uml.interaction.model.util.Optionals;
+import org.eclipse.uml2.uml.Element;
 import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.Lifeline;
 
@@ -83,6 +85,16 @@ public class LifelineBodyDropEditPolicy extends DragDropEditPolicy implements IS
 		OptionalInt top = flatMap(execution.getTop(), t -> map(deltaY, y -> t + y));
 		OptionalInt bottom = flatMap(execution.getBottom(), b -> map(deltaY, y -> b + y));
 
+		// check if there is a change of lifeline, in this case, opt for the start event cover change
+		// this allows for nice handling of self messages.
+		if (lifeline.isPresent() && !lifeline.get().equals(execution.getOwner())) {
+
+			Optional<MOccurrence<? extends Element>> start = execution.getStart();
+			if (start.isPresent()) {
+				return lifeline.map(ll -> wrap(start.get().setCovered(ll, top))).orElse(null);
+			}
+		}
+		// default behavior, use the set owner API.
 		return lifeline.map(ll -> wrap(execution.setOwner(ll, top, bottom))).orElse(null);
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/locators/SelfMessageRouter.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/locators/SelfMessageRouter.java
@@ -1,0 +1,66 @@
+/*****************************************************************************
+ * Copyright (c) 2018 EclipseSource and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   EclipseSource - Initial API and implementation
+ *   
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.locators;
+
+import org.eclipse.draw2d.Connection;
+import org.eclipse.draw2d.ConnectionAnchor;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.gmf.runtime.draw2d.ui.internal.routers.ObliqueRouter;
+import org.eclipse.gmf.runtime.draw2d.ui.internal.routers.OrthogonalRouter;
+
+/**
+ * Specific router used for
+ */
+@SuppressWarnings("restriction")
+public class SelfMessageRouter extends ObliqueRouter implements OrthogonalRouter {
+
+	private int space;
+
+	public SelfMessageRouter(int space) {
+		this.space = space;
+	}
+
+	@Override
+	protected PointList calculateBendPoints(Connection conn) {
+		ConnectionAnchor source = conn.getSourceAnchor();
+		ConnectionAnchor target = conn.getTargetAnchor();
+
+		PointList points = new PointList(4);
+
+		if (source == null || target == null) {
+			return points;
+		}
+
+		Point sourceLoc = source.getLocation(source.getReferencePoint());
+		Point targetLoc = target.getLocation(target.getReferencePoint());
+
+		// ensure the segment stays vertical and not oblique.
+		int sourceX = sourceLoc.x();
+		int targetX = targetLoc.x();
+		int vSegmentX = Math.min(sourceX + space(), targetX + space());
+
+		points.addPoint(sourceLoc);
+		points.addPoint(new Point(vSegmentX, sourceLoc.y()));
+		points.addPoint(new Point(vSegmentX, targetLoc.y()));
+		points.addPoint(targetLoc);
+
+		return points;
+	}
+
+	private int space() {
+		return space;
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/util/MessageUtil.java
+++ b/plugins/org.eclipse.papyrus.uml.diagram.sequence.runtime/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/util/MessageUtil.java
@@ -22,12 +22,15 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.requests.CreateConnectionRequest;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateConnectionViewRequest;
 import org.eclipse.gmf.runtime.diagram.ui.requests.CreateUnspecifiedTypeConnectionRequest;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
 import org.eclipse.gmf.runtime.emf.type.core.IHintedType;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.MessageEditPart;
 import org.eclipse.papyrus.uml.interaction.graph.util.CrossReferenceUtil;
+import org.eclipse.papyrus.uml.interaction.model.util.Optionals;
 import org.eclipse.papyrus.uml.service.types.element.UMLElementTypes;
 import org.eclipse.papyrus.uml.service.types.utils.ElementUtil;
 import org.eclipse.uml2.uml.ExecutionSpecification;
@@ -122,6 +125,19 @@ public class MessageUtil {
 
 	public static boolean isSynchronousMessage(IElementType messageType) {
 		return isSynchronous(getSort(messageType));
+	}
+
+	@SuppressWarnings("boxing")
+	public static boolean isSynchronousMessage(ConnectionEditPart editPart) {
+		Optional<MessageEditPart> connection = Optionals.as(Optional.ofNullable(editPart),
+				MessageEditPart.class);
+
+		return connection.map(MessageEditPart::resolveSemanticElement)//
+				.filter(Message.class::isInstance)//
+				.map(Message.class::cast) //
+				.map(Message::getMessageSort) //
+				.map(MessageUtil::isSynchronous) //
+				.orElse(false);
 	}
 
 	public static boolean isSynchronous(MessageSort messageSort) {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertMessageCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertMessageCommand.java
@@ -599,8 +599,7 @@ public class InsertMessageCommand extends ModelCommandWithDependencies.Creation<
 		if (isSelfMessage()) {
 			actualReceiverY = () -> senderY.getAsInt()
 					+ layoutConstraints().getMinimumHeight(ViewTypes.MESSAGE);
-			actualSenderY = () -> senderY.getAsInt()
-					+ layoutConstraints().getMinimumHeight(ViewTypes.MESSAGE);
+			actualSenderY = () -> senderY.getAsInt();
 		} else {
 			actualReceiverY = receiverY;
 			actualSenderY = senderY;
@@ -629,7 +628,11 @@ public class InsertMessageCommand extends ModelCommandWithDependencies.Creation<
 
 		if (executionCreationParameter.isCreateReply()) {
 			additionalCommands.addAll(createAutomaticReplyMessageCommands(sendEvent, execution,
-					executionShape, actualSenderY, actualReceiverY));
+					executionShape, () -> actualReceiverY.getAsInt() + execMinHeight,
+					isSelfMessage()
+							? () -> actualReceiverY.getAsInt() + execMinHeight
+									+ layoutConstraints().getMinimumHeight(ViewTypes.MESSAGE)
+							: () -> actualReceiverY.getAsInt() + execMinHeight));
 		} else {
 			CreationCommand<OccurrenceSpecification> finish = semanticHelper().createFinish(execution,
 					CreationParameters.after(execution));
@@ -676,8 +679,7 @@ public class InsertMessageCommand extends ModelCommandWithDependencies.Creation<
 		int execMinHeight = layoutConstraints().getMinimumHeight(ViewTypes.EXECUTION_SPECIFICATION);
 
 		Command replyMessageView = diagramHelper().createMessageConnector(replyMessage, executionShape,
-				() -> senderY.getAsInt() + execMinHeight, () -> receiverShape,
-				() -> receiverY.getAsInt() + execMinHeight, null);
+				() -> senderY.getAsInt(), () -> receiverShape, () -> receiverY.getAsInt(), null);
 		commands.add(replyMessageView);
 
 		return commands;

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/PendingChildData.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/PendingChildData.java
@@ -12,11 +12,15 @@
 
 package org.eclipse.papyrus.uml.interaction.internal.model.commands;
 
+import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates.equalTo;
+
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.uml2.uml.Element;
 
 /**
@@ -82,6 +86,13 @@ public final class PendingChildData extends PendingContainmentChangeData<MElemen
 						.forEach(nested -> setPendingChild(owner, nested));
 			}
 		}
+	}
+
+	public static <T extends MElement<? extends Element>> Predicate<T> changesContainer(MLifeline owner) {
+		return self -> {
+			Optional<MElement<? extends Element>> pendingParent = getPendingOwner(self);
+			return pendingParent.filter(equalTo(owner)).isPresent();
+		};
 	}
 
 }

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetCoveredCommand.java
@@ -48,6 +48,7 @@ import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
 import org.eclipse.papyrus.uml.interaction.model.util.Lifelines;
 import org.eclipse.papyrus.uml.interaction.model.util.Optionals;
 import org.eclipse.uml2.uml.Classifier;
@@ -136,6 +137,25 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 
 		int newYPosition = yPosition.orElseGet(() -> getTarget().getTop().getAsInt());
 
+		// enhance new position in case of message being transformed into a self message or back to a non self
+		// message
+		if (isTargetEnd()) {
+			if (isBecomingSelfMessage()) {
+				newYPosition += layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE);
+			} else if (isBecomingNonSelfMessage()) {
+				// retrieve source end position
+				Optional<MMessageEnd> sourceEnd = Optionals.as(Optional.of(getTarget()), MMessageEnd.class)
+						.flatMap(MMessageEnd::getOtherEnd);
+				Optional<MMessage> message = Optionals.as(Optional.of(getTarget()), MMessageEnd.class)
+						.map(MMessageEnd::getOwner);
+				if (message.isPresent() && message.get().isSynchronous()) {
+					newYPosition = sourceEnd.map(MMessageEnd::getTop).orElse(yPosition).getAsInt();
+				} else {
+					newYPosition = yPosition.getAsInt();
+				}
+			}
+		}
+
 		// Can't put an interaction fragment on a lifeline that is already destroyed
 		if (!existsAt(lifeline, newYPosition)) {
 			return bomb();
@@ -184,7 +204,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 			result = bomb();
 		} else {
 			// Handle a dependent execution
-			result = dependencies(getTarget()).map(chaining(result)).orElse(result);
+			result = dependencies(getTarget(), newYPosition).map(chaining(result)).orElse(result);
 
 			// Handle message details
 			if (getTarget() instanceof MMessageEnd) {
@@ -197,7 +217,36 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 		return result;
 	}
 
-	protected Optional<Command> dependencies(MOccurrence<? extends Element> occurrence) {
+	private boolean isTargetEnd() {
+		Optional<MMessageEnd> end = Optionals.as(Optional.of(getTarget()), MMessageEnd.class);
+		Optional<MMessageEnd> receive = end.map(MMessageEnd::getOwner).flatMap(MMessage::getReceive);
+		return end.isPresent() && end.equals(receive);
+	}
+
+	protected boolean isBecomingSelfMessage() {
+		return isChangingLifeline() && willBeSelfMessage() && !wasSelfMessage();
+	}
+
+	protected boolean isBecomingNonSelfMessage() {
+		return isChangingPosition() && wasSelfMessage() && !willBeSelfMessage();
+	}
+
+	protected boolean wasSelfMessage() {
+		Optional<MLifeline> otherLifeline = Optionals.as(Optional.of(getTarget()), MMessageEnd.class)
+				.flatMap(MMessageEnd::getOtherEnd).flatMap(MMessageEnd::getCovered);
+		Optional<MLifeline> endlifeline = Optionals.as(Optional.of(getTarget()), MMessageEnd.class)
+				.flatMap(MMessageEnd::getCovered);
+		return endlifeline.isPresent() && endlifeline.equals(otherLifeline);
+	}
+
+	protected boolean willBeSelfMessage() {
+		Optional<MMessageEnd> otherEnd = Optionals.as(Optional.of(getTarget()), MMessageEnd.class)
+				.flatMap(MMessageEnd::getOtherEnd);
+		return (otherEnd.flatMap(MMessageEnd::getCovered).map(MLifeline::getElement).orElse(null) == lifeline
+				.getElement());
+	}
+
+	protected Optional<Command> dependencies(MOccurrence<? extends Element> occurrence, int newYPosition) {
 		List<Command> result = new ArrayList<>();
 		Consumer<Command> commandSink = cmd -> Optional.ofNullable(cmd).ifPresent(result::add);
 
@@ -214,11 +263,11 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 		if (!isThisMessageEndBeingDisconnected) {
 			// Either we aren't disconnecting the message end, or it's not a message
 			// end that we're moving
-			occurrence.getStartedExecution()
-					.map(exec -> exec.setOwner(lifeline, yPosition, OptionalInt.empty()))
+			occurrence.getStartedExecution().filter(exec -> !hasDependency(exec, SetOwnerCommand.class))
+					.map(exec -> exec.setOwner(lifeline, OptionalInt.of(newYPosition), OptionalInt.empty()))
 					.ifPresent(result::add);
-			occurrence.getFinishedExecution()
-					.map(exec -> exec.setOwner(lifeline, OptionalInt.empty(), yPosition))
+			occurrence.getFinishedExecution().filter(exec -> !hasDependency(exec, SetOwnerCommand.class))
+					.map(exec -> exec.setOwner(lifeline, OptionalInt.empty(), OptionalInt.of(newYPosition)))
 					.ifPresent(result::add);
 		}
 
@@ -226,12 +275,12 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 		if ((occurrence instanceof MMessageEnd) && !(occurrence instanceof MDestruction)) {
 			MMessageEnd end = (MMessageEnd)occurrence;
 			if (isChangingLifeline() || isChangingPosition()) {
-				collectMessageDependencies(end, isDisconnectingMessageEnd, commandSink);
+				collectMessageDependencies(end, isDisconnectingMessageEnd, newYPosition, commandSink);
 			}
 		} else if (occurrence instanceof MExecutionOccurrence) {
 			MExecutionOccurrence execOcc = (MExecutionOccurrence)occurrence;
 			if (isChangingLifeline() || isChangingPosition()) {
-				collectExecutionOccurrenceDependencies(execOcc, commandSink);
+				collectExecutionOccurrenceDependencies(execOcc, newYPosition, commandSink);
 			}
 		}
 
@@ -246,10 +295,11 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 	 * @param isDisconnecting
 	 *            whether the {@code end} is being disconnected from the start/finish of an execution
 	 *            specification
+	 * @param newYPosition
 	 * @param commandSink
 	 *            accumulator of dependency commands (accepts {@code null} values)
 	 */
-	private void collectMessageDependencies(MMessageEnd end, boolean isDisconnecting,
+	private void collectMessageDependencies(MMessageEnd end, boolean isDisconnecting, int newYPosition,
 			Consumer<? super Command> commandSink) {
 
 		MMessage message = end.getOwner();
@@ -261,7 +311,6 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 
 		Connector connector = edge.get();
 		Shape lifelineBody = getLifelineBody().get();
-		int newYPosition = yPosition.orElseGet(() -> end.getTop().getAsInt());
 
 		// Handle attached execution specification, unless we're detaching from a message end
 		Optional<MExecutionOccurrence> replacement = isDisconnecting ? Optional.empty()
@@ -286,13 +335,13 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 				commandSink.accept(defer(
 						() -> reconnectSource(connector, newAttachedShape.get(), newYPosition).orElse(null)));
 				Optional<MMessageEnd> otherEnd = end.getOtherEnd();
-				otherEnd.flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
+				otherEnd.flatMap(oEnd -> handleSelfMessageChange(oEnd, newYPosition)).ifPresent(commandSink);
 				otherEnd.flatMap(this::handleOppositeSendOrReplyMessage).ifPresent(commandSink);
 			} else if (end.isReceive()) {
 				commandSink.accept(defer(
 						() -> reconnectTarget(connector, newAttachedShape.get(), newYPosition).orElse(null)));
 				Optional<MMessageEnd> otherEnd = end.getOtherEnd();
-				otherEnd.flatMap(this::handleSelfMessageChange).ifPresent(commandSink);
+				otherEnd.flatMap(oEnd -> handleSelfMessageChange(oEnd, newYPosition)).ifPresent(commandSink);
 				otherEnd.flatMap(this::handleOppositeSendOrReplyMessage).ifPresent(commandSink);
 			} // else don't know what to do with it
 		}
@@ -320,15 +369,62 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 							map(exec.getBottom(), b -> b + deltaY))).ifPresent(commandSink);
 				} else {
 					Optional<MLifeline> otherCovered = other.flatMap(MMessageEnd::getCovered);
-					OptionalInt otherNewY = map(otherY, y -> y + deltaY);
 
 					// Track this end
+					final OptionalInt otherNewY;
+					if (end.isStart()) {
+						if (wasSelfMessage() && willBeSelfMessage()) {
+							otherNewY = OptionalInt.of(PendingVerticalExtentData
+									.getPendingTop(end.getExecution().get()).getAsInt()
+									- layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE));
+						} else {
+							otherNewY = PendingVerticalExtentData.getPendingTop(end.getExecution().get());
+						}
+
+					} else if (end.isFinish()) {
+						OptionalInt tmp = PendingVerticalExtentData
+								.getPendingBottom(end.getExecution().get());
+						if (otherEnd.isReceive()) {
+							// add an additional room for the self message
+							if (willBeSelfMessage()) {
+								tmp = OptionalInt.of(tmp.getAsInt() + layoutHelper().getConstraints()
+										.getMinimumHeight(ViewTypes.MESSAGE));
+							}
+						}
+						otherNewY = tmp;
+					} else {
+						OptionalInt tmp = yPosition;
+						// only a simple occurrence on the execution. Move using delta
+						if (otherEnd.isReceive()) {
+							// add an additional room for the self message
+							if (isBecomingSelfMessage() && !wasSelfMessage()) {
+								tmp = OptionalInt.of(tmp.getAsInt() + layoutHelper().getConstraints()
+										.getMinimumHeight(ViewTypes.MESSAGE));
+							}
+						}
+						otherNewY = tmp;
+					}
 					otherCovered.map(ll -> otherEnd.setCovered(ll, otherNewY)).ifPresent(commandSink);
 				}
 			} else if (shouldTrackOppositeEnd(end)) {
 				Optional<MLifeline> otherCovered = otherEnd.getCovered();
 				// Track this end
 				otherCovered.map(ll -> otherEnd.setCovered(ll, yPosition)).ifPresent(commandSink);
+			} else {
+				Optional<MLifeline> otherCovered = other.flatMap(MMessageEnd::getCovered);
+				// only a simple occurrence on the execution. Move using delta
+				if (otherEnd.isReceive()) {
+					// add an additional room for the self message
+					if (isBecomingSelfMessage() && !wasSelfMessage()) {
+						// ensure the position has a least the space for self messages, but it could be bigger
+						int minLayout = yPosition.getAsInt()
+								+ layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE);
+						int currentOtherPos = otherEnd.getTop().getAsInt();
+						OptionalInt otherNewY = OptionalInt.of(Math.max(minLayout, currentOtherPos));
+						otherCovered.map(ll -> otherEnd.setCovered(ll, otherNewY)).ifPresent(commandSink);
+					}
+				}
+
 			}
 		}
 	}
@@ -419,7 +515,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 				.map(MMessageEnd.class::cast).map(MMessageEnd::getOwner);
 	}
 
-	Optional<Command> handleSelfMessageChange(MMessageEnd otherEnd) {
+	Optional<Command> handleSelfMessageChange(MMessageEnd otherEnd, int newYPosition) {
 		Optional<Command> result;
 
 		// If the message end opposite one being moved to this lifeline is already on that lifeline,
@@ -448,14 +544,14 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 			Command bend;
 			if (otherEnd.isSend()) {
 				// We're reconnecting the source end, but we need to maintain the gap
-				int newYPosition = currentYPosition - height;
-				Shape newAttachShape = executionShapeAt(lifeline, newYPosition).orElse(lifelineBody);
+				// int newYPosition = currentYPosition - height;
+				Shape newAttachShape = executionShapeAt(lifeline, currentYPosition).orElse(lifelineBody);
 				bend = reconnectSource(connector, newAttachShape, currentYPosition)
 						.orElse(IdentityCommand.INSTANCE);
 			} else {
-				int newYPosition = currentYPosition + height;
-				Shape newAttachShape = executionShapeAt(lifeline, newYPosition).orElse(lifelineBody);
-				bend = reconnectTarget(connector, newAttachShape, newYPosition)
+				int newReceivePosition = Math.max(newYPosition, currentYPosition);
+				Shape newAttachShape = executionShapeAt(lifeline, newReceivePosition).orElse(lifelineBody);
+				bend = reconnectTarget(connector, newAttachShape, newReceivePosition)
 						.orElse(IdentityCommand.INSTANCE);
 			}
 
@@ -478,7 +574,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 	 * @param commandSink
 	 *            accumulator of dependency commands (accepts {@code null} values)
 	 */
-	private void collectExecutionOccurrenceDependencies(MExecutionOccurrence occurrence,
+	private void collectExecutionOccurrenceDependencies(MExecutionOccurrence occurrence, int newYPosition,
 			Consumer<? super Command> commandSink) {
 
 		boolean shouldReplace = (occurrence.isStart() || occurrence.isFinish())
@@ -486,7 +582,7 @@ public class SetCoveredCommand extends ModelCommandWithDependencies<MOccurrenceI
 		if (shouldReplace) {
 			// Replace it by a message end? But not if we exist because of separation
 			// of a message end from the execution in the first place
-			Optional<MMessageEnd> end = getMessageEnd(yPosition);
+			Optional<MMessageEnd> end = getMessageEnd(OptionalInt.of(newYPosition));
 			end.map(occurrence::replaceBy).ifPresent(commandSink);
 		}
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetOwnerCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/SetOwnerCommand.java
@@ -34,7 +34,11 @@ import org.eclipse.papyrus.uml.interaction.internal.model.impl.MElementImpl;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MMessage;
+import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
 import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.spi.ViewTypes;
+import org.eclipse.papyrus.uml.interaction.model.util.Executions;
 import org.eclipse.papyrus.uml.interaction.model.util.Lifelines;
 import org.eclipse.papyrus.uml.interaction.model.util.Optionals;
 import org.eclipse.papyrus.uml.interaction.model.util.SequenceDiagramSwitch;
@@ -49,9 +53,9 @@ public class SetOwnerCommand extends ModelCommandWithDependencies<MElementImpl<?
 
 	private final MElement<? extends Element> newOwner;
 
-	private final OptionalInt top;
+	private OptionalInt top;
 
-	private final OptionalInt bottom;
+	private OptionalInt bottom;
 
 	// The element on the lifeline that we may need to nudge, if the new owner is a lifeline
 	private final Optional<MElement<? extends Element>> nudgeElement;
@@ -79,10 +83,65 @@ public class SetOwnerCommand extends ModelCommandWithDependencies<MElementImpl<?
 						: Lifelines.elementAfterAbsolute(lifeline,
 								bottom.orElseGet(() -> element.getBottom().orElse(0))));
 
+		// ensure message starting the execution would still have some room
+		fixLocation();
+
 		// Publish this ownership change in the dependency context for other commands to find
 		PendingChildData.setPendingChild(newOwner, element);
 		// And vertical extent change
-		PendingVerticalExtentData.setPendingVerticalExtent(element, top, bottom);
+		PendingVerticalExtentData.setPendingVerticalExtent(element, this.top, this.bottom);
+	}
+
+	private void fixLocation() {
+		MElement<?> target = getTarget();
+		if (MExecution.class.isInstance(target)) {
+			MExecution execution = MExecution.class.cast(target);
+			boolean wasSelfMessage = wasStartingSelfMessage(execution);
+			boolean isSelfMessage = isStartingSelfMessage(execution);
+
+			if (!wasSelfMessage && isSelfMessage) {
+				if (top.isPresent()) {
+					// check if there is already a setCoveredCommand on the starting message
+					if (!execution.getStart().filter(occ -> hasDependency(occ, SetCoveredCommand.class))
+							.isPresent()) {
+						top = OptionalInt.of(top.getAsInt()
+								+ layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE));
+					}
+				}
+				if (bottom.isPresent()) {
+					if (!execution.getStart().filter(occ -> hasDependency(occ, SetCoveredCommand.class))
+							.isPresent()) {
+						bottom = OptionalInt.of(bottom.getAsInt()
+								+ layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE));
+					}
+				} else {
+					// bottom should still be set.
+					// to compute it, compute original height + new top position
+					if (top.isPresent()) {
+						bottom = OptionalInt.of(top.getAsInt() + execution.getBottom().getAsInt()
+								- execution.getTop().getAsInt());
+					}
+				}
+			} else if (wasSelfMessage && !isSelfMessage) {
+				if (top.isPresent()) {
+					if (!execution.getStart().filter(occ -> hasDependency(occ, SetCoveredCommand.class))
+							.isPresent()) {
+						top = OptionalInt.of(top.getAsInt()
+								- layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE));
+					}
+				}
+				if (bottom.isPresent()) {
+					if (!execution.getStart().filter(occ -> hasDependency(occ, SetCoveredCommand.class))
+							.isPresent()) {
+						bottom = OptionalInt.of(bottom.getAsInt()
+								- layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE));
+					}
+				} else {
+					bottom = OptionalInt.of(top.getAsInt() + execution.getBottom().getAsInt()
+							- execution.getTop().getAsInt());
+				}
+			}
+		}
 	}
 
 	protected boolean isChangingOwner() {
@@ -186,13 +245,61 @@ public class SetOwnerCommand extends ModelCommandWithDependencies<MElementImpl<?
 			// that *will be* spanned do not; they only must be reattached per the step below
 			result = execution.getOccurrences().stream()
 					.map(occ -> occ.setCovered(lifeline, topMapping.apply(occ.getTop()))).reduce(chaining());
-		} else if (isChangingPosition() && !isChangingOwner()) {
-			// We are reshaping it. Refresh nested executions, if necessary
-			result = execution.getNestedExecutions().stream()
-					.filter(PendingVerticalExtentData.spannedBy(execution).negate())
-					.peek(nested -> setPendingNested(PendingNestedData.NO_EXECUTION, nested))
-					.map(nested -> nested.setOwner(lifeline, nested.getTop(), nested.getBottom()))
-					.filter(Objects::nonNull).reduce(chaining());
+		} else if (isChangingPosition()) {
+			if (!isChangingOwner()) {
+				// We are reshaping it. Refresh nested executions, if necessary
+				result = execution.getNestedExecutions().stream()
+						.filter(PendingVerticalExtentData.spannedBy(execution).negate())
+						.peek(nested -> setPendingNested(PendingNestedData.NO_EXECUTION, nested))
+						.map(nested -> nested.setOwner(lifeline, nested.getTop(), nested.getBottom()))
+						.filter(Objects::nonNull).reduce(chaining());
+			} else {
+				// we are moving and changing owner. Receive event of the finish message may also be move down
+				// from some pixels because of becoming a self message.
+				int deltaTop = map(this.top, t -> t - execution.getTop().getAsInt()).orElse(0);
+				UnaryOperator<OptionalInt> topMapping = deltaTop == 0 ? UnaryOperator.identity()
+						: top_ -> map(top_, t -> t + deltaTop);
+
+				result = execution.getOccurrences().stream()
+						.filter(occ -> !occ.equals(execution.getFinish().orElse(null)))
+						.map(occ -> occ.setCovered(lifeline, topMapping.apply(occ.getTop())))
+						.filter(Objects::nonNull).reduce(chaining());
+				boolean isSelfMessage = isStartingSelfMessage(execution);
+				boolean wasSelfMessage = wasStartingSelfMessage(execution);
+				if (isSelfMessage && !wasSelfMessage) {
+					UnaryOperator<OptionalInt> topFinishMapping = deltaTop == 0 ? UnaryOperator.identity()
+							: top_ -> map(top_, t -> t + deltaTop
+									+ layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE));
+					final Optional<Command> last = execution.getFinish()
+							.map(occ -> occ.setCovered(lifeline, topFinishMapping.apply(occ.getTop())));
+					if (result.isPresent()) {
+						if (last.isPresent()) {
+							result.get().chain(last.get());
+						}
+					} else {
+						result = last;
+					}
+				} else if (!isSelfMessage && wasSelfMessage) {
+					UnaryOperator<OptionalInt> topFinishMapping = deltaTop == 0 ? UnaryOperator.identity()
+							: top_ -> map(top_, t -> t// + deltaTop
+									- layoutHelper().getConstraints().getMinimumHeight(ViewTypes.MESSAGE));
+					final Optional<Command> last = execution.getFinish()
+							.map(occ -> occ.setCovered(lifeline, topFinishMapping.apply(occ.getTop())));
+					if (result.isPresent()) {
+						if (last.isPresent()) {
+							result.get().chain(last.get());
+						}
+					} else {
+						result = last;
+					}
+				} else {
+					UnaryOperator<OptionalInt> topFinishMapping = deltaTop == 0 ? UnaryOperator.identity()
+							: top_ -> map(top_, t -> t + deltaTop);
+					final Optional<Command> last = execution.getFinish()
+							.map(occ -> occ.setCovered(lifeline, topFinishMapping.apply(occ.getTop())));
+					result.map(cc -> last.map(l -> cc.chain(l))).orElseGet(() -> last);
+				}
+			}
 		}
 
 		// Note that nested executions will be handled implicitly by either their start or finish.
@@ -208,6 +315,24 @@ public class SetOwnerCommand extends ModelCommandWithDependencies<MElementImpl<?
 		result = Optionals.stream(result, reattach).reduce(chaining());
 
 		return result;
+	}
+
+	private boolean isStartingSelfMessage(MExecution execution) {
+		Optional<MLifeline> sendStartLL = Executions.getStartMessage(execution).flatMap(MMessage::getSend)
+				.flatMap(MMessageEnd::getCovered);
+		return as(Optional.of(newOwner), MLifeline.class).map(MElement::getElement)
+				.equals(sendStartLL.map(MElement::getElement));
+	}
+
+	private boolean wasStartingSelfMessage(MExecution execution) {
+		Optional<MLifeline> sendStartLL = Executions.getStartMessage(execution).flatMap(MMessage::getSend)
+				.flatMap(MMessageEnd::getCovered);
+		if (!sendStartLL.isPresent()) {
+			return false;
+		}
+		return sendStartLL.equals(Executions.getStartMessage(execution).flatMap(MMessage::getReceive)
+				.flatMap(MMessageEnd::getCovered));
+
 	}
 
 	protected void ensurePadding() {

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
@@ -14,7 +14,6 @@ package org.eclipse.papyrus.uml.interaction.internal.model.spi.impl;
 
 import static org.eclipse.papyrus.uml.interaction.graph.util.Suppliers.compose;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -46,7 +45,6 @@ import org.eclipse.gmf.runtime.notation.Routing;
 import org.eclipse.gmf.runtime.notation.Shape;
 import org.eclipse.gmf.runtime.notation.Size;
 import org.eclipse.gmf.runtime.notation.View;
-import org.eclipse.gmf.runtime.notation.datatype.RelativeBendpoint;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.CreationParameters;
 import org.eclipse.papyrus.uml.interaction.model.spi.DeferredCreateCommand;
@@ -346,30 +344,29 @@ public class DefaultDiagramHelper implements DiagramHelper {
 							: targetView);
 			if (selfMessage) {
 				// A self message is fixed at the minimal gap if it is of a synchronous sort
-				int minTargetDistance = sourceDistance
-						+ layoutHelper().getConstraints().getMinimumHeight(result);
+				// warning, source distance and target distance may be in 2 different local dimensions
+				// so the computation has to be done in absolute coordinates then translated back to local
+				// dimensions
+
+				int minTargetDistance = sourceY.getAsInt()
+						+ layoutHelper().getConstraints().getMinimumHeight(result)
+						- layoutHelper()
+								.getTop(ViewTypes.DESTRUCTION_SPECIFICATION.equals(targetView.getType())
+										? (Shape)targetView.eContainer() // Calculate relative to the lifeline
+										: targetView);
 				targetDistance = syncMessage ? minTargetDistance
 						: Math.max(targetDistance, minTargetDistance);
 			}
 			anchorFactory.builderFor(targetView).from(sourceView).to(targetView).at(targetDistance)
 					.targetEnd().build();
 
-			// We need to have a bendpoints list, even if it's empty
-			RelativeBendpoints bendpoints = (RelativeBendpoints)result
-					.createBendpoints(NotationPackage.Literals.RELATIVE_BENDPOINTS);
-
 			// Specific routing for self-messages
 			if (selfMessage) {
 				result.setRouting(Routing.RECTILINEAR_LITERAL);
-
-				int xOffset = layoutHelper().getConstraints().getMinimumWidth(result);
-				int yOffset = layoutHelper().getConstraints().getMinimumHeight(result);
-				RelativeBendpoint bp1 = new RelativeBendpoint(0, 0, 0, -yOffset);
-				RelativeBendpoint bp2 = new RelativeBendpoint(xOffset, 0, xOffset, -yOffset);
-				RelativeBendpoint bp3 = new RelativeBendpoint(xOffset, yOffset, xOffset, 0);
-				RelativeBendpoint bp4 = new RelativeBendpoint(0, yOffset, 0, 0);
-				bendpoints.setPoints(Arrays.asList(bp1, bp2, bp3, bp4));
 			}
+
+			RelativeBendpoints bendpoints = NotationFactory.eINSTANCE.createRelativeBendpoints();
+			result.setBendpoints(bendpoints);
 
 			// create a decoration node to be seen by CSS rules
 			DecorationNode nameLabel = (DecorationNode)result
@@ -430,27 +427,6 @@ public class DefaultDiagramHelper implements DiagramHelper {
 	public Command configureSelfMessageConnector(Message message, Connector messageView) {
 		Command result = SetCommand.create(editingDomain, messageView,
 				NotationPackage.Literals.ROUTING_STYLE__ROUTING, Routing.RECTILINEAR_LITERAL);
-
-		// Compute the target anchor
-		Shape source = (Shape)messageView.getSource();
-		AnchorFactory anchorFactory = new AnchorFactory(messageView, layoutHelper());
-		int sourceDistance = layoutHelper().getYPosition(messageView.getSourceAnchor(), source)
-				- layoutHelper().getTop(source);
-		int targetDistance = sourceDistance + layoutHelper().getConstraints().getMinimumHeight(messageView);
-		String id = anchorFactory.builderFor(source).from(source).to(source).at(targetDistance).targetEnd()
-				.computeIdentity();
-		result = result.chain(SetCommand.create(editingDomain, messageView.getTargetAnchor(),
-				NotationPackage.Literals.IDENTITY_ANCHOR__ID, id));
-
-		int xOffset = layoutHelper().getConstraints().getMinimumWidth(messageView);
-		int yOffset = layoutHelper().getConstraints().getMinimumHeight(messageView);
-		RelativeBendpoint bp1 = new RelativeBendpoint(0, 0, 0, -yOffset);
-		RelativeBendpoint bp2 = new RelativeBendpoint(xOffset, 0, xOffset, -yOffset);
-		RelativeBendpoint bp3 = new RelativeBendpoint(xOffset, yOffset, xOffset, 0);
-		RelativeBendpoint bp4 = new RelativeBendpoint(0, yOffset, 0, 0);
-		result = result.chain(SetCommand.create(editingDomain, messageView.getBendpoints(),
-				NotationPackage.Literals.RELATIVE_BENDPOINTS__POINTS, Arrays.asList(bp1, bp2, bp3, bp4)));
-
 		return result;
 	}
 
@@ -458,8 +434,10 @@ public class DefaultDiagramHelper implements DiagramHelper {
 	public Command configureStraightMessageConnector(Message message, Connector messageView) {
 		Command result = SetCommand.create(editingDomain, messageView,
 				NotationPackage.Literals.ROUTING_STYLE__ROUTING, Routing.MANUAL_LITERAL);
-		result = result.chain(SetCommand.create(editingDomain, messageView.getBendpoints(),
-				NotationPackage.Literals.RELATIVE_BENDPOINTS__POINTS, Collections.EMPTY_LIST));
+		if (messageView.getBendpoints() != null) {
+			result = result.chain(SetCommand.create(editingDomain, messageView.getBendpoints(),
+					NotationPackage.Literals.RELATIVE_BENDPOINTS__POINTS, Collections.EMPTY_LIST));
+		}
 		return result;
 	}
 
@@ -476,6 +454,24 @@ public class DefaultDiagramHelper implements DiagramHelper {
 				.to((Shape)connector.getTarget()).sourceEnd().at(yOffset).computeIdentity();
 		result = result.chain(SetCommand.create(editingDomain, anchor,
 				NotationPackage.Literals.IDENTITY_ANCHOR__ID, newID));
+
+		// if message changes from self message to standard, or from standard to self, the routing style must
+		// be updated.
+		// compute the future value of self message
+		Lifeline sourceLL = getLifeline(newSource);
+		Lifeline targetLL = getLifeline(connector.getTarget());
+		boolean selfMessage = (sourceLL != null) && (sourceLL == targetLL);
+
+		Routing newRouting = Routing.MANUAL_LITERAL;
+		if (selfMessage) {
+			newRouting = Routing.RECTILINEAR_LITERAL;
+		}
+
+		// should force?
+		if (newRouting != connector.getRouting()) {
+			result.chain(SetCommand.create(editingDomain, connector,
+					NotationPackage.Literals.ROUTING_STYLE__ROUTING, newRouting));
+		}
 
 		return result;
 	}
@@ -505,6 +501,23 @@ public class DefaultDiagramHelper implements DiagramHelper {
 				.from((Shape)connector.getSource()).to(newTarget).targetEnd().at(yOffset).computeIdentity();
 		result = result.chain(SetCommand.create(editingDomain, anchor,
 				NotationPackage.Literals.IDENTITY_ANCHOR__ID, newID));
+
+		// if message changes from self message to standard, or from standard to self, the routing style must
+		// be updated.
+		// compute the future value of self message
+		Lifeline sourceLL = getLifeline(connector.getSource());
+		Lifeline targetLL = getLifeline(newTarget);
+		boolean selfMessage = (sourceLL != null) && (sourceLL == targetLL);
+
+		Routing newRouting = Routing.MANUAL_LITERAL;
+		if (selfMessage) {
+			newRouting = Routing.RECTILINEAR_LITERAL;
+		}
+		// should force?
+		if (newRouting != connector.getRouting()) {
+			result.chain(SetCommand.create(editingDomain, connector,
+					NotationPackage.Literals.ROUTING_STYLE__ROUTING, newRouting));
+		}
 
 		return result;
 	}

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/spi/impl/DefaultDiagramHelper.java
@@ -469,7 +469,7 @@ public class DefaultDiagramHelper implements DiagramHelper {
 
 		// should force?
 		if (newRouting != connector.getRouting()) {
-			result.chain(SetCommand.create(editingDomain, connector,
+			result = result.chain(SetCommand.create(editingDomain, connector,
 					NotationPackage.Literals.ROUTING_STYLE__ROUTING, newRouting));
 		}
 
@@ -515,7 +515,7 @@ public class DefaultDiagramHelper implements DiagramHelper {
 		}
 		// should force?
 		if (newRouting != connector.getRouting()) {
-			result.chain(SetCommand.create(editingDomain, connector,
+			result = result.chain(SetCommand.create(editingDomain, connector,
 					NotationPackage.Literals.ROUTING_STYLE__ROUTING, newRouting));
 		}
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AbstractGraphicalEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/AbstractGraphicalEditPolicyUITest.java
@@ -64,6 +64,9 @@ public abstract class AbstractGraphicalEditPolicyUITest {
 	/** The width of an execution specification. */
 	protected static final int EXEC_WIDTH = 10;
 
+	/** The default height of an execution specification. */
+	protected static final int EXEC_HEIGHT = 40;
+
 	/** Constant for the source end of a connection edit-part. */
 	protected static final int SOURCE_END = 0;
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionAnchorsUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionAnchorsUITest.java
@@ -135,6 +135,8 @@ public class ExecutionAnchorsUITest extends AbstractGraphicalEditPolicyUITest {
 	@After
 	public void checkAfter() {
 		editor.undo();
+		editor.forceRefresh();
+		editor.flushDisplayEvents();
 		assertEquals(request_source, getSource(requestEP));
 		assertEquals(request_target, getTarget(requestEP));
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -278,6 +278,9 @@ public class ExecutionSpecificationDragEditPolicyUITest {
 		@Rule
 		public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
 
+		@ClassRule
+		public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
+
 		@AutoFixture("exec1")
 		private ExecutionSpecification exec;
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationGraphicalNodeEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationGraphicalNodeEditPolicyUITest.java
@@ -31,19 +31,20 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration test cases for the
- * {@link ExecutionSpecificationGraphicalNodeEditPolicy} class.
+ * Integration test cases for the {@link ExecutionSpecificationGraphicalNodeEditPolicy} class.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
 @ModelResource("one-exec.di")
 @Maximized
 @RunWith(Parameterized.class)
 public class ExecutionSpecificationGraphicalNodeEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
 
+	private static final int MESSAGE_Y = 195;
+
 	@ClassRule
-	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().dontCreateExecutionsForSyncMessages();
+	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
+			.dontCreateExecutionsForSyncMessages();
 
 	// Horizontal position of the first lifeline's body
 	private static final int LIFELINE_1_BODY_X = 121;
@@ -52,6 +53,7 @@ public class ExecutionSpecificationGraphicalNodeEditPolicyUITest extends Abstrac
 	private static final int LIFELINE_2_BODY_X = 281;
 
 	private static final boolean SENDER = true; // source = true
+
 	private static final boolean RECEIVER = !SENDER;
 
 	private final int sendX;
@@ -61,7 +63,8 @@ public class ExecutionSpecificationGraphicalNodeEditPolicyUITest extends Abstrac
 	/**
 	 * Initializes me.
 	 */
-	public ExecutionSpecificationGraphicalNodeEditPolicyUITest(boolean rightToLeft, String direction) {
+	public ExecutionSpecificationGraphicalNodeEditPolicyUITest(boolean rightToLeft,
+			@SuppressWarnings("unused") String direction) {
 		super();
 
 		if (rightToLeft) {
@@ -75,16 +78,18 @@ public class ExecutionSpecificationGraphicalNodeEditPolicyUITest extends Abstrac
 
 	@Test
 	public void createAsyncMessage() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 195), at(recvX, 195));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, MESSAGE_Y),
+				at(recvX, MESSAGE_Y));
 
-		assertThat(messageEP, runs(x(SENDER), 195, x(RECEIVER), 195, 2));
+		assertThat(messageEP, runs(x(SENDER), MESSAGE_Y, x(RECEIVER), MESSAGE_Y, 2));
 	}
 
 	@Test
 	public void createSyncMessage() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, 195), at(recvX, 195));
+		EditPart messageEP = createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, MESSAGE_Y),
+				at(recvX, MESSAGE_Y));
 
-		assertThat(messageEP, runs(x(SENDER), 195, x(RECEIVER), 195, 2));
+		assertThat(messageEP, runs(x(SENDER), MESSAGE_Y, x(RECEIVER), MESSAGE_Y, 2));
 	}
 
 	//
@@ -94,19 +99,18 @@ public class ExecutionSpecificationGraphicalNodeEditPolicyUITest extends Abstrac
 	@Parameters(name = "{1}")
 	public static Iterable<Object[]> parameters() {
 		return Arrays.asList(new Object[][] { //
-				{ false, "left-to-right" }, //
-				{ true, "right-to-left" }, //
+				{false, "left-to-right" }, //
+				{true, "right-to-left" }, //
 		});
 	}
 
 	/**
-	 * Compute an adjusted {@code x} coördinate based the test message's
-	 * directionality and whether that end is at an execution specification or a
-	 * lifeline stem.
+	 * Compute an adjusted {@code x} coordinate based the test message's directionality and whether that end
+	 * is at an execution specification or a lifeline stem.
 	 *
-	 * @param source whether this is the source end of the message
-	 *
-	 * @return the adjusted X coördinate
+	 * @param source
+	 *            whether this is the source end of the message
+	 * @return the adjusted X coordinate
 	 */
 	int x(boolean source) {
 		if (sendX > recvX) {

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionWithSelfMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionWithSelfMoveUITest.java
@@ -110,7 +110,7 @@ public class ExecutionWithSelfMoveUITest extends AbstractGraphicalEditPolicyUITe
 
 	@Test
 	public void moveUpExecution() {
-		int delta = -50;
+		int delta = -30;
 
 		Point grabAt = execution1Rect.getCenter();
 		Point dropAt = execution1Rect.getCenter().translate(0, delta);
@@ -118,15 +118,14 @@ public class ExecutionWithSelfMoveUITest extends AbstractGraphicalEditPolicyUITe
 
 		// check result
 		Rectangle exec1EPNew = execution1Rect.getCopy().translate(new Point(0, delta));
-		EditPart exec1EP = findEditPart("execution-self::Interaction1::Execution1", false);
-		assertThat(getBounds(exec1EP), equalTo(exec1EPNew));
 		PointList newRequestPoints = requestPoints.getCopy();
 		newRequestPoints.translate(0, delta);
 		assertThat(requestEP, runs(exec1EPNew.getCenter().x(), exec1EPNew.getTop().y() - 20,
 				exec1EPNew.getTopRight().x(), exec1EPNew.getTopRight().y()));
 
-		PointList newReplyPoints = replyPoints.getCopy();
-		newReplyPoints.translate(0, delta);
+		EditPart exec1EP = findEditPart("execution-self::Interaction1::Execution1", false);
+		assertThat(getBounds(exec1EP), equalTo(exec1EPNew));
+
 		assertThat(replyEP, runs(exec1EPNew.getBottomRight().x(), exec1EPNew.getBottomRight().y(),
 				exec1EPNew.getCenter().x(), exec1EPNew.getBottom().y() + 20));
 	}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionWithSelfMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionWithSelfMoveUITest.java
@@ -1,0 +1,128 @@
+/*****************************************************************************
+ * Copyright (c) 2018 EclipseSource and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   EclipseSource - Initial API and implementation
+ *   
+ *****************************************************************************/
+
+package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
+
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.runs;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Lifeline;
+import org.eclipse.uml2.uml.Message;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * UI test for moving executions with self start / finish messages.
+ */
+@ModelResource("execution-self.di")
+@Maximized
+public class ExecutionWithSelfMoveUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@Rule
+	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
+
+	@AutoFixture("Lifeline1")
+	private Lifeline lifeline1;
+
+	@AutoFixture
+	private EditPart lifeline1EP;
+
+	@AutoFixture("request")
+	private Message request;
+
+	@AutoFixture
+	private EditPart requestEP;
+
+	@AutoFixture("reply")
+	private Message reply;
+
+	@AutoFixture
+	private EditPart replyEP;
+
+	@AutoFixture("Execution1")
+	private ExecutionSpecification execution1;
+
+	@AutoFixture
+	private EditPart execution1EP;
+
+	private Rectangle execution1Rect;
+
+	private PointList replyPoints;
+
+	private PointList requestPoints;
+
+	@Before
+	public void updateFixtures() {
+		execution1Rect = getBounds(execution1EP);
+		requestPoints = getPoints(requestEP).getCopy();
+		replyPoints = getPoints(replyEP).getCopy();
+	}
+
+	@Test
+	public void moveDownExecution() {
+		int delta = +50;
+
+		Point grabAt = execution1Rect.getCenter();
+		Point dropAt = execution1Rect.getCenter().translate(0, delta);
+		editor.moveSelection(grabAt, dropAt);
+
+		// check result
+		Rectangle exec1EPNew = execution1Rect.getCopy().translate(new Point(0, delta));
+		EditPart exec1EP = findEditPart("execution-self::Interaction1::Execution1", false);
+		assertThat(getBounds(exec1EP), equalTo(exec1EPNew));
+		PointList newRequestPoints = requestPoints.getCopy();
+		newRequestPoints.translate(0, delta);
+		assertThat(requestEP, runs(exec1EPNew.getCenter().x(), exec1EPNew.getTop().y() - 20,
+				exec1EPNew.getTopRight().x(), exec1EPNew.getTopRight().y()));
+
+		PointList newReplyPoints = replyPoints.getCopy();
+		newReplyPoints.translate(0, delta);
+		assertThat(replyEP, runs(exec1EPNew.getBottomRight().x(), exec1EPNew.getBottomRight().y(),
+				exec1EPNew.getCenter().x(), exec1EPNew.getBottom().y() + 20));
+	}
+
+	@Test
+	public void moveUpExecution() {
+		int delta = -50;
+
+		Point grabAt = execution1Rect.getCenter();
+		Point dropAt = execution1Rect.getCenter().translate(0, delta);
+		editor.moveSelection(grabAt, dropAt);
+
+		// check result
+		Rectangle exec1EPNew = execution1Rect.getCopy().translate(new Point(0, delta));
+		EditPart exec1EP = findEditPart("execution-self::Interaction1::Execution1", false);
+		assertThat(getBounds(exec1EP), equalTo(exec1EPNew));
+		PointList newRequestPoints = requestPoints.getCopy();
+		newRequestPoints.translate(0, delta);
+		assertThat(requestEP, runs(exec1EPNew.getCenter().x(), exec1EPNew.getTop().y() - 20,
+				exec1EPNew.getTopRight().x(), exec1EPNew.getTopRight().y()));
+
+		PointList newReplyPoints = replyPoints.getCopy();
+		newReplyPoints.translate(0, delta);
+		assertThat(replyEP, runs(exec1EPNew.getBottomRight().x(), exec1EPNew.getBottomRight().y(),
+				exec1EPNew.getCenter().x(), exec1EPNew.getBottom().y() + 20));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionWithSelfMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionWithSelfMoveUITest.java
@@ -21,6 +21,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
@@ -29,8 +30,10 @@ import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.Lifeline;
 import org.eclipse.uml2.uml.Message;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 /**
  * UI test for moving executions with self start / finish messages.
@@ -38,6 +41,9 @@ import org.junit.Test;
 @ModelResource("execution-self.di")
 @Maximized
 public class ExecutionWithSelfMoveUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
 
 	@Rule
 	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineBodyGraphicalNodeEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineBodyGraphicalNodeEditPolicyUITest.java
@@ -24,30 +24,34 @@ import java.util.Arrays;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineBodyGraphicalNodeEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.Figures;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy}
- * class.
+ * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy} class.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
 @ModelResource("two-lifelines.di")
 @Maximized
 @RunWith(Parameterized.class)
 public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
 
 	@ClassRule
-	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().dontCreateExecutionsForSyncMessages();
+	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
+			.dontCreateExecutionsForSyncMessages();
+
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
 
 	// Horizontal position of the first lifeline's body
 	private static final int LIFELINE_1_BODY_X = 121;
@@ -60,7 +64,12 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 	private final int recvX;
 
 	/**
-	 * Initializes me.
+	 * Initializes me with my test parameters.
+	 * 
+	 * @param rightToLeft
+	 *            whether to draw the message from right-to-left (otherwise, left-to-right)
+	 * @param direction
+	 *            human-readable interpretation of the {@code leftToRight} parameter
 	 */
 	public LifelineBodyGraphicalNodeEditPolicyUITest(boolean rightToLeft, String direction) {
 		super();
@@ -76,21 +85,24 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 
 	@Test
 	public void createAsyncMessage() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 125), at(recvX, 125));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 125),
+				at(recvX, 125));
 
 		assertThat(messageEP, runs(sendX, 125, recvX, 125, 2));
 	}
 
 	@Test
 	public void createSlopedAsyncMessage() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 125), at(recvX, 140));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 125),
+				at(recvX, 140));
 
 		assertThat("Message should be sloped", messageEP, runs(sendX, 125, recvX, 140, 2));
 	}
 
 	@Test
 	public void attemptBackwardSlopedAsyncMessage_allowed() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 140), at(recvX, 138));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 140),
+				at(recvX, 138));
 
 		// The target to which the user draw the message should have priority over the
 		// source
@@ -106,7 +118,8 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 
 	@Test
 	public void createCrossedAsyncMessages() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 150), at(recvX, 150));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 150),
+				at(recvX, 150));
 
 		assumeThat(messageEP, runs(sendX, 150, recvX, 150, 2));
 
@@ -117,14 +130,17 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 
 	@Test
 	public void attemptSlopedSyncMessage() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, 115), at(recvX, 130));
+		EditPart messageEP = createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, 115),
+				at(recvX, 130));
 
-		assertThat("Message should be horizontal to receive location", messageEP, runs(sendX, 130, recvX, 130, 2));
+		assertThat("Message should be horizontal to receive location", messageEP,
+				runs(sendX, 130, recvX, 130, 2));
 	}
 
 	@Test
 	public void asyncMessageLessThanSlopeThreshold() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 115), at(recvX, 119));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 115),
+				at(recvX, 119));
 
 		assertThat("Message should be horizontal", messageEP, isHorizontal());
 	}
@@ -172,8 +188,8 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 	@Parameters(name = "{1}")
 	public static Iterable<Object[]> parameters() {
 		return Arrays.asList(new Object[][] { //
-				{ false, "left-to-right" }, //
-				{ true, "right-to-left" }, //
+				{false, "left-to-right" }, //
+				{true, "right-to-left" }, //
 		});
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
@@ -47,6 +48,8 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.Dest
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.ExecutionSpecificationEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage;
@@ -64,6 +67,7 @@ import org.eclipse.uml2.uml.Element;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestRule;
@@ -789,13 +793,46 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 	@ModelResource("execution-busy.di")
 	public static class ExecutionSpanningOccurrences extends MessageNoExecution {
 
-		private static final int LIFELINE_4_BODY_X = 596;
+		@Rule
+		public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
 
-		private final int m2Y = 173;
+		@AutoFixture
+		private EditPart requestEP;
 
-		private final int m3Y = 198;
+		@AutoFixture
+		private PointList requestGeom;
 
-		private final int m4Y = 223;
+		@AutoFixture
+		private EditPart m2EP;
+
+		@AutoFixture
+		private PointList m2Geom;
+
+		@AutoFixture
+		private EditPart m3EP;
+
+		@AutoFixture
+		private PointList m3Geom;
+
+		@AutoFixture
+		private EditPart m4EP;
+
+		@AutoFixture
+		private PointList m4Geom;
+
+		@AutoFixture
+		private EditPart replyEP;
+
+		@AutoFixture
+		private PointList replyGeom;
+
+		private int LIFELINE_4_BODY_X;
+
+		private int m2Y;
+
+		private int m3Y;
+
+		private int m4Y;
 
 		@Override
 		protected void switchLifeline(VerificationMode mode) {
@@ -863,19 +900,29 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		@Override
 		public void createMessage() {
 			// The connections all exist already. Just locate the request message
-			MMessage request = requireMessage("request");
-			messageEP = requireEditPart(request);
-			assumeThat(messageEP, runs(sendX, mesgY, getGrabX(), mesgY, 2));
+			messageEP = requestEP;
+			mesgY = requestGeom.getLastPoint().y();
+
+			// Get select geometric parameters
+			LIFELINE_4_BODY_X = m3Geom.getLastPoint().x();
+			m2Y = m2Geom.getLastPoint().y();
+			m3Y = m3Geom.getLastPoint().y();
+			m4Y = m4Geom.getLastPoint().y();
 		}
 
 		@Override
 		int getGrabX() {
-			return super.getGrabX() - (EXEC_WIDTH / 2);
+			return requestGeom.getLastPoint().x();
+		}
+
+		@Override
+		public int getReleaseX() {
+			return m2Geom.getLastPoint().x();
 		}
 
 		@Override
 		int getNewRecvX() {
-			return super.getNewRecvX() - (EXEC_WIDTH / 2);
+			return m2Geom.getLastPoint().x() - (EXEC_WIDTH / 2);
 		}
 
 	}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
@@ -91,9 +91,6 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 	// Width of the destruction X shape
 	private static final int DESTRUCTION_WIDTH = 20;
 
-	// Width of an execution specification
-	private static final int EXEC_WIDTH = 10;
-
 	// Vertical gap between send and receive of a self-message
 	private static final int SELF_MESSAGE_HEIGHT = 20;
 
@@ -139,10 +136,10 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 
 		protected void switchLifeline(VerificationMode mode) {
 			editor.with(editor.allowSemanticReordering(),
-					() -> editor.moveSelection(at(getGrabX(), mesgY), at(newRecvX, mesgY)));
+					() -> editor.moveSelection(at(getGrabX(), getGrabY()), at(getReleaseX(), getReleaseY())));
 
 			// Verify the new visuals
-			mode.verify(messageEP, runs(sendX, mesgY, getNewRecvX(), mesgY));
+			mode.verify(messageEP, runs(sendX, mesgY, getNewRecvX(), getNewRecvY()));
 
 			// And the semantics
 			MMessage msg = getRequestMessage();
@@ -161,6 +158,19 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			editor.undo();
 
 			// Verify the old visuals
+			mode.verify(messageEP, runs(sendX, mesgY, getGrabX(), getGrabY()));
+
+			// And the old semantics
+			MMessage msg = getRequestMessage();
+			mode.verify("Sender changed", msg.getSender(), is(getSender()));
+			mode.verify("Receiver not reverted", msg.getReceiver(), not(getReceiver()));
+			mode.verify("Wrong receiver", msg.getReceiver(), is(getOriginalReceiver()));
+		}
+
+		protected void undoSwitchSelfLifeline(VerificationMode mode) {
+			editor.undo();
+
+			// Verify the old visuals
 			mode.verify(messageEP, runs(sendX, mesgY, getGrabX(), mesgY));
 
 			// And the old semantics
@@ -169,6 +179,30 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			mode.verify("Receiver not reverted", msg.getReceiver(), not(getReceiver()));
 			mode.verify("Wrong receiver", msg.getReceiver(), is(getOriginalReceiver()));
 		}
+	}
+
+	public static class MessageSelfNoExecution extends MessageNoExecution {
+
+		@Override
+		public int getReleaseX() {
+			return sendX;
+		}
+
+		@Override
+		public int getNewRecvX() {
+			return sendX;
+		}
+
+		@Override
+		public int getNewRecvY() {
+			return mesgY + 20;
+		}
+
+		@Override
+		Optional<MLifeline> getReceiver() {
+			return getSender();
+		}
+
 	}
 
 	public static class MessageNoReply extends MessageNoExecution {
@@ -182,7 +216,7 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 
 			// Verify the new visuals
 			mode.verify(getExecutionEditPart(),
-					isBounded(isNear(getNewRecvX(), 5), isNear(mesgY), anything(), anything()));
+					isBounded(isNear(getNewRecvX(), 5), isNear(getNewRecvY()), anything(), anything()));
 
 			// And the semantics
 			MExecution exec = requireExecution();
@@ -235,6 +269,29 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 
 	}
 
+	public static class MessageSelfNoReply extends MessageNoReply {
+
+		@Override
+		public int getReleaseX() {
+			return sendX;
+		}
+
+		@Override
+		public int getNewRecvX() {
+			return sendX;
+		}
+
+		@Override
+		public int getNewRecvY() {
+			return mesgY + 20;
+		}
+
+		@Override
+		Optional<MLifeline> getReceiver() {
+			return getSender();
+		}
+	}
+
 	public static class MessageWithReply extends MessageNoReply {
 
 		@ClassRule
@@ -268,6 +325,251 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 			mode.verify("Receiver changed", reply.getReceiver(), is(getSender()));
 			mode.verify("Sender not reverted", reply.getSender(), not(getReceiver()));
 			mode.verify("Wrong sender", reply.getSender(), is(getOriginalReceiver()));
+		}
+
+		//
+		// Test framework
+		//
+
+		EditPart getReplyEditPart() {
+			@SuppressWarnings("unchecked")
+			Optional<EditPart> editPart = editor.getDiagramEditPart().getConnections().stream().skip(1)
+					.findFirst();
+			return assuming(editPart, "No execution edit-part created");
+		}
+	}
+
+	public static class MessageSelfWithReply extends MessageNoExecution {
+
+		@Override
+		public int getReleaseX() {
+			return sendX;
+		}
+
+		@Override
+		public int getNewRecvY() {
+			return mesgY + 20;
+		}
+
+		@Override
+		Optional<MLifeline> getReceiver() {
+			return getSender();
+		}
+
+		@Override
+		MLifeline requireReceiver() {
+			return requireLifeline("Lifeline1");
+		}
+
+		@ClassRule
+		public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().createRepliesForSyncCalls();
+
+		@Override
+		protected void switchLifeline(VerificationMode mode) {
+			super.switchLifeline(ASSERT);
+
+			// Verify the new visuals
+			mode.verify(getExecutionEditPart(), isBounded(isNear(getReleaseX(), 5), isNear(getNewRecvY()),
+					is(EXEC_WIDTH), is(EXEC_HEIGHT)));
+
+			// And the semantics
+			MExecution exec = requireExecution();
+			mode.verify("Owner not changed", exec.getOwner(), not(requireOriginalReceiver()));
+			mode.verify("Wrong owner", exec.getOwner(), is(requireReceiver()));
+			MOccurrence<?> finish = verifying(mode, exec.getFinish(), "No finish occurrence");
+			mode.verify("Finish coverage lost", finish.getCovered().isPresent(), is(true));
+			MLifeline covered = finish.getCovered().get();
+			mode.verify("Finish coverage not changed", covered, not(requireOriginalReceiver()));
+			mode.verify("Wrong finish coverage", covered, is(requireReceiver()));
+
+			// check the reply
+			MMessage msg = getReplyMessage();
+			mode.verify("Sender changed", msg.getSender(), is(getSender()));
+			mode.verify("Receiver not changed", msg.getReceiver(), not(getOriginalReceiver()));
+			mode.verify("Wrong receiver", msg.getReceiver(), is(getReceiver()));
+			mode.verify(getReplyEditPart(), runs(getNewRecvX(), getNewRecvY() + EXEC_HEIGHT, getReleaseX(),
+					getNewRecvY() + EXEC_HEIGHT + SELF_MESSAGE_HEIGHT));
+
+		}
+
+		@Override
+		protected void undoSwitchLifeline(VerificationMode mode) {
+			super.undoSwitchLifeline(ASSERT);
+
+			// Verify the old visuals
+			mode.verify(getExecutionEditPart(),
+					isBounded(isNear(getGrabX(), 5), isNear(mesgY), anything(), anything()));
+
+			// And the old semantics
+			MExecution exec = requireExecution();
+			mode.verify("Owner not reverted", exec.getOwner(), is(requireOriginalReceiver()));
+			MOccurrence<?> finish = verifying(mode, exec.getFinish(), "No finish occurrence");
+			mode.verify("Finish coverage lost", finish.getCovered().isPresent(), is(true));
+			MLifeline covered = finish.getCovered().get();
+			mode.verify("Finish coverage not reverted", covered, is(requireOriginalReceiver()));
+		}
+
+		//
+		// Test framework
+		//
+
+		EditPart getExecutionEditPart() {
+			Optional<EditPart> editPart = Optional.of(messageEP).map(ConnectionEditPart.class::cast)
+					.map(ConnectionEditPart::getTarget)
+					.filter(ExecutionSpecificationEditPart.class::isInstance);
+			return assuming(editPart, "No execution edit-part created");
+		}
+
+		@Override
+		int getGrabX() {
+			return super.getGrabX() - (EXEC_WIDTH / 2);
+		}
+
+		@Override
+		int getNewRecvX() {
+			return sendX + (EXEC_WIDTH / 2);
+		}
+
+		//
+		// Test framework
+		//
+
+		EditPart getReplyEditPart() {
+			@SuppressWarnings("unchecked")
+			Optional<EditPart> editPart = editor.getDiagramEditPart().getConnections().stream().skip(1)
+					.findFirst();
+			return assuming(editPart, "No execution edit-part created");
+		}
+	}
+
+	public static class MessageSelfToUnSelfWithReply extends MessageNoExecution {
+
+		@ClassRule
+		public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().createRepliesForSyncCalls();
+
+		@Override
+		protected int getInitialSenderX() {
+			return LIFELINE_1_BODY_X;
+		}
+
+		@Override
+		protected int getInitialSenderY() {
+			return mesgY;
+		}
+
+		@Override
+		protected int getInitialReceiverX() {
+			return LIFELINE_1_BODY_X;
+		}
+
+		@Override
+		protected int getInitialReceiverY() {
+			return mesgY + 20;
+		}
+
+		@Override
+		public int getReleaseX() {
+			return LIFELINE_2_BODY_X;
+		}
+
+		@Override
+		int getGrabX() {
+			return getInitialReceiverX() + (EXEC_WIDTH / 2);
+		}
+
+		@Override
+		int getGrabY() {
+			return getInitialReceiverY();
+		}
+
+		@Override
+		public int getNewRecvY() {
+			return mesgY;
+		}
+
+		@Override
+		int getNewRecvX() {
+			return LIFELINE_2_BODY_X - (EXEC_WIDTH / 2);
+		}
+
+		@Override
+		MLifeline requireReceiver() {
+			return requireLifeline("Lifeline2");
+		}
+
+		@Override
+		Optional<MLifeline> getReceiver() {
+			return getLifeline("Lifeline2");
+		}
+
+		@Override
+		Optional<MLifeline> getOriginalReceiver() {
+			return getLifeline("Lifeline1");
+		}
+
+		@Override
+		Optional<MLifeline> getSender() {
+			return getLifeline("Lifeline1");
+		}
+
+		@Override
+		MLifeline requireOriginalReceiver() {
+			return requireLifeline("Lifeline1");
+		}
+
+		@Override
+		protected void switchLifeline(VerificationMode mode) {
+			super.switchLifeline(ASSERT);
+
+			// Verify the new visuals
+			mode.verify(getExecutionEditPart(), isBounded(isNear(getReleaseX(), 5), isNear(getNewRecvY()),
+					is(EXEC_WIDTH), is(EXEC_HEIGHT)));
+
+			// And the semantics
+			MExecution exec = requireExecution();
+			mode.verify("Owner not changed", exec.getOwner(), not(requireOriginalReceiver()));
+			mode.verify("Wrong owner", exec.getOwner(), is(requireReceiver()));
+			MOccurrence<?> finish = verifying(mode, exec.getFinish(), "No finish occurrence");
+			mode.verify("Finish coverage lost", finish.getCovered().isPresent(), is(true));
+			MLifeline covered = finish.getCovered().get();
+			mode.verify("Finish coverage not changed", covered, not(requireOriginalReceiver()));
+			mode.verify("Wrong finish coverage", covered, is(requireReceiver()));
+
+			// check the reply
+			MMessage msg = getReplyMessage();
+			mode.verify("Sender changed", msg.getSender(), is(getReceiver()));
+			mode.verify("Wrong receiver", msg.getReceiver(), is(getSender()));
+			mode.verify(getReplyEditPart(), runs(getNewRecvX(), getNewRecvY() + EXEC_HEIGHT,
+					getInitialReceiverX(), getNewRecvY() + EXEC_HEIGHT));
+
+		}
+
+		@Override
+		protected void undoSwitchLifeline(VerificationMode mode) {
+			super.undoSwitchLifeline(ASSERT);
+
+			// Verify the old visuals
+			mode.verify(getExecutionEditPart(), isBounded(isNear(getGrabX() - EXEC_WIDTH, 5),
+					isNear(getGrabY()), is(EXEC_WIDTH), is(EXEC_HEIGHT)));
+
+			// And the old semantics
+			MExecution exec = requireExecution();
+			mode.verify("Owner not reverted", exec.getOwner(), is(requireOriginalReceiver()));
+			MOccurrence<?> finish = verifying(mode, exec.getFinish(), "No finish occurrence");
+			mode.verify("Finish coverage lost", finish.getCovered().isPresent(), is(true));
+			MLifeline covered = finish.getCovered().get();
+			mode.verify("Finish coverage not reverted", covered, is(requireOriginalReceiver()));
+		}
+
+		//
+		// Test framework
+		//
+
+		EditPart getExecutionEditPart() {
+			Optional<EditPart> editPart = Optional.of(messageEP).map(ConnectionEditPart.class::cast)
+					.map(ConnectionEditPart::getTarget)
+					.filter(ExecutionSpecificationEditPart.class::isInstance);
+			return assuming(editPart, "No execution edit-part created");
 		}
 
 		//
@@ -579,15 +881,160 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 
 	}
 
+	@RunWith(JUnit4.class)
+	public static class ExecutionSwitchLifeline extends LifelineSwitchingUITest {
+
+		@ClassRule
+		public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().createRepliesForSyncCalls();
+
+		@Test
+		public void switchLifeline() {
+			switchLifeline(ASSERT);
+		}
+
+		protected void switchLifeline(VerificationMode mode) {
+			editor.with(editor.allowSemanticReordering(),
+					() -> editor.moveSelection(at(getGrabX(), getGrabY()), at(getReleaseX(), getReleaseY())));
+
+			// Verify the new visuals
+			mode.verify(messageEP, runs(sendX, mesgY, getNewRecvX(), getNewRecvY()));
+
+			// And the semantics
+			MMessage msg = getRequestMessage();
+			mode.verify("Sender changed", msg.getSender(), is(getSender()));
+			mode.verify("Receiver not changed", msg.getReceiver(), not(getOriginalReceiver()));
+			mode.verify("Wrong receiver", msg.getReceiver(), is(getReceiver()));
+
+			mode.verify(getExecutionEditPart(), isBounded(isNear(getReleaseX(), 5), isNear(getNewRecvY()),
+					is(EXEC_WIDTH), is(EXEC_HEIGHT)));
+
+			// And the semantics
+			MExecution exec = requireExecution();
+			mode.verify("Owner not changed", exec.getOwner(), not(requireOriginalReceiver()));
+			mode.verify("Wrong owner", exec.getOwner(), is(requireReceiver()));
+			MOccurrence<?> finish = verifying(mode, exec.getFinish(), "No finish occurrence");
+			mode.verify("Finish coverage lost", finish.getCovered().isPresent(), is(true));
+			MLifeline covered = finish.getCovered().get();
+			mode.verify("Finish coverage not changed", covered, not(requireOriginalReceiver()));
+			mode.verify("Wrong finish coverage", covered, is(requireReceiver()));
+
+			// check the reply
+			MMessage reply = getReplyMessage();
+			mode.verify("Sender changed", reply.getSender(), is(getSender()));
+			mode.verify("Receiver not changed", reply.getReceiver(), not(getOriginalReceiver()));
+			mode.verify("Wrong receiver", reply.getReceiver(), is(getReceiver()));
+			mode.verify(getReplyEditPart(), runs(getNewRecvX(), getNewRecvY() + EXEC_HEIGHT, getReleaseX(),
+					getNewRecvY() + EXEC_HEIGHT + SELF_MESSAGE_HEIGHT));
+		}
+
+		@Override
+		public void createMessage() {
+			messageEP = createConnection(getMessageType(), at(getInitialSenderX(), getInitialSenderY()),
+					at(getInitialReceiverX(), getInitialReceiverY()));
+		}
+
+		@Override
+		int getNewRecvX() {
+			return sendX + EXEC_WIDTH / 2;
+		}
+
+		@Override
+		int getNewRecvY() {
+			return mesgY + 20;
+		}
+
+		@Override
+		int getGrabX() {
+			return super.getGrabX();
+		}
+
+		@Override
+		int getGrabY() {
+			return mesgY + EXEC_HEIGHT / 2;
+		}
+
+		@Override
+		public int getReleaseY() {
+			return getGrabY();
+		}
+
+		@Override
+		public int getReleaseX() {
+			return sendX;
+		}
+
+		@Override
+		Optional<MLifeline> getReceiver() {
+			return getLifeline("Lifeline1");
+		}
+
+		@Override
+		MLifeline requireReceiver() {
+			return requireLifeline("Lifeline1");
+		}
+
+		//
+		// Test framework
+		//
+
+		EditPart getExecutionEditPart() {
+			Optional<EditPart> editPart = Optional.of(messageEP).map(ConnectionEditPart.class::cast)
+					.map(ConnectionEditPart::getTarget)
+					.filter(ExecutionSpecificationEditPart.class::isInstance);
+			return assuming(editPart, "No execution edit-part created");
+		}
+
+		EditPart getReplyEditPart() {
+			@SuppressWarnings("unchecked")
+			Optional<EditPart> editPart = editor.getDiagramEditPart().getConnections().stream().skip(1)
+					.findFirst();
+			return assuming(editPart, "No execution edit-part created");
+		}
+
+	}
 	//
 	// Test framework
 	//
 
 	@Before
 	public void createMessage() {
-		messageEP = createConnection(getMessageType(), at(sendX, mesgY), at(recvX, mesgY));
+		messageEP = createConnection(getMessageType(), at(getInitialSenderX(), getInitialSenderY()),
+				at(getInitialReceiverX(), getInitialReceiverY()));
 
-		assumeThat(messageEP, runs(sendX, mesgY, getGrabX(), mesgY));
+		if (moveTarget()) {
+			assumeThat(messageEP, runs(getInitialSenderX(), getInitialSenderY(), getGrabX(), getGrabY()));
+		} else {
+			assumeThat(messageEP, runs(getGrabX(), getGrabY(), getInitialReceiverX(), getInitialReceiverY()));
+		}
+
+	}
+
+	protected boolean moveTarget() {
+		return true;
+	}
+
+	protected int getInitialReceiverY() {
+		return mesgY;
+	}
+
+	protected int getInitialReceiverX() {
+		return recvX;
+	}
+
+	protected int getInitialSenderY() {
+		return mesgY;
+	}
+
+	protected int getInitialSenderX() {
+		return sendX;
+	}
+
+	public int getReleaseX() {
+		return newRecvX;
+	}
+
+	public int getReleaseY() {
+		return mesgY;
 	}
 
 	IElementType getMessageType() {
@@ -598,8 +1045,16 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		return recvX;
 	}
 
+	int getGrabY() {
+		return mesgY;
+	}
+
 	int getNewRecvX() {
 		return newRecvX;
+	}
+
+	int getNewRecvY() {
+		return mesgY;
 	}
 
 	MInteraction getInteraction() {

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageExecutionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageExecutionUITest.java
@@ -29,6 +29,7 @@ import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.infra.gmfdiag.common.utils.DiagramEditPartsUtil;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
@@ -39,14 +40,13 @@ import org.eclipse.uml2.uml.OccurrenceSpecification;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 /**
- * Integration test cases for disconnection of messages from execution
- * specification start/finish.
+ * Integration test cases for disconnection of messages from execution specification start/finish.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
 @ModelResource("two-lifelines.di")
 @Maximized
 public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
@@ -55,19 +55,25 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().createExecutionsForSyncMessages()
 			.createRepliesForSyncCalls();
 
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
+
 	// Horizontal position of the first lifeline's body
 	private static final int LL1_BODY_X = 121;
 
 	// Horizontal position of the second lifeline's body
 	private static final int LL2_BODY_X = 281;
 
-	private static final int EXEC_WIDTH = 10;
-
 	private EditPart requestEP;
+
 	private Message request;
+
 	private EditPart execEP;
+
 	private ExecutionSpecification exec;
+
 	private EditPart replyEP;
+
 	private Message reply;
 
 	/**
@@ -146,8 +152,8 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 
 		editor.drag(grabAt, dropStart);
 
-		assertThat("Request message not moved", requestEP, runs(LL1_BODY_X, dropStart.y,
-				LL2_BODY_X - (EXEC_WIDTH / 2), dropStart.y, RESIZE_TOLERANCE));
+		assertThat("Request message not moved", requestEP,
+				runs(LL1_BODY_X, dropStart.y, LL2_BODY_X - (EXEC_WIDTH / 2), dropStart.y, RESIZE_TOLERANCE));
 
 		int oldBottom = execBounds.bottom();
 		execBounds.setY(dropStart.y);
@@ -171,8 +177,7 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 				LL1_BODY_X, dropFinish.y, RESIZE_TOLERANCE));
 
 		execBounds.setHeight(dropFinish.y - execBounds.y);
-		assertThat("Execution not moved or resized", execEP,
-				isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
+		assertThat("Execution not moved or resized", execEP, isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
 	}
 
 	@Test
@@ -197,8 +202,7 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat("Execution not moved/resized", execEP, isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
 
 		MessageEnd requestRecv = request.getReceiveEvent();
-		assertThat("Incorrect semantic ordering", exec.getStart(),
-				editor.semanticallyPrecedes(requestRecv));
+		assertThat("Incorrect semantic ordering", exec.getStart(), editor.semanticallyPrecedes(requestRecv));
 	}
 
 	@Test
@@ -218,8 +222,7 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 				runs(LL2_BODY_X - (EXEC_WIDTH / 2), msgY, LL1_BODY_X, msgY, RESIZE_TOLERANCE));
 
 		execBounds.setHeight(dropFinish.y - execBounds.y);
-		assertThat("Execution not moved or resized", execEP,
-				isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
+		assertThat("Execution not moved or resized", execEP, isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
 
 		MessageEnd replySend = reply.getSendEvent();
 		assertThat("Incorrect semantic ordering", exec.getFinish(), editor.semanticallyFollows(replySend));
@@ -235,25 +238,23 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 				at(LL2_BODY_X, 200));
 		assumeThat("Request message not created", requestEP, notNullValue());
 
-		request = (Message) requestEP.getAdapter(EObject.class);
+		request = (Message)requestEP.getAdapter(EObject.class);
 
-		exec = ((OccurrenceSpecification) request.getReceiveEvent()).getCovered().getCoveredBys().stream()
+		exec = ((OccurrenceSpecification)request.getReceiveEvent()).getCovered().getCoveredBys().stream()
 				.filter(ExecutionSpecification.class::isInstance).map(ExecutionSpecification.class::cast)
 				.findFirst().orElse(null);
-		execEP = (exec == null)
-				? null
+		execEP = (exec == null) ? null
 				: DiagramEditPartsUtil.getChildByEObject(exec, editor.getDiagramEditPart(), false);
 		assumeThat("Execution not created", execEP, notNullValue());
 
-		reply = ((MessageEnd) exec.getFinish()).getMessage();
-		replyEP = (reply == null)
-				? null
+		reply = ((MessageEnd)exec.getFinish()).getMessage();
+		replyEP = (reply == null) ? null
 				: DiagramEditPartsUtil.getChildByEObject(reply, editor.getDiagramEditPart(), true);
 		assumeThat("Reply message not created", replyEP, notNullValue());
 	}
 
 	static Point getMessageGrabPoint(EditPart editPart) {
-		Connection connection = (Connection) ((ConnectionEditPart) editPart).getFigure();
+		Connection connection = (Connection)((ConnectionEditPart)editPart).getFigure();
 		return connection.getPoints().getMidpoint();
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageReconnectionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageReconnectionUITest.java
@@ -22,30 +22,35 @@ import java.util.Arrays;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineBodyGraphicalNodeEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy}
- * class's message re-connection behaviour.
+ * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy} class's message re-connection
+ * behaviour.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
 @ModelResource("two-lifelines.di")
 @Maximized
 @RunWith(Parameterized.class)
 public class MessageReconnectionUITest extends AbstractGraphicalEditPolicyUITest {
-	
+
 	@ClassRule
-	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().dontCreateExecutionsForSyncMessages();
-	
+	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
+			.dontCreateExecutionsForSyncMessages();
+
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
+
 	// Horizontal position of the first lifeline's body
 	private static final int LIFELINE_1_BODY_X = 121;
 
@@ -64,6 +69,19 @@ public class MessageReconnectionUITest extends AbstractGraphicalEditPolicyUITest
 
 	/**
 	 * Initializes me.
+	 * 
+	 * @param rightToLeft
+	 *            whether to draw the message from right to left (otherwise, left to right)
+	 * @param direction
+	 *            human-presentable representation of the {@code rightToLeft} parameter
+	 * @param moveSource
+	 *            whether the move the source end of the message (otherwise, the target)
+	 * @param whichEnd
+	 *            human-presentable representation of the {@code moveSource} parameter
+	 * @param rightToLeft
+	 *            whether to move the message end down in the diagram (otherwise, up)
+	 * @param whichWay
+	 *            human-presentable representation of the {@code moveDown} parameter
 	 */
 	public MessageReconnectionUITest(boolean rightToLeft, String direction, boolean moveSource,
 			String whichEnd, boolean moveDown, String whichWay) {
@@ -134,8 +152,7 @@ public class MessageReconnectionUITest extends AbstractGraphicalEditPolicyUITest
 
 		editor.moveSelection(at(x, INITIAL_Y), at(x, y));
 
-		assertThat("Was able to move sync message end", messageEP,
-				runs(sendX, INITIAL_Y, recvX, INITIAL_Y));
+		assertThat("Was able to move sync message end", messageEP, runs(sendX, INITIAL_Y, recvX, INITIAL_Y));
 	}
 
 	//
@@ -145,14 +162,14 @@ public class MessageReconnectionUITest extends AbstractGraphicalEditPolicyUITest
 	@Parameters(name = "{1}, {3}, {5}")
 	public static Iterable<Object[]> parameters() {
 		return Arrays.asList(new Object[][] { //
-				{ false, "left-to-right", false, "target", false, "up" }, //
-				{ false, "left-to-right", false, "target", true, "down" }, //
-				{ false, "left-to-right", true, "source", false, "up" }, //
-				{ false, "left-to-right", true, "source", true, "down" }, //
-				{ true, "right-to-left", false, "target", false, "up" }, //
-				{ true, "right-to-left", false, "target", true, "down" }, //
-				{ true, "right-to-left", true, "source", false, "up" }, //
-				{ true, "right-to-left", true, "source", true, "down" }, //
+				{false, "left-to-right", false, "target", false, "up" }, //
+				{false, "left-to-right", false, "target", true, "down" }, //
+				{false, "left-to-right", true, "source", false, "up" }, //
+				{false, "left-to-right", true, "source", true, "down" }, //
+				{true, "right-to-left", false, "target", false, "up" }, //
+				{true, "right-to-left", false, "target", true, "down" }, //
+				{true, "right-to-left", true, "source", false, "up" }, //
+				{true, "right-to-left", true, "source", true, "down" }, //
 		});
 	}
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageCreationUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageCreationUITest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeThat;
 
 import java.util.Arrays;
 
@@ -30,6 +31,7 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.ExecutionSpecificationEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.MessageEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.util.MessageUtil;
@@ -39,6 +41,7 @@ import org.eclipse.uml2.uml.MessageSort;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -56,6 +59,9 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 	@ClassRule
 	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
 			.dontCreateExecutionsForSyncMessages();
+
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
 
 	// Horizontal position of the first lifeline's body
 	private static final int LIFELINE_1_BODY_X = 121;
@@ -132,6 +138,12 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 				}
 				break;
 			default:
+				if (messageEP == null) {
+					assumeThat("Should fail to get a message edit-part only for create message", messageSort,
+							equalTo(MessageSort.CREATE_MESSAGE_LITERAL));
+					return; // Unreachable
+				}
+
 				if (mode != CreationMode.WITH_EXECUTION) {
 					assertThat(messageEP, runs(x(), top(), x(), bottom(), 2));
 				} else {

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageCreationUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageCreationUITest.java
@@ -12,20 +12,29 @@
 
 package org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.tests;
 
+import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.isBounded;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.EditParts.runs;
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.EditorFixture.at;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gmf.runtime.emf.type.core.IElementType;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.ExecutionSpecificationEditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.MessageEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.util.MessageUtil;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageSort;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -79,6 +88,7 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 		this.mode = mode;
 		messageX = mode == CreationMode.ON_EXECUTION ? LIFELINE_2_BODY_X : LIFELINE_1_BODY_X;
 		messageY = Y_POSITION + (mode.isTall() ? CUSTOM_SPAN : 0);
+
 	}
 
 	@Test
@@ -124,7 +134,22 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 			default:
 				if (mode != CreationMode.WITH_EXECUTION) {
 					assertThat(messageEP, runs(x(), top(), x(), bottom(), 2));
-				} // TODO: Assert the self-message shape with execution when we draw it properly
+				} else {
+					// messageEP is the sync message.
+					assertThat(messageEP, runs(x(), top(), x() + 5, bottom()));
+
+					// then find the execution linked to this message
+					assertThat(messageEP, instanceOf(MessageEditPart.class));
+					EditPart executionEP = ((MessageEditPart)messageEP).getTarget();
+					assertThat(executionEP, instanceOf(ExecutionSpecificationEditPart.class));
+					assertThat(executionEP, isBounded(x() - 5, bottom(), 10, 40)); // default sizes
+					ConnectionEditPart replyEP = (ConnectionEditPart)((ExecutionSpecificationEditPart)executionEP)
+							.getSourceConnections().get(0);
+					EObject reply = ((View)replyEP.getModel()).getElement();
+					assertThat(reply, instanceOf(Message.class));
+					assertThat(((Message)reply).getMessageSort(), equalTo(MessageSort.REPLY_LITERAL));
+					assertThat(replyEP, runs(x() + 5, bottom() + 40, x(), bottom() + 40 + MINIMUM_SPAN));
+				}
 
 				break;
 		}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageReconnectionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageReconnectionUITest.java
@@ -67,11 +67,13 @@ public class SelfMessageReconnectionUITest extends AbstractGraphicalEditPolicyUI
 	private static final int LIFELINE_2_BODY_X = 281;
 
 	private static final int SEND_Y = 195;
+
 	private static final int RECV_Y = SEND_Y + 20;
 
 	private static final int SELF_MESSAGE_WIDTH = 40;
 
 	private final MessageSort messageSort;
+
 	private final ReconnectionMode reconnectionMode;
 
 	private EditPart messageEP;
@@ -97,55 +99,55 @@ public class SelfMessageReconnectionUITest extends AbstractGraphicalEditPolicyUI
 		Modifiers modifiers = editor.unmodified();
 
 		switch (reconnectionMode) {
-		case SLIDE_SEND_UP:
-			grabY = SEND_Y;
-			dropX = LIFELINE_1_BODY_X;
-			delta = -10;
-			dropY = SEND_Y + delta;
-			break;
-		case SLIDE_SEND_DOWN:
-			grabY = SEND_Y;
-			dropX = LIFELINE_1_BODY_X;
-			dropY = SEND_Y + delta;
-			break;
-		case SLIDE_RECEIVE_UP:
-			dropX = LIFELINE_1_BODY_X;
-			delta = -10;
-			dropY = RECV_Y + delta;
-			break;
-		case SLIDE_RECEIVE_DOWN:
-			dropX = LIFELINE_1_BODY_X;
-			dropY = RECV_Y + delta;
-			break;
-		case MOVE_UP:
-			// Grab the spine of the message
-			grabX = LIFELINE_1_BODY_X + SELF_MESSAGE_WIDTH;
-			grabY = (SEND_Y + RECV_Y) / 2;
-			dropX = grabX;
-			delta = -10;
-			dropY = grabY + delta;
-			break;
-		case MOVE_DOWN:
-			// Grab the spine of the message
-			grabX = LIFELINE_1_BODY_X + SELF_MESSAGE_WIDTH;
-			grabY = (SEND_Y + RECV_Y) / 2;
-			dropX = grabX;
-			dropY = grabY + delta;
-			break;
-		case RECEIVE_ON_OTHER_LIFELINE:
-			dropX = LIFELINE_2_BODY_X;
-			dropY = RECV_Y;
-			modifiers = editor.allowSemanticReordering();
-			break;
-		case RECEIVE_ON_SENDING_LIFELINE:
-			grabX = LIFELINE_2_BODY_X - 5;
-			grabY = SEND_Y + (isSynchronous(messageSort) ? 0 : 15);
-			dropX = LIFELINE_1_BODY_X;
-			dropY = SEND_Y; // The editor should enforce the minimum gap
-			modifiers = editor.allowSemanticReordering();
-			break;
-		default:
-			throw new IllegalStateException("Unsupported reconnection mode: " + reconnectionMode);
+			case SLIDE_SEND_UP:
+				grabY = SEND_Y;
+				dropX = LIFELINE_1_BODY_X;
+				delta = -10;
+				dropY = SEND_Y + delta;
+				break;
+			case SLIDE_SEND_DOWN:
+				grabY = SEND_Y;
+				dropX = LIFELINE_1_BODY_X;
+				dropY = SEND_Y + delta;
+				break;
+			case SLIDE_RECEIVE_UP:
+				dropX = LIFELINE_1_BODY_X;
+				delta = -10;
+				dropY = RECV_Y + delta;
+				break;
+			case SLIDE_RECEIVE_DOWN:
+				dropX = LIFELINE_1_BODY_X;
+				dropY = RECV_Y + delta;
+				break;
+			case MOVE_UP:
+				// Grab the spine of the message
+				grabX = LIFELINE_1_BODY_X + SELF_MESSAGE_WIDTH;
+				grabY = (SEND_Y + RECV_Y) / 2;
+				dropX = grabX;
+				delta = -10;
+				dropY = grabY + delta;
+				break;
+			case MOVE_DOWN:
+				// Grab the spine of the message
+				grabX = LIFELINE_1_BODY_X + SELF_MESSAGE_WIDTH;
+				grabY = (SEND_Y + RECV_Y) / 2;
+				dropX = grabX;
+				dropY = grabY + delta;
+				break;
+			case RECEIVE_ON_OTHER_LIFELINE:
+				dropX = LIFELINE_2_BODY_X;
+				dropY = RECV_Y;
+				modifiers = editor.allowSemanticReordering();
+				break;
+			case RECEIVE_ON_SENDING_LIFELINE:
+				grabX = LIFELINE_2_BODY_X - 5;
+				grabY = SEND_Y + (isSynchronous(messageSort) ? 0 : 15);
+				dropX = LIFELINE_1_BODY_X;
+				dropY = SEND_Y; // The editor should enforce the minimum gap
+				modifiers = editor.allowSemanticReordering();
+				break;
+			default:
+				throw new IllegalStateException("Unsupported reconnection mode: " + reconnectionMode);
 		}
 
 		Point grabAt = at(grabX, grabY);
@@ -153,61 +155,59 @@ public class SelfMessageReconnectionUITest extends AbstractGraphicalEditPolicyUI
 		editor.with(modifiers, () -> editor.moveSelection(grabAt, dropAt));
 
 		switch (reconnectionMode) {
-		case SLIDE_SEND_UP:
-			if (async) {
-				assertThat("Send end not moved as expected", messageEP,
-						runs(sendX(), dropY, recvX(), RECV_Y, 2));
-			} else {
-				assertThat("Synchronous message was reshaped", messageEP,
-						runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
-			}
-			break;
-		case SLIDE_SEND_DOWN:
-		case SLIDE_RECEIVE_UP:
-			if (async) {
-				assertThat("Minimum gap not maintained", messageEP,
-						runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
-			} else {
-				assertThat("Synchronous message was reshaped", messageEP,
-						runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
-			}
-			break;
-		case SLIDE_RECEIVE_DOWN:
-			if (async) {
-				assertThat("Receive end not moved as expected", messageEP,
-						runs(sendX(), SEND_Y, recvX(), dropY, 2));
-			} else {
-				assertThat("Synchronous message was reshaped", messageEP,
-						runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
-			}
-			break;
-		case MOVE_UP:
-		case MOVE_DOWN:
-			assertThat("Message not moved as expected", messageEP,
-					runs(sendX(), SEND_Y + delta, recvX(), RECV_Y + delta, 2));
-			break;
-		case RECEIVE_ON_OTHER_LIFELINE: {
-			assertThat("Lifeline and slope incorrect", messageEP, runs(sendX(), SEND_Y, recvX(),
-					// Async messages may slope; others snap to horizontal
-					async ? RECV_Y : SEND_Y, 2));
+			case SLIDE_SEND_UP:
+				if (async) {
+					assertThat("Send end not moved as expected", messageEP,
+							runs(sendX(), dropY, recvX(), RECV_Y, 2));
+				} else {
+					assertThat("Synchronous message was reshaped", messageEP,
+							runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
+				}
+				break;
+			case SLIDE_SEND_DOWN:
+			case SLIDE_RECEIVE_UP:
+				if (async) {
+					assertThat("Minimum gap not maintained", messageEP,
+							runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
+				} else {
+					assertThat("Synchronous message was reshaped", messageEP,
+							runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
+				}
+				break;
+			case SLIDE_RECEIVE_DOWN:
+				if (async) {
+					assertThat("Receive end not moved as expected", messageEP,
+							runs(sendX(), SEND_Y, recvX(), dropY, 2));
+				} else {
+					assertThat("Synchronous message was reshaped", messageEP,
+							runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
+				}
+				break;
+			case MOVE_UP:
+			case MOVE_DOWN:
+				assertThat("Message not moved as expected", messageEP,
+						runs(sendX(), SEND_Y + delta, recvX(), RECV_Y + delta, 2));
+				break;
+			case RECEIVE_ON_OTHER_LIFELINE: {
+				assertThat("Lifeline and slope incorrect", messageEP, runs(sendX(), SEND_Y, recvX(),
+						// Async messages may slope; others snap to horizontal
+						async ? RECV_Y : SEND_Y, 2));
 
-			Routing routing = getRouting(messageEP);
-			assertThat("Lifeline is not oblique", routing, is(Routing.MANUAL_LITERAL));
-			RelativeBendpoints bendpoints = getBendpoints(messageEP);
-			assertThat("Message has bendpoints", (List<?>) bendpoints.getPoints(),
-					not(hasItem(anything())));
-			break;
-		}
-		case RECEIVE_ON_SENDING_LIFELINE: {
-			assertThat("Self-message send and receive not separate by correct gap", messageEP,
-					runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
+				Routing routing = getRouting(messageEP);
+				assertThat("Lifeline is not oblique", routing, is(Routing.MANUAL_LITERAL));
+				RelativeBendpoints bendpoints = getBendpoints(messageEP);
+				assertThat("Message has bendpoints", (List<?>)bendpoints.getPoints(),
+						not(hasItem(anything())));
+				break;
+			}
+			case RECEIVE_ON_SENDING_LIFELINE: {
+				assertThat("Self-message send and receive not separate by correct gap", messageEP,
+						runs(sendX(), SEND_Y, recvX(), RECV_Y, 2));
 
-			Routing routing = getRouting(messageEP);
-			assertThat("Lifeline is not rectilinear", routing, is(Routing.RECTILINEAR_LITERAL));
-			RelativeBendpoints bendpoints = getBendpoints(messageEP);
-			assertThat("Wrong number of message bendpoints", bendpoints.getPoints().size(), is(4));
-			break;
-		}
+				Routing routing = getRouting(messageEP);
+				assertThat("Lifeline is not rectilinear", routing, is(Routing.RECTILINEAR_LITERAL));
+				break;
+			}
 		}
 	}
 
@@ -223,7 +223,7 @@ public class SelfMessageReconnectionUITest extends AbstractGraphicalEditPolicyUI
 		for (MessageSort sort : Arrays.asList(MessageSort.SYNCH_CALL_LITERAL,
 				MessageSort.ASYNCH_CALL_LITERAL)) {
 			for (ReconnectionMode mode : ReconnectionMode.values()) {
-				result.add(new Object[] { sort, mode });
+				result.add(new Object[] {sort, mode });
 			}
 		}
 
@@ -234,23 +234,22 @@ public class SelfMessageReconnectionUITest extends AbstractGraphicalEditPolicyUI
 	public void createMessage() {
 		IElementType type = SequenceElementTypes.getMessageType(messageSort);
 		switch (reconnectionMode) {
-		default: // the majority of cases are self-messages
-			// Drop connection at the same Y coördinate; the editor adds the internal gap
-			messageEP = createConnection(type, at(LIFELINE_1_BODY_X, SEND_Y),
-					at(LIFELINE_1_BODY_X, SEND_Y));
-			break;
-		case RECEIVE_ON_SENDING_LIFELINE:
-			int receiveY = SEND_Y + (isSynchronous(messageSort) ? 0 : 15);
-			messageEP = createConnection(type, at(LIFELINE_1_BODY_X, SEND_Y),
-					at(LIFELINE_2_BODY_X, receiveY));
-			break;
+			default: // the majority of cases are self-messages
+				// Drop connection at the same Y coördinate; the editor adds the internal gap
+				messageEP = createConnection(type, at(LIFELINE_1_BODY_X, SEND_Y),
+						at(LIFELINE_1_BODY_X, SEND_Y));
+				break;
+			case RECEIVE_ON_SENDING_LIFELINE:
+				int receiveY = SEND_Y + (isSynchronous(messageSort) ? 0 : 15);
+				messageEP = createConnection(type, at(LIFELINE_1_BODY_X, SEND_Y),
+						at(LIFELINE_2_BODY_X, receiveY));
+				break;
 		}
 	}
 
 	/**
-	 * Compute an adjusted {@code x} coördinate from which the message is expected
-	 * to be sent, based whether the send end is on an execution specification or on
-	 * the lifeline stem.
+	 * Compute an adjusted {@code x} coördinate from which the message is expected to be sent, based whether
+	 * the send end is on an execution specification or on the lifeline stem.
 	 *
 	 * @return the adjusted send end X coördinate
 	 */
@@ -259,27 +258,26 @@ public class SelfMessageReconnectionUITest extends AbstractGraphicalEditPolicyUI
 	}
 
 	/**
-	 * Compute an adjusted {@code x} coördinate at which the message is expected to
-	 * be received, based whether the receive end is on an execution specification
-	 * or on the lifeline stem.
+	 * Compute an adjusted {@code x} coördinate at which the message is expected to be received, based whether
+	 * the receive end is on an execution specification or on the lifeline stem.
 	 *
 	 * @return the adjusted receive end X coördinate
 	 */
 	int recvX() {
 		switch (reconnectionMode) {
-		default: // the majority of cases are self-messages
-			return LIFELINE_1_BODY_X;
-		case RECEIVE_ON_OTHER_LIFELINE:
-			return LIFELINE_2_BODY_X - 5;
+			default: // the majority of cases are self-messages
+				return LIFELINE_1_BODY_X;
+			case RECEIVE_ON_OTHER_LIFELINE:
+				return LIFELINE_2_BODY_X - 5;
 		}
 	}
 
 	Routing getRouting(EditPart editPart) {
-		return ((Connector) editPart.getModel()).getRouting();
+		return ((Connector)editPart.getModel()).getRouting();
 	}
 
 	RelativeBendpoints getBendpoints(EditPart editPart) {
-		return Optional.ofNullable(((Connector) editPart.getModel()).getBendpoints())
+		return Optional.ofNullable(((Connector)editPart.getModel()).getBendpoints())
 				.filter(RelativeBendpoints.class::isInstance).map(RelativeBendpoints.class::cast)
 				.orElse(null);
 	}
@@ -304,8 +302,8 @@ public class SelfMessageReconnectionUITest extends AbstractGraphicalEditPolicyUI
 		/** Re-connect a receiving end of a self-message to some other lifeline. */
 		RECEIVE_ON_OTHER_LIFELINE,
 		/**
-		 * Re-connect the receiving end of a message between two lifelines to the
-		 * sending lifeline, to make it a self-message.
+		 * Re-connect the receiving end of a message between two lifelines to the sending lifeline, to make it
+		 * a self-message.
 		 */
 		RECEIVE_ON_SENDING_LIFELINE;
 	}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-self.di
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-self.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-self.notation
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-self.notation
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_ch1tgAUpEemuyflIUac6iQ" type="LightweightSequenceDiagram" name="execution-self" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_ch1tgQUpEemuyflIUac6iQ" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_ch1tggUpEemuyflIUac6iQ" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_ch1tgwUpEemuyflIUac6iQ" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_dRsdIAUpEemuyflIUac6iQ" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_dRsdIQUpEemuyflIUac6iQ" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_dRsdIgUpEemuyflIUac6iQ" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_dRsdIwUpEemuyflIUac6iQ" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_eR1EcAUpEemuyflIUac6iQ" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="execution-self.uml#_eR0dZQUpEemuyflIUac6iQ"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eR1EcQUpEemuyflIUac6iQ" x="-4" y="61" width="10" height="40"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_dRsdJAUpEemuyflIUac6iQ" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="execution-self.uml#_dQaDsAUpEemuyflIUac6iQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dRsdJQUpEemuyflIUac6iQ" x="68" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ch1thAUpEemuyflIUac6iQ" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_ch1thQUpEemuyflIUac6iQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_ch1thgUpEemuyflIUac6iQ"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_ch1thwUpEemuyflIUac6iQ" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="execution-self.uml#_chsjkAUpEemuyflIUac6iQ"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="execution-self.uml#_chsjkAUpEemuyflIUac6iQ"/>
+  <edges xmi:type="notation:Connector" xmi:id="_eR0dYAUpEemuyflIUac6iQ" type="Edge_Message" source="_dRsdIwUpEemuyflIUac6iQ" target="_eR1EcAUpEemuyflIUac6iQ" routing="Rectilinear">
+    <children xmi:type="notation:DecorationNode" xmi:id="_eR0dYQUpEemuyflIUac6iQ" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="execution-self.uml#_eRz2UgUpEemuyflIUac6iQ"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eR0dYgUpEemuyflIUac6iQ"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eR0dYwUpEemuyflIUac6iQ" id="41"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eR0dZAUpEemuyflIUac6iQ" id="start"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_eR1rgAUpEemuyflIUac6iQ" type="Edge_Message" source="_eR1EcAUpEemuyflIUac6iQ" target="_dRsdIwUpEemuyflIUac6iQ" routing="Rectilinear">
+    <children xmi:type="notation:DecorationNode" xmi:id="_eR1rgQUpEemuyflIUac6iQ" type="Edge_Message_Name"/>
+    <element xmi:type="uml:Message" href="execution-self.uml#_eR1EdAUpEemuyflIUac6iQ"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eR1rggUpEemuyflIUac6iQ"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eR1rgwUpEemuyflIUac6iQ" id="end"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eR1rhAUpEemuyflIUac6iQ" id="121"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-self.uml
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/execution-self.uml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_chcE4AUpEemuyflIUac6iQ" name="execution-self">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_clKHQAUpEemuyflIUac6iQ">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_chsjkAUpEemuyflIUac6iQ" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_dQaDsAUpEemuyflIUac6iQ" name="Lifeline1" coveredBy="_eRz2UAUpEemuyflIUac6iQ _eRz2UQUpEemuyflIUac6iQ _eR0dZQUpEemuyflIUac6iQ _eR1EcgUpEemuyflIUac6iQ _eR1EcwUpEemuyflIUac6iQ"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_eRz2UAUpEemuyflIUac6iQ" name="s-request" covered="_dQaDsAUpEemuyflIUac6iQ" message="_eRz2UgUpEemuyflIUac6iQ"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_eRz2UQUpEemuyflIUac6iQ" name="r-request" covered="_dQaDsAUpEemuyflIUac6iQ" message="_eRz2UgUpEemuyflIUac6iQ"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_eR0dZQUpEemuyflIUac6iQ" name="Execution1" covered="_dQaDsAUpEemuyflIUac6iQ" finish="_eR1EcgUpEemuyflIUac6iQ" start="_eRz2UQUpEemuyflIUac6iQ"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_eR1EcgUpEemuyflIUac6iQ" name="s-reply" covered="_dQaDsAUpEemuyflIUac6iQ" message="_eR1EdAUpEemuyflIUac6iQ"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_eR1EcwUpEemuyflIUac6iQ" name="r-reply" covered="_dQaDsAUpEemuyflIUac6iQ" message="_eR1EdAUpEemuyflIUac6iQ"/>
+    <message xmi:type="uml:Message" xmi:id="_eRz2UgUpEemuyflIUac6iQ" name="request" receiveEvent="_eRz2UQUpEemuyflIUac6iQ" sendEvent="_eRz2UAUpEemuyflIUac6iQ"/>
+    <message xmi:type="uml:Message" xmi:id="_eR1EdAUpEemuyflIUac6iQ" name="reply" messageSort="reply" receiveEvent="_eR1EcwUpEemuyflIUac6iQ" sendEvent="_eR1EcgUpEemuyflIUac6iQ"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/EditorFixture.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/tests/rules/EditorFixture.java
@@ -46,6 +46,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartViewer;
 import org.eclipse.gef.Request;
@@ -451,6 +452,8 @@ public class EditorFixture extends ModelFixture.Edit {
 			return null;
 		}
 
+		forceRefresh();
+
 		// Find the new edit-part
 		assertThat("No unsepecified-type request", request[0], notNullValue());
 		CreateConnectionViewAndElementRequest createRequest = (CreateConnectionViewAndElementRequest)request[0]
@@ -461,6 +464,15 @@ public class EditorFixture extends ModelFixture.Edit {
 		EditPart result = (EditPart)getDiagramEditPart().getViewer().getEditPartRegistry().get(createdView);
 		assertThat("New edit-part not found", result, notNullValue());
 		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	public void forceRefresh() {
+		getDiagramEditPart().getConnections().stream().map(ConnectionEditPart.class::cast)
+				.forEach(cep -> ((ConnectionEditPart)cep).getFigure().invalidate());
+		getDiagramEditPart().getConnections().stream().map(ConnectionEditPart.class::cast)
+				.forEach(cep -> ((ConnectionEditPart)cep).getFigure().validate());
+		getDiagramEditPart().refresh();
 	}
 
 	/**
@@ -611,6 +623,8 @@ public class EditorFixture extends ModelFixture.Edit {
 		tool.mouseUp(new MouseEvent(mouse), viewer);
 
 		flushDisplayEvents();
+
+		forceRefresh();
 	}
 
 	/**


### PR DESCRIPTION
- update the self router to not use bendpoints
- update feedback to switch from self to oblique and vice versa
- update management of start/end messages for execution specifications
- add some tests for self messages corner cases
- add some (weird) refresh method for tests, to get them green on remote
build. working fine locally PDE and maven, but not on remote build
server
- update anchors on executions to manage automatically the sides.

Change-Id: Ieb479d5b1109c4f4b4a76c0df5e45b48c73192d2
Signed-off-by: Remi Schnekenburger <rschnekenburger@eclipsesource.com>