### PR TITLE
Fix #453 Re-ordering when moving nested execution

### DIFF
--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Tag.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Tag.java
@@ -37,7 +37,17 @@ public enum Tag {
 	 * Tags a {@link Vertex} that is an execution finish occurrence or an {@code Edge} that links an execution
 	 * specification vertex to its finish vertex.
 	 */
-	EXECUTION_FINISH;
+	EXECUTION_FINISH,
+	/**
+	 * Tags a {@link Vertex} that is the sending of a message or an {@code Edge} that links a message vertex
+	 * to the message-end vertex that sends it.
+	 */
+	MESSAGE_SEND,
+	/**
+	 * Tags a {@link Vertex} that is the receiving of a message or an {@code Edge} that links a message vertex
+	 * to the message-end vertex that receives it.
+	 */
+	MESSAGE_RECEIVE;
 
 	static {
 		if (values().length > 16) {

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/internal/graph/GraphComputer.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/internal/graph/GraphComputer.java
@@ -104,7 +104,12 @@ public class GraphComputer {
 		if (existing != null) {
 			// This edge already exists
 			result.destroy();
-			result = existing.setGroupKind(groupKind);
+
+			// Transfer grouping and tagging details
+			existing.setGroupKind(groupKind);
+			existing.copyTags(result);
+
+			result = existing;
 		}
 
 		return result.setGroupKind(groupKind);
@@ -315,7 +320,8 @@ public class GraphComputer {
 
 		@Override
 		public Void caseMessage(Message message) {
-			EdgeImpl edge = edge(message, message.getReceiveEvent());
+			EdgeImpl edge = edge(message, tag(message.getReceiveEvent(), Tag.MESSAGE_RECEIVE))
+					.tag(Tag.MESSAGE_RECEIVE);
 
 			if (message.getMessageSort() == MessageSort.CREATE_MESSAGE_LITERAL) {
 				// Create message precedes the created lifeline
@@ -343,7 +349,7 @@ public class GraphComputer {
 		public Void caseMessageEnd(MessageEnd end) {
 			Message message = end.getMessage();
 			if ((message != null) && end.isSend()) {
-				edge(end, message);
+				edge(tag(end, Tag.MESSAGE_SEND), message).tag(Tag.MESSAGE_SEND);
 			}
 			return null;
 		}

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/internal/graph/TaggableImpl.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/internal/graph/TaggableImpl.java
@@ -46,6 +46,10 @@ abstract class TaggableImpl<T extends TaggableImpl<T>> implements Taggable {
 		return (tags & (1 << tag.ordinal())) != 0;
 	}
 
+	final void copyTags(TaggableImpl<T> copyFrom) {
+		this.tags = copyFrom.tags;
+	}
+
 	@SuppressWarnings("unchecked")
 	T tag(Tag tag) {
 		tags |= 1 << tag.ordinal();

--- a/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/NudgeRegressionUITest.java
+++ b/tests/org.eclipse.papyrus.uml.diagram.sequence.runtime.tests/src/org/eclipse/papyrus/uml/diagram/sequence/runtime/internal/edit/policies/tests/NudgeRegressionUITest.java
@@ -16,6 +16,7 @@ import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GE
 import static org.eclipse.papyrus.uml.diagram.sequence.runtime.tests.matchers.GEFMatchers.isPoint;
 import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.gt;
 import static org.eclipse.papyrus.uml.interaction.tests.matchers.NumberMatchers.lt;
+import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -76,6 +77,12 @@ public class NudgeRegressionUITest extends AbstractGraphicalEditPolicyUITest {
 
 	@AutoFixture
 	private PointList async2Geom;
+
+	@AutoFixture
+	private EditPart request1;
+
+	@AutoFixture
+	private PointList request1Geom;
 
 	/**
 	 * Initializes me.
@@ -147,6 +154,22 @@ public class NudgeRegressionUITest extends AbstractGraphicalEditPolicyUITest {
 		assertThat("message not moved", msgY, lt(y));
 		assertThat("execution not bumped", exec3Geom.bottom(), lt(msgY));
 		assertThat("execution reshaped", exec3Geom.height(), is(height));
+	}
+
+	@Test
+	public void moveNestedExecUp() {
+		Point grabAt = exec2Geom.getCenter();
+		Point dropAt = exec2Geom.getCenter().getTranslated(0, -50);
+
+		int x = request1Geom.getLastPoint().x(); // This should not change
+
+		editor.moveSelection(grabAt, dropAt);
+		autoFixtures.refresh();
+
+		int y = exec2Geom.y(); // This will have changed
+
+		assertThat("async1 not bumped", async1Geom.getLastPoint(), isPoint(anything(), lt(y)));
+		assertThat("request1 not bumped", request1Geom.getLastPoint(), isPoint(is(x), lt(y)));
 	}
 
 	//


### PR DESCRIPTION
Update the nudge command to account for the need to stretch up the top of the requesting execution when moving up an
execution started by it via a message.