### PR TITLE
Issue #389: Fix test assumption violations on Mac

### DIFF
--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionSpecificationDragEditPolicyUITest.java
@@ -278,6 +278,9 @@ public class ExecutionSpecificationDragEditPolicyUITest {
 		@Rule
 		public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
 
+		@ClassRule
+		public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
+
 		@AutoFixture("exec1")
 		private ExecutionSpecification exec;
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionWithSelfMoveUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/ExecutionWithSelfMoveUITest.java
@@ -21,6 +21,7 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPart;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
@@ -29,8 +30,10 @@ import org.eclipse.uml2.uml.ExecutionSpecification;
 import org.eclipse.uml2.uml.Lifeline;
 import org.eclipse.uml2.uml.Message;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 /**
  * UI test for moving executions with self start / finish messages.
@@ -38,6 +41,9 @@ import org.junit.Test;
 @ModelResource("execution-self.di")
 @Maximized
 public class ExecutionWithSelfMoveUITest extends AbstractGraphicalEditPolicyUITest {
+
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
 
 	@Rule
 	public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineBodyGraphicalNodeEditPolicyUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineBodyGraphicalNodeEditPolicyUITest.java
@@ -24,30 +24,34 @@ import java.util.Arrays;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineBodyGraphicalNodeEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.Figures;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy}
- * class.
+ * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy} class.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
 @ModelResource("two-lifelines.di")
 @Maximized
 @RunWith(Parameterized.class)
 public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphicalEditPolicyUITest {
 
 	@ClassRule
-	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().dontCreateExecutionsForSyncMessages();
+	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
+			.dontCreateExecutionsForSyncMessages();
+
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
 
 	// Horizontal position of the first lifeline's body
 	private static final int LIFELINE_1_BODY_X = 121;
@@ -60,7 +64,12 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 	private final int recvX;
 
 	/**
-	 * Initializes me.
+	 * Initializes me with my test parameters.
+	 * 
+	 * @param rightToLeft
+	 *            whether to draw the message from right-to-left (otherwise, left-to-right)
+	 * @param direction
+	 *            human-readable interpretation of the {@code leftToRight} parameter
 	 */
 	public LifelineBodyGraphicalNodeEditPolicyUITest(boolean rightToLeft, String direction) {
 		super();
@@ -76,21 +85,24 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 
 	@Test
 	public void createAsyncMessage() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 125), at(recvX, 125));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 125),
+				at(recvX, 125));
 
 		assertThat(messageEP, runs(sendX, 125, recvX, 125, 2));
 	}
 
 	@Test
 	public void createSlopedAsyncMessage() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 125), at(recvX, 140));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 125),
+				at(recvX, 140));
 
 		assertThat("Message should be sloped", messageEP, runs(sendX, 125, recvX, 140, 2));
 	}
 
 	@Test
 	public void attemptBackwardSlopedAsyncMessage_allowed() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 140), at(recvX, 138));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 140),
+				at(recvX, 138));
 
 		// The target to which the user draw the message should have priority over the
 		// source
@@ -106,7 +118,8 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 
 	@Test
 	public void createCrossedAsyncMessages() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 150), at(recvX, 150));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 150),
+				at(recvX, 150));
 
 		assumeThat(messageEP, runs(sendX, 150, recvX, 150, 2));
 
@@ -117,14 +130,17 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 
 	@Test
 	public void attemptSlopedSyncMessage() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, 115), at(recvX, 130));
+		EditPart messageEP = createConnection(SequenceElementTypes.Sync_Message_Edge, at(sendX, 115),
+				at(recvX, 130));
 
-		assertThat("Message should be horizontal to receive location", messageEP, runs(sendX, 130, recvX, 130, 2));
+		assertThat("Message should be horizontal to receive location", messageEP,
+				runs(sendX, 130, recvX, 130, 2));
 	}
 
 	@Test
 	public void asyncMessageLessThanSlopeThreshold() {
-		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 115), at(recvX, 119));
+		EditPart messageEP = createConnection(SequenceElementTypes.Async_Message_Edge, at(sendX, 115),
+				at(recvX, 119));
 
 		assertThat("Message should be horizontal", messageEP, isHorizontal());
 	}
@@ -172,8 +188,8 @@ public class LifelineBodyGraphicalNodeEditPolicyUITest extends AbstractGraphical
 	@Parameters(name = "{1}")
 	public static Iterable<Object[]> parameters() {
 		return Arrays.asList(new Object[][] { //
-				{ false, "left-to-right" }, //
-				{ true, "right-to-left" }, //
+				{false, "left-to-right" }, //
+				{true, "right-to-left" }, //
 		});
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/LifelineSwitchingUITest.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.PointList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
@@ -47,6 +48,8 @@ import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.Dest
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.ExecutionSpecificationEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixture;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.AutoFixtureRule;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.internal.model.SequenceDiagramPackage;
@@ -64,6 +67,7 @@ import org.eclipse.uml2.uml.Element;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TestRule;
@@ -789,13 +793,46 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 	@ModelResource("execution-busy.di")
 	public static class ExecutionSpanningOccurrences extends MessageNoExecution {
 
-		private static final int LIFELINE_4_BODY_X = 596;
+		@Rule
+		public final AutoFixtureRule autoFixtures = new AutoFixtureRule(this);
 
-		private final int m2Y = 173;
+		@AutoFixture
+		private EditPart requestEP;
 
-		private final int m3Y = 198;
+		@AutoFixture
+		private PointList requestGeom;
 
-		private final int m4Y = 223;
+		@AutoFixture
+		private EditPart m2EP;
+
+		@AutoFixture
+		private PointList m2Geom;
+
+		@AutoFixture
+		private EditPart m3EP;
+
+		@AutoFixture
+		private PointList m3Geom;
+
+		@AutoFixture
+		private EditPart m4EP;
+
+		@AutoFixture
+		private PointList m4Geom;
+
+		@AutoFixture
+		private EditPart replyEP;
+
+		@AutoFixture
+		private PointList replyGeom;
+
+		private int LIFELINE_4_BODY_X;
+
+		private int m2Y;
+
+		private int m3Y;
+
+		private int m4Y;
 
 		@Override
 		protected void switchLifeline(VerificationMode mode) {
@@ -863,19 +900,29 @@ public class LifelineSwitchingUITest extends AbstractGraphicalEditPolicyUITest {
 		@Override
 		public void createMessage() {
 			// The connections all exist already. Just locate the request message
-			MMessage request = requireMessage("request");
-			messageEP = requireEditPart(request);
-			assumeThat(messageEP, runs(sendX, mesgY, getGrabX(), mesgY, 2));
+			messageEP = requestEP;
+			mesgY = requestGeom.getLastPoint().y();
+
+			// Get select geometric parameters
+			LIFELINE_4_BODY_X = m3Geom.getLastPoint().x();
+			m2Y = m2Geom.getLastPoint().y();
+			m3Y = m3Geom.getLastPoint().y();
+			m4Y = m4Geom.getLastPoint().y();
 		}
 
 		@Override
 		int getGrabX() {
-			return super.getGrabX() - (EXEC_WIDTH / 2);
+			return requestGeom.getLastPoint().x();
+		}
+
+		@Override
+		public int getReleaseX() {
+			return m2Geom.getLastPoint().x();
 		}
 
 		@Override
 		int getNewRecvX() {
-			return super.getNewRecvX() - (EXEC_WIDTH / 2);
+			return m2Geom.getLastPoint().x() - (EXEC_WIDTH / 2);
 		}
 
 	}

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageExecutionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageExecutionUITest.java
@@ -29,6 +29,7 @@ import org.eclipse.gef.ConnectionEditPart;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.infra.gmfdiag.common.utils.DiagramEditPartsUtil;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
@@ -39,14 +40,13 @@ import org.eclipse.uml2.uml.OccurrenceSpecification;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 /**
- * Integration test cases for disconnection of messages from execution
- * specification start/finish.
+ * Integration test cases for disconnection of messages from execution specification start/finish.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
 @ModelResource("two-lifelines.di")
 @Maximized
 public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
@@ -55,19 +55,25 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().createExecutionsForSyncMessages()
 			.createRepliesForSyncCalls();
 
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
+
 	// Horizontal position of the first lifeline's body
 	private static final int LL1_BODY_X = 121;
 
 	// Horizontal position of the second lifeline's body
 	private static final int LL2_BODY_X = 281;
 
-	private static final int EXEC_WIDTH = 10;
-
 	private EditPart requestEP;
+
 	private Message request;
+
 	private EditPart execEP;
+
 	private ExecutionSpecification exec;
+
 	private EditPart replyEP;
+
 	private Message reply;
 
 	/**
@@ -146,8 +152,8 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 
 		editor.drag(grabAt, dropStart);
 
-		assertThat("Request message not moved", requestEP, runs(LL1_BODY_X, dropStart.y,
-				LL2_BODY_X - (EXEC_WIDTH / 2), dropStart.y, RESIZE_TOLERANCE));
+		assertThat("Request message not moved", requestEP,
+				runs(LL1_BODY_X, dropStart.y, LL2_BODY_X - (EXEC_WIDTH / 2), dropStart.y, RESIZE_TOLERANCE));
 
 		int oldBottom = execBounds.bottom();
 		execBounds.setY(dropStart.y);
@@ -171,8 +177,7 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 				LL1_BODY_X, dropFinish.y, RESIZE_TOLERANCE));
 
 		execBounds.setHeight(dropFinish.y - execBounds.y);
-		assertThat("Execution not moved or resized", execEP,
-				isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
+		assertThat("Execution not moved or resized", execEP, isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
 	}
 
 	@Test
@@ -197,8 +202,7 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat("Execution not moved/resized", execEP, isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
 
 		MessageEnd requestRecv = request.getReceiveEvent();
-		assertThat("Incorrect semantic ordering", exec.getStart(),
-				editor.semanticallyPrecedes(requestRecv));
+		assertThat("Incorrect semantic ordering", exec.getStart(), editor.semanticallyPrecedes(requestRecv));
 	}
 
 	@Test
@@ -218,8 +222,7 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 				runs(LL2_BODY_X - (EXEC_WIDTH / 2), msgY, LL1_BODY_X, msgY, RESIZE_TOLERANCE));
 
 		execBounds.setHeight(dropFinish.y - execBounds.y);
-		assertThat("Execution not moved or resized", execEP,
-				isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
+		assertThat("Execution not moved or resized", execEP, isBounded(isRect(execBounds, RESIZE_TOLERANCE)));
 
 		MessageEnd replySend = reply.getSendEvent();
 		assertThat("Incorrect semantic ordering", exec.getFinish(), editor.semanticallyFollows(replySend));
@@ -235,25 +238,23 @@ public class MessageExecutionUITest extends AbstractGraphicalEditPolicyUITest {
 				at(LL2_BODY_X, 200));
 		assumeThat("Request message not created", requestEP, notNullValue());
 
-		request = (Message) requestEP.getAdapter(EObject.class);
+		request = (Message)requestEP.getAdapter(EObject.class);
 
-		exec = ((OccurrenceSpecification) request.getReceiveEvent()).getCovered().getCoveredBys().stream()
+		exec = ((OccurrenceSpecification)request.getReceiveEvent()).getCovered().getCoveredBys().stream()
 				.filter(ExecutionSpecification.class::isInstance).map(ExecutionSpecification.class::cast)
 				.findFirst().orElse(null);
-		execEP = (exec == null)
-				? null
+		execEP = (exec == null) ? null
 				: DiagramEditPartsUtil.getChildByEObject(exec, editor.getDiagramEditPart(), false);
 		assumeThat("Execution not created", execEP, notNullValue());
 
-		reply = ((MessageEnd) exec.getFinish()).getMessage();
-		replyEP = (reply == null)
-				? null
+		reply = ((MessageEnd)exec.getFinish()).getMessage();
+		replyEP = (reply == null) ? null
 				: DiagramEditPartsUtil.getChildByEObject(reply, editor.getDiagramEditPart(), true);
 		assumeThat("Reply message not created", replyEP, notNullValue());
 	}
 
 	static Point getMessageGrabPoint(EditPart editPart) {
-		Connection connection = (Connection) ((ConnectionEditPart) editPart).getFigure();
+		Connection connection = (Connection)((ConnectionEditPart)editPart).getFigure();
 		return connection.getPoints().getMidpoint();
 	}
 }

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageReconnectionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/MessageReconnectionUITest.java
@@ -22,30 +22,35 @@ import java.util.Arrays;
 import org.eclipse.gef.EditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.policies.LifelineBodyGraphicalNodeEditPolicy;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy}
- * class's message re-connection behaviour.
+ * Integration test cases for the {@link LifelineBodyGraphicalNodeEditPolicy} class's message re-connection
+ * behaviour.
  *
  * @author Christian W. Damus
  */
-@SuppressWarnings("restriction")
 @ModelResource("two-lifelines.di")
 @Maximized
 @RunWith(Parameterized.class)
 public class MessageReconnectionUITest extends AbstractGraphicalEditPolicyUITest {
-	
+
 	@ClassRule
-	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs().dontCreateExecutionsForSyncMessages();
-	
+	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
+			.dontCreateExecutionsForSyncMessages();
+
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
+
 	// Horizontal position of the first lifeline's body
 	private static final int LIFELINE_1_BODY_X = 121;
 
@@ -64,6 +69,19 @@ public class MessageReconnectionUITest extends AbstractGraphicalEditPolicyUITest
 
 	/**
 	 * Initializes me.
+	 * 
+	 * @param rightToLeft
+	 *            whether to draw the message from right to left (otherwise, left to right)
+	 * @param direction
+	 *            human-presentable representation of the {@code rightToLeft} parameter
+	 * @param moveSource
+	 *            whether the move the source end of the message (otherwise, the target)
+	 * @param whichEnd
+	 *            human-presentable representation of the {@code moveSource} parameter
+	 * @param rightToLeft
+	 *            whether to move the message end down in the diagram (otherwise, up)
+	 * @param whichWay
+	 *            human-presentable representation of the {@code moveDown} parameter
 	 */
 	public MessageReconnectionUITest(boolean rightToLeft, String direction, boolean moveSource,
 			String whichEnd, boolean moveDown, String whichWay) {
@@ -134,8 +152,7 @@ public class MessageReconnectionUITest extends AbstractGraphicalEditPolicyUITest
 
 		editor.moveSelection(at(x, INITIAL_Y), at(x, y));
 
-		assertThat("Was able to move sync message end", messageEP,
-				runs(sendX, INITIAL_Y, recvX, INITIAL_Y));
+		assertThat("Was able to move sync message end", messageEP, runs(sendX, INITIAL_Y, recvX, INITIAL_Y));
 	}
 
 	//
@@ -145,14 +162,14 @@ public class MessageReconnectionUITest extends AbstractGraphicalEditPolicyUITest
 	@Parameters(name = "{1}, {3}, {5}")
 	public static Iterable<Object[]> parameters() {
 		return Arrays.asList(new Object[][] { //
-				{ false, "left-to-right", false, "target", false, "up" }, //
-				{ false, "left-to-right", false, "target", true, "down" }, //
-				{ false, "left-to-right", true, "source", false, "up" }, //
-				{ false, "left-to-right", true, "source", true, "down" }, //
-				{ true, "right-to-left", false, "target", false, "up" }, //
-				{ true, "right-to-left", false, "target", true, "down" }, //
-				{ true, "right-to-left", true, "source", false, "up" }, //
-				{ true, "right-to-left", true, "source", true, "down" }, //
+				{false, "left-to-right", false, "target", false, "up" }, //
+				{false, "left-to-right", false, "target", true, "down" }, //
+				{false, "left-to-right", true, "source", false, "up" }, //
+				{false, "left-to-right", true, "source", true, "down" }, //
+				{true, "right-to-left", false, "target", false, "up" }, //
+				{true, "right-to-left", false, "target", true, "down" }, //
+				{true, "right-to-left", true, "source", false, "up" }, //
+				{true, "right-to-left", true, "source", true, "down" }, //
 		});
 	}
 

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageCreationUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/SelfMessageCreationUITest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeThat;
 
 import java.util.Arrays;
 
@@ -30,6 +31,7 @@ import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.ExecutionSpecificationEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.edit.parts.MessageEditPart;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.internal.providers.SequenceElementTypes;
+import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.LightweightSeqDPrefs;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.rules.Maximized;
 import org.eclipse.papyrus.uml.diagram.sequence.runtime.util.MessageUtil;
@@ -39,6 +41,7 @@ import org.eclipse.uml2.uml.MessageSort;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -56,6 +59,9 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 	@ClassRule
 	public static LightweightSeqDPrefs prefs = new LightweightSeqDPrefs()
 			.dontCreateExecutionsForSyncMessages();
+
+	@ClassRule
+	public static TestRule tolerance = GEFMatchers.defaultTolerance(1);
 
 	// Horizontal position of the first lifeline's body
 	private static final int LIFELINE_1_BODY_X = 121;
@@ -132,6 +138,12 @@ public class SelfMessageCreationUITest extends AbstractGraphicalEditPolicyUITest
 				}
 				break;
 			default:
+				if (messageEP == null) {
+					assumeThat("Should fail to get a message edit-part only for create message", messageSort,
+							equalTo(MessageSort.CREATE_MESSAGE_LITERAL));
+					return; // Unreachable
+				}
+
 				if (mode != CreationMode.WITH_EXECUTION) {
 					assertThat(messageEP, runs(x(), top(), x(), bottom(), 2));
 				} else {


### PR DESCRIPTION
Fix several new test assumption violations on Mac platform, along with some compiler warnings in files changed for that reason.  Note that one of the `LifelineSwitchingUITest` cases that was being skipped on an assumption violation is now (accurately) showing a **regression** on all platforms (a message that becomes a self-message now doesn’t have any vertical extent where it does on the master branch).

Also fix the definition of some sub-suites of the `LifelineSwitchingUITest` that were making wrong assertions/assumptions.  Those tests now pass instead of skip.